### PR TITLE
use a elastic search wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,10 @@ dependencies = [
  "osmpbfreader 0.1.0 (git+https://github.com/TeXitoi/osmpbfreader-rs)",
  "rs-es 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex 0.30.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ dependencies = [
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmpbfreader 0.1.0 (git+https://github.com/TeXitoi/osmpbfreader-rs)",
+ "rs-es 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -20,6 +21,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aster"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_syntax 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +47,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "byteorder"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cookie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "openssl 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "csv"
@@ -104,6 +134,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "hpack"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "httparse"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hyper"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +218,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "matches"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,12 +241,46 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "mime"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "miniz-sys"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys-extras 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -171,6 +293,16 @@ dependencies = [
  "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys-extras"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -202,6 +334,24 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "quasi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_syntax 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quasi_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aster 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex 0.30.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,9 +377,72 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rs-es"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hyper 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex 0.30.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc_version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_codegen"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aster 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi_codegen 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex 0.30.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solicit"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "strsim"
@@ -237,11 +450,69 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "syntex"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_syntax 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syntex_syntax"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "traitobject"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicase"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -255,6 +526,11 @@ dependencies = [
 [[package]]
 name = "unicode-normalization"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,7 @@ docopt = "*"
 rustc-serialize = "*"
 csv = "*"
 curl = "*"
+rs-es = "*"
+
 [dependencies.osmpbfreader]
 git = "https://github.com/TeXitoi/osmpbfreader-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mimirsbrunn"
 version = "0.0.1"
 authors = ["Canal TP <dt.ro@canaltp.fr>"]
+build = "build.rs"
 
 [dependencies]
 log = "0.3"
@@ -11,6 +12,12 @@ rustc-serialize = "*"
 csv = "*"
 curl = "*"
 rs-es = "*"
+serde = "*"
+serde_json = "*"
 
 [dependencies.osmpbfreader]
 git = "https://github.com/TeXitoi/osmpbfreader-rs"
+
+[build-dependencies]
+serde_codegen = "*"
+syntex = "*"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,29 @@
+#[cfg(not(feature = "serde_macros"))]
+mod inner {
+    extern crate syntex;
+    extern crate serde_codegen;
+
+    use std::env;
+    use std::path::Path;
+
+    pub fn main() {
+        let out_dir = env::var_os("OUT_DIR").unwrap();
+
+        let src = Path::new("src/lib.rs.in");
+        let dst = Path::new(&out_dir).join("lib.rs");
+
+        let mut registry = syntex::Registry::new();
+
+        serde_codegen::register(&mut registry);
+        registry.expand("", &src, &dst).unwrap();
+    }
+}
+
+#[cfg(feature = "serde_macros")]
+mod inner {
+    pub fn main() {}
+}
+
+fn main() {
+    inner::main();
+}

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,6 @@
+// this file is used to be able to use serde (https://github.com/serde-rs/serde) in rust stable
+// cf serde readme for explanations
+
 #[cfg(not(feature = "serde_macros"))]
 mod inner {
     extern crate syntex;

--- a/build.rs
+++ b/build.rs
@@ -1,32 +1,20 @@
 // this file is used to be able to use serde (https://github.com/serde-rs/serde) in rust stable
 // cf serde readme for explanations
 
-#[cfg(not(feature = "serde_macros"))]
-mod inner {
-    extern crate syntex;
-    extern crate serde_codegen;
+extern crate syntex;
+extern crate serde_codegen;
 
-    use std::env;
-    use std::path::Path;
+use std::env;
+use std::path::Path;
 
-    pub fn main() {
-        let out_dir = env::var_os("OUT_DIR").unwrap();
+pub fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
 
-        let src = Path::new("src/lib.rs.in");
-        let dst = Path::new(&out_dir).join("lib.rs");
+    let src = Path::new("src/lib.rs.in");
+    let dst = Path::new(&out_dir).join("lib.rs");
 
-        let mut registry = syntex::Registry::new();
+    let mut registry = syntex::Registry::new();
 
-        serde_codegen::register(&mut registry);
-        registry.expand("", &src, &dst).unwrap();
-    }
-}
-
-#[cfg(feature = "serde_macros")]
-mod inner {
-    pub fn main() {}
-}
-
-fn main() {
-    inner::main();
+    serde_codegen::register(&mut registry);
+    registry.expand("", &src, &dst).unwrap();
 }

--- a/json/settings.json
+++ b/json/settings.json
@@ -3,7 +3,7 @@
         "number_of_shards": "16",
         "analysis": {
             "filter": {
-                "prefix_filter": { 
+                "prefix_filter": {
                     "type":     "edge_ngram",
                     "min_gram": 1,
                     "max_gram": 20
@@ -49,7 +49,7 @@
                         "prefix": {
                             "type": "string",
                             "index_options": "docs",
-                            "index_analyzer": "prefix",
+                            "analyzer": "prefix",
                             "search_analyzer": "word"
                         },
                         "ngram": { "type": "string", "index_options": "docs", "analyzer": "ngram" }
@@ -92,7 +92,7 @@
                         "prefix": {
                             "type": "string",
                             "index_options": "docs",
-                            "index_analyzer": "prefix",
+                            "analyzer": "prefix",
                             "search_analyzer": "word"
                         },
                         "ngram": { "type": "string", "index_options": "docs", "analyzer": "ngram" }
@@ -122,7 +122,7 @@
                         "prefix": {
                             "type": "string",
                             "index_options": "docs",
-                            "index_analyzer": "prefix",
+                            "analyzer": "prefix",
                             "search_analyzer": "word"
                         },
                         "ngram": { "type": "string", "index_options": "docs", "analyzer": "ngram" }

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -33,6 +33,9 @@ extern crate csv;
 extern crate rustc_serialize;
 extern crate curl;
 extern crate mimirsbrunn;
+#[macro_use]
+extern crate log;
+extern crate env_logger;
 
 use std::path::Path;
 use mimirsbrunn::rubber::Rubber;
@@ -95,7 +98,7 @@ impl Bano {
 }
 
 fn index_bano(files: &[String]) {
-    let rubber = Rubber {index_name: "munin".to_string()};
+    let mut rubber = Rubber::new("localhost".to_string(), 9200, "munin".to_string());
 
     println!("purge and create Munin...");
     rubber.create_index().unwrap();
@@ -125,7 +128,8 @@ Usage:
 ";
 
 fn main() {
-    println!("importing bano into Mimir");
+    env_logger::init().unwrap();
+    info!("importing bano into Mimir");
 
     let args: Args = docopt::Docopt::new(USAGE)
                          .and_then(|d| d.decode())

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -35,7 +35,7 @@ extern crate curl;
 extern crate mimirsbrunn;
 
 use std::path::Path;
-
+use mimirsbrunn::rubber::Rubber;
 
 #[derive(RustcDecodable, RustcEncodable)]
 pub struct Bano {
@@ -95,8 +95,10 @@ impl Bano {
 }
 
 fn index_bano(files: &[String]) {
+    let rubber = Rubber {index_name: "munin".to_string()};
+
     println!("purge and create Munin...");
-    mimirsbrunn::purge_and_create_munin().unwrap();
+    rubber.create_index().unwrap();
     println!("Munin purged and created.");
 
     for f in files.iter() {
@@ -107,7 +109,7 @@ fn index_bano(files: &[String]) {
             let b: Bano = r.unwrap();
             b.into_addr()
         });
-        let nb = mimirsbrunn::index(iter).unwrap();
+        let nb = rubber.index(iter).unwrap();
         println!("importing {}: {} addresses added.", f, nb);
     }
 }

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -113,7 +113,7 @@ fn index_bano(files: &[String]) {
         });
         match rubber.index(iter) {
             Err(e) => panic!("failed to bulk insert file {} because: {}", f, e),
-            Ok(nb) => info!("importing {}: {} addresses added.", f, nb)
+            Ok(nb) => info!("importing {}: {} addresses added.", f, nb),
         }
     }
 }

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -100,20 +100,21 @@ impl Bano {
 fn index_bano(files: &[String]) {
     let mut rubber = Rubber::new("localhost".to_string(), 9200, "munin".to_string());
 
-    println!("purge and create Munin...");
+    info!("purge and create Munin...");
     rubber.create_index().unwrap();
-    println!("Munin purged and created.");
 
     for f in files.iter() {
-        println!("importing {}...", f);
+        info!("importing {}...", f);
         let mut rdr = csv::Reader::from_file(&Path::new(&f)).unwrap().has_headers(false);
 
         let iter = rdr.decode().map(|r| {
             let b: Bano = r.unwrap();
             b.into_addr()
         });
-        let nb = rubber.index(iter).unwrap();
-        println!("importing {}: {} addresses added.", f, nb);
+        match rubber.index(iter) {
+            Err(e) => panic!("failed to bulk insert file {} because: {}", f, e),
+            Ok(nb) => info!("importing {}: {} addresses added.", f, nb)
+        }
     }
 }
 

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -187,6 +187,6 @@ fn main() {
     update_coordinates(&args.flag_input, &mut res);
     match index_osm(&args.flag_connection_string, &res) {
         Err(e) => panic!("failed to index osm because: {}", e),
-        Ok(nb) => info!("Adminstrative regions : {}", nb)
+        Ok(nb) => info!("Adminstrative regions : {}", nb),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@
 
 pub mod rubber;
 
+#[macro_use]
+extern crate log;
+
 extern crate rustc_serialize;
 use rustc_serialize::Encodable;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,10 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-extern crate rustc_serialize;
-extern crate curl;
+pub mod rubber;
 
-use rustc_serialize::json;
+extern crate rustc_serialize;
 use rustc_serialize::Encodable;
-use std::collections::HashMap;
-use std::collections::hash_map::Entry::{Occupied, Vacant};
 
 trait Incr: Clone {
     fn id(&self) -> &str;
@@ -90,69 +87,4 @@ pub struct Addr {
     pub name: String,
     pub coord: Coord,
     pub weight: u32,
-}
-
-pub fn purge_and_create_munin() -> Result<(), curl::ErrCode> {
-    // first, we must delete with its own handle the old munin
-    try!(curl::http::handle().delete("http://localhost:9200/munin").exec());
-
-    let analysis = include_str!("../json/settings.json");
-    assert!(analysis.parse::<json::Json>().is_ok());
-    let res = try!(curl::http::handle().put("http://localhost:9200/munin", analysis).exec());
-    assert!(res.get_code() == 200, "Error adding analysis: {}", res);
-
-    Ok(())
-}
-
-fn push_bulk<'a, T: Encodable>(s: &mut String, elt: &T) {
-    s.push_str("{index: {}}\n");
-    s.push_str(&json::encode(elt).unwrap());
-    s.push('\n');
-}
-pub fn bulk_index<'a, T, I>(url: &str, mut iter: I) -> Result<u32, curl::ErrCode>
-    where T: Encodable,
-          I: Iterator<Item = T>
-{
-    let url = format!("{}/_bulk", url);
-    let mut handle = curl::http::handle();
-    let mut nb = 0;
-    let mut chunk = String::new();
-    loop {
-        chunk.clear();
-        let addr = match iter.next() {
-            Some(a) => a,
-            None => break,
-        };
-        push_bulk(&mut chunk, &addr);
-        nb += 1;
-        for addr in iter.by_ref().take(1000) {
-            push_bulk(&mut chunk, &addr);
-            nb += 1;
-        }
-        let res = try!(handle.post(&*url, &chunk).exec());
-        assert!(res.get_code() != 201,
-                format!("result of bulk insert is not 201: {}", res));
-    }
-    Ok(nb)
-}
-
-fn upsert<T: Incr>(elt: &T, map: &mut HashMap<String, T>) {
-    match map.entry(elt.id().to_string()) {
-        Vacant(e) => { e.insert(elt.clone()); }
-        Occupied(mut e) => e.get_mut().incr(),
-    }
-}
-
-pub fn index<I: Iterator<Item = Addr>>(iter: I) -> Result<u32, curl::ErrCode> {
-    let mut admins = HashMap::new();
-    let mut streets = HashMap::new();
-    try!(bulk_index("http://localhost:9200/munin/addr",
-                    iter.inspect(|addr| {
-                        upsert(&addr.street.administrative_region, &mut admins);
-                        upsert(&addr.street, &mut streets);
-                    })));
-    try!(bulk_index("http://localhost:9200/munin/admin",
-                    admins.into_iter().map(|e| e.1)));
-    bulk_index("http://localhost:9200/munin/street",
-               streets.into_iter().map(|e| e.1))
 }

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -28,7 +28,65 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate log;
 
-include!(concat!(env!("OUT_DIR"), "/lib.rs"));
+extern crate serde;
+extern crate serde_json;
+
+pub mod rubber;
+
+
+trait Incr: Clone {
+    fn id(&self) -> &str;
+    fn incr(&mut self);
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Coord {
+    pub lat: f64,
+    pub lon: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Admin {
+    pub id: String,
+    pub level: u32,
+    pub name: String,
+    pub zip_code: String,
+    pub weight: u32,
+    pub coord: Coord,
+}
+impl Incr for Admin {
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn incr(&mut self) {
+        self.weight += 1;
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Street {
+    pub id: String,
+    pub street_name: String,
+    pub name: String,
+    pub administrative_region: Admin,
+    pub weight: u32,
+}
+impl Incr for Street {
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn incr(&mut self) {
+        self.weight += 1;
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Addr {
+    pub id: String,
+    pub house_number: String,
+    pub street: Street,
+    pub name: String,
+    pub coord: Coord,
+    pub weight: u32,
+}

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -46,6 +46,11 @@ trait Incr: Clone {
 trait DocType {
   fn doc_type() -> &'static str; // provides the elasticsearch type name
 }
+impl <'a, T: DocType> DocType for &'a T {
+    fn doc_type() -> &'static str {
+        T::doc_type()
+  }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Coord {

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -43,7 +43,7 @@ trait Incr: Clone {
     fn incr(&mut self);
 }
 
-trait DocType {
+pub trait DocType {
   fn doc_type() -> &'static str; // provides the elasticsearch type name
 }
 impl <'a, T: DocType> DocType for &'a T {

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -43,6 +43,10 @@ trait Incr: Clone {
     fn incr(&mut self);
 }
 
+trait DocType {
+  fn doc_type() -> &'static str; // provides the elasticsearch type name
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Coord {
     pub lat: f64,
@@ -66,6 +70,9 @@ impl Incr for Admin {
         self.weight += 1;
     }
 }
+impl DocType for Admin {
+  fn doc_type() -> &'static str { "admin" }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Street {
@@ -83,6 +90,9 @@ impl Incr for Street {
         self.weight += 1;
     }
 }
+impl DocType for Street {
+  fn doc_type() -> &'static str { "street" }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Addr {
@@ -92,4 +102,7 @@ pub struct Addr {
     pub name: String,
     pub coord: Coord,
     pub weight: u32,
+}
+impl DocType for Addr {
+  fn doc_type() -> &'static str { "addr" }
 }

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -29,6 +29,9 @@
 // www.navitia.io
 
 
+// Note: this file is needed to use serde in rust stable
+// cf mimirsbrunn/build.rs for explanations
+
 extern crate serde;
 extern crate serde_json;
 

--- a/src/rubber.rs
+++ b/src/rubber.rs
@@ -1,0 +1,104 @@
+// Copyright © 2016, Canal TP and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+//     the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+//     powered by Canal TP (www.canaltp.fr).
+// Help us simplify mobility and open public transport:
+//     a non ending quest to the responsive locomotion way of traveling!
+//
+// LICENCE: This program is free software; you can redistribute it
+// and/or modify it under the terms of the GNU Affero General Public
+// License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program. If not, see
+// <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// IRC #navitia on freenode
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+
+extern crate curl;
+extern crate rustc_serialize;
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry::{Occupied, Vacant};
+use self::rustc_serialize::json;
+use rustc_serialize::Encodable;
+
+use super::{Addr, Incr};
+
+
+pub struct Rubber {
+    pub index_name: String
+}
+
+impl Rubber {
+
+    pub fn create_index(&self) -> Result<(), curl::ErrCode> {
+        // first, we must delete with its own handle the old munin
+        try!(curl::http::handle().delete("http://localhost:9200/".to_string() + &self.index_name).exec());
+
+        let analysis = include_str!("../json/settings.json");
+        assert!(analysis.parse::<json::Json>().is_ok());
+        let res = try!(curl::http::handle().put("http://localhost:9200/munin", analysis).exec());
+        assert!(res.get_code() == 200, "Error adding analysis: {}", res);
+
+        Ok(())
+    }
+
+    fn push_bulk<'a, T: Encodable>(&self, s: &mut String, elt: &T) {
+        s.push_str("{index: {}}\n");
+        s.push_str(&json::encode(elt).unwrap());
+        s.push('\n');
+    }
+    fn bulk_index<'a, T, I>(&self, url: &str, mut iter: I) -> Result<u32, curl::ErrCode>
+        where T: Encodable, I: Iterator<Item = T>
+    {
+        let url = format!("{}/_bulk", url);
+        let mut handle = curl::http::handle();
+        let mut nb = 0;
+        let mut chunk = String::new();
+        loop {
+            chunk.clear();
+            let addr = match iter.next() { Some(a) => a, None => break };
+            self.push_bulk(&mut chunk, &addr);
+            nb += 1;
+            for addr in iter.by_ref().take(1000) {
+                self.push_bulk(&mut chunk, &addr);
+                nb += 1;
+            }
+            let res = try!(handle.post(&*url, &chunk).exec());
+            assert!(res.get_code() != 201, format!("result of bulk insert is not 201: {}", res));
+        }
+        Ok(nb)
+    }
+
+    fn upsert<T: Incr>(&self, elt: &T, map: &mut HashMap<String, T>) {
+        match map.entry(elt.id().to_string()) {
+            Vacant(e) => { e.insert(elt.clone()); }
+            Occupied(mut e) => e.get_mut().incr()
+        }
+    }
+
+    pub fn index<I: Iterator<Item = Addr>>(&self, iter: I) -> Result<u32, curl::ErrCode> {
+        let mut admins = HashMap::new();
+        let mut streets = HashMap::new();
+        try!(self.bulk_index("http://localhost:9200/munin/addr", iter.inspect(|addr| {
+            self.upsert(&addr.street.administrative_region, &mut admins);
+            self.upsert(&addr.street, &mut streets);
+        })));
+        try!(self.bulk_index("http://localhost:9200/munin/admin", admins.into_iter().map(|e| e.1)));
+        self.bulk_index("http://localhost:9200/munin/street", streets.into_iter().map(|e| e.1))
+    }
+}

--- a/src/rubber.rs
+++ b/src/rubber.rs
@@ -38,8 +38,9 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 
 use super::{Addr, Incr};
 
+// Rubber is an wrapper around elasticsearch API
 pub struct Rubber {
-    pub index_name: String,
+    index_name: String,
     client: rs_es::Client
 }
 
@@ -91,7 +92,6 @@ impl Rubber {
     pub fn index<I: Iterator<Item = Addr>>(&mut self, iter: I) -> Result<u32, curl::ErrCode> {
         let mut admins = HashMap::new();
         let mut streets = HashMap::new();
-
 
         try!(self.bulk_index("addr", iter.inspect(|addr| {
             upsert(&addr.street.administrative_region, &mut admins);

--- a/src/rubber.rs
+++ b/src/rubber.rs
@@ -95,13 +95,15 @@ impl Rubber {
     pub fn index<I: Iterator<Item = Addr>>(&mut self, iter: I) -> Result<u32, rs_es::error::EsError> {
         let mut admins = HashMap::new();
         let mut streets = HashMap::new();
+        let mut nb = 0;
 
-        try!(self.bulk_index(iter.inspect(|addr| {
+        nb += try!(self.bulk_index(iter.inspect(|addr| {
             upsert(&addr.street.administrative_region, &mut admins);
             upsert(&addr.street, &mut streets);
         })));
-        try!(self.bulk_index(admins.into_iter().map(|e| e.1)));
-        self.bulk_index(streets.into_iter().map(|e| e.1))
+        nb += try!(self.bulk_index(admins.values()));
+        nb += try!(self.bulk_index(streets.values()));
+        Ok(nb)
     }
 }
 


### PR DESCRIPTION
to abstract a bit some stuff, use an elastic search wrapper.

since the wrapper use elastic search 2 interfaces (and that we want to use it anyway), migrate settings to elastic search 2 version.

Note: this will break the build, you now at least need elactic search 2.0 (but the production version will be elastic search 2.3)

since rs-es use serde, use the '.in' trick to use it with rust stable (cf https://github.com/serde-rs/serde)


TODO:
* use the same input as osm2mimir (connection string or separate repositories ?)
* create the index with the wrapper (not done for the moment)
* use logger everywhere
* migrate osm2mimir to the wrapper
* attach the es type name to the objects

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canaltp/mimirsbrunn/7)
<!-- Reviewable:end -->
