### PR TITLE
zero downtime data updates with indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target/*
-libs/skojig/target/*
+libs/*/target/*
 build_packages/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,7 @@
 name = "mimirsbrunn"
 version = "0.0.1"
 dependencies = [
+ "chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "docker_wrapper 0.1.0",
@@ -13,6 +14,7 @@ dependencies = [
  "regex 0.1.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "skojig 0.1.0",
 ]
@@ -75,6 +77,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "byteorder"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "conduit-mime-types"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "curl 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "docker_wrapper 0.1.0",
  "docopt 0.6.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mimir 0.0.1",
  "osm_builder 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
 name = "mimir"
 version = "0.0.1"
 dependencies = [
+ "chrono 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "docopt 0.6.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mdo 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mimir 0.0.1",
  "osm_builder 0.1.0",
  "osmpbfreader 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ curl = "*"
 rs-es = { version = "0.3.4", default-features = false }
 regex = "*"
 osmpbfreader = "*"
+chrono = "0.2"
+serde = "*"
 
 [dev-dependencies]
 serde_json = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = "*"
 
 [dev-dependencies]
 serde_json = "*"
+hyper = "0.9.4"
 
 [features]
 default = ["rs-es/default", "skojig/default", "mimir/default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde = "*"
 [dev-dependencies]
 serde_json = "*"
 hyper = "0.9.4"
+mdo = "*"
 
 [features]
 default = ["rs-es/default", "skojig/default", "mimir/default"]

--- a/libs/docker_wrapper/src/lib.rs
+++ b/libs/docker_wrapper/src/lib.rs
@@ -44,7 +44,7 @@ pub struct DockerWrapper {
 
 impl DockerWrapper {
     pub fn host(&self) -> String {
-        format!("localhost:{}", self.port)
+        format!("http://localhost:{}", self.port)
     }
 
     fn setup(&self) -> Result<(), Box<Error>> {

--- a/libs/mimir/Cargo.toml
+++ b/libs/mimir/Cargo.toml
@@ -15,6 +15,7 @@ serde = "*"
 serde_json = "*"
 regex = "*"
 serde_macros = { version = "*", optional = true }
+chrono = "0.2.*"
 
 [features]
 default = ["serde_codegen", "rs-es/default"]
@@ -23,4 +24,3 @@ nightly = ["serde_macros"]
 [build-dependencies]
 serde_codegen = { version = "0.7.5", optional = true }
 syntex = "0.32.0"
-

--- a/libs/mimir/src/lib.rs
+++ b/libs/mimir/src/lib.rs
@@ -37,6 +37,8 @@ extern crate env_logger;
 extern crate serde;
 extern crate serde_json;
 
+extern crate chrono;
+
 pub mod objects;
 pub mod rubber;
 

--- a/libs/mimir/src/objects.rs.in
+++ b/libs/mimir/src/objects.rs.in
@@ -178,7 +178,9 @@ pub struct AliasOperations {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AliasOperation {
+    #[serde(skip_serializing_if="Option::is_none")]
     pub add: Option<AliasParameter>,
+    #[serde(skip_serializing_if="Option::is_none")]
     pub remove: Option<AliasParameter>,
 }
 

--- a/libs/mimir/src/objects.rs.in
+++ b/libs/mimir/src/objects.rs.in
@@ -170,3 +170,21 @@ impl MultiPolygon {
         format!("MULTIPOLYGON({})", polys.join(", "))
     }
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AliasOperations {
+    pub actions: Vec<AliasOperation>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AliasOperation {
+    pub add: Option<AliasParameter>,
+    pub remove: Option<AliasParameter>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AliasParameter{
+    pub index: String,
+    pub alias: String,
+
+}

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -34,130 +34,121 @@ extern crate serde;
 extern crate serde_json;
 extern crate regex;
 
-use super::objects::{Addr, Incr, DocType};
+use super::objects::DocType;
+use chrono;
 
 use super::objects::{AliasOperations, AliasOperation, AliasParameter};
+use serde_json::value::Value;
+
 // Rubber is an wrapper around elasticsearch API
 pub struct Rubber {
-    index_name: String,
     client: rs_es::Client,
+}
+
+/// return the index associated to the given type and dataset
+/// this will be an alias over another real index
+fn get_main_index(doc_type: &str, dataset: &str) -> String {
+    format!("munin_{}_{}", doc_type, dataset)
 }
 
 impl Rubber {
     // build a rubber with a connection string (http://host:port/index)
     pub fn new(cnx: &str) -> Rubber {
-        let re = regex::Regex::new(r"(?:https?://)?(?P<host>.+?):(?P<port>\d+)/(?P<index>\w+)")
-                     .unwrap();
+        let re = regex::Regex::new(r"(?:https?://)?(?P<host>.+?):(?P<port>\d+)").unwrap();
         let cap = re.captures(cnx).unwrap();
         let host = cap.name("host").unwrap();
         let port = cap.name("port").unwrap().parse::<u32>().unwrap();
-        let index = cap.name("index").unwrap();
-        info!("elastic search host {:?} port {:?} index {:?}",
-              host,
-              port,
-              index);
+        info!("elastic search host {:?} port {:?}", host, port);
 
-        Rubber {
-            index_name: index.to_string(),
-            client: rs_es::Client::new(&host, port),
+        Rubber { client: rs_es::Client::new(&host, port) }
+    }
+
+    pub fn make_index(&self, doc_type: &str, dataset: &str) -> Result<String, String> {
+        let current_time = chrono::UTC::now().format("%Y%m%d_%H%M%S");
+        let index_name = format!("munin_{}_{}_{}", doc_type, dataset, current_time);
+        if !self.is_existing_index(&index_name).unwrap() {
+            info!("creating index {}", index_name);
+            self.create_index(&index_name.to_string()).map(|_| index_name)
+        } else {
+            Ok(index_name)
         }
     }
 
-    pub fn new_with_index(cnx: &str, index: &str) -> Rubber {
-        let re = regex::Regex::new(r"(?:https?://)?(?P<host>.+?):(?P<port>\d+)")
-                     .unwrap();
-        let cap = re.captures(cnx).unwrap();
-        let host = cap.name("host").unwrap();
-        let port = cap.name("port").unwrap().parse::<u32>().unwrap();
-        info!("elastic search host {:?} port {:?} index {:?}",
-              host,
-              port,
-              index);
-
-        Rubber {
-            index_name: index.to_string(),
-            client: rs_es::Client::new(&host, port),
-        }
-    }
-
-    pub fn clean_db_by_doc_type(&mut self,
-                                doc_type: &[&str])
-                                -> Result<usize, rs_es::error::EsError> {
-        info!("Clean elasticsearch db...");
-        let scroll = rs_es::units::Duration::minutes(1);
-        let mut scan: rs_es::operations::search::ScanResult<serde_json::Value> =
-            match self.client
-                      .search_query()
-                      .with_indexes(&[&self.index_name])
-                      .with_size(10000)
-                      .with_source(rs_es::operations::search::Source::include(&["_id"]))
-                      .with_types(&doc_type)
-                      .scan(&scroll) {
-                Ok(scan) => scan,
-                Err(e) => {
-                    info!("Scan error: {:?}", e);
-                    return Err(e);
-                }
-            };
-        let mut count: usize = 0;
-        loop {
-            let page = match scan.scroll(&mut self.client, &scroll) {
-                Ok(page) => page,
-                Err(e) => {
-                    info!("scroll error: {:?}", e);
-                    try!(scan.close(&mut self.client));
-                    return Err(e);
-                }
-            };
-            let mut hits = page.hits.hits;
-            if hits.len() == 0 {
-                break;
-            }
-            count = count + hits.len();
-            info!("Delete : Count {}", hits.len());
-            let actions: Vec<rs_es::operations::bulk::Action<()>> =
-                hits.drain(..)
-                    .map(|hit| {
-                        rs_es::operations::bulk::Action::delete(hit.id)
-                            .with_index(hit.index)
-                            .with_doc_type(hit.doc_type)
-                    })
-                    .collect();
-            try!(self.client.bulk(&actions).send());
-        }
-        try!(scan.close(&mut self.client));
-        Ok((count))
-    }
-
-    pub fn create_index(&mut self) {
+    fn create_index(&self, name: &String) -> Result<(), String> {
+        // TODO return an error
         debug!("creating index");
         // Note: for the moment I don't see an easy way to do this with rs_es
         let analysis = include_str!("../../../json/settings.json");
-        let res = curl::http::handle()
-                      .put(self.client.full_url(&self.index_name), analysis)
-                      .exec()
-                      .map(|res| res.get_code() == 200)
-                      .unwrap_or(false);
-        if !res {
-            info!("Error adding analysis");
-        }
+        curl::http::handle()
+            .put(self.client.full_url(&name), analysis)
+            .exec()
+            .map_err(|e| {
+                info!("Error while creating new index {}", name);
+                e.to_string()
+            })
+            .and_then(|res| {
+                if res.get_code() == 200 {
+                    Ok(())
+                } else {
+                    Err(format!("cannot create index: {}",
+                                ::std::str::from_utf8(res.get_body()).unwrap()))
+                }
+            })
     }
 
-    pub fn create_index_with_name(&mut self, name: &String) {
-        debug!("creating index");
-        // Note: for the moment I don't see an easy way to do this with rs_es
-        let analysis = include_str!("../../../json/settings.json");
-        let res = curl::http::handle()
-                      .put(self.client.full_url(&name), analysis)
-                      .exec()
-                      .map(|res| res.get_code() == 200)
-                      .unwrap_or(false);
-        if !res {
-            info!("Error while creating new index {}", name);
-        }
+    fn get_last_index(&self, doc_type: &str, dataset: &str) -> Result<Vec<String>, String> {
+
+        debug!("get last index: {base_index}/_aliases",
+               base_index = get_main_index(doc_type, dataset));
+        curl::http::handle()
+            .get(self.client.full_url(&format!("{base_index}/_aliases",
+                                               base_index = get_main_index(doc_type, dataset))))
+            .exec()
+            .map_err(|e| e.to_string())
+            .and_then(|res| {
+                match res.get_code() {
+                    200 => {
+                        let body = ::std::str::from_utf8(res.get_body()).unwrap();
+                        let value: Value = ::serde_json::from_str(body).unwrap();
+                        Ok(value.as_object()
+                                .and_then(|aliases| Some(aliases.keys().cloned().collect()))
+                                .unwrap_or_else(|| {
+                                    info!("no previous index to delete for type {} and dataset {}",
+                                          doc_type,
+                                          dataset);
+                                    vec![]
+                                }))
+                    }
+                    404 => {
+                        info!("impossible to find alias {}, no last index to remove",
+                              get_main_index(doc_type, dataset));
+                        Ok(vec![])
+                    }
+                    _ => Err(format!("invalid elasticsearch response: {:?}", res)),
+                }
+            })
     }
 
-    pub fn is_existing_index(&self, name: &String) -> Result<bool, String> {
+    /// publish the index as the new index for this doc_type and this dataset
+    /// move the index alias of the doc_type and the dataset to point to this indexes
+    /// and remove the old index
+    pub fn publish_index(&mut self,
+                         doc_type: &str,
+                         dataset: &str,
+                         index: String)
+                         -> Result<(), String> {
+        debug!("publishing index");
+        let last_indexes = try!(self.get_last_index(doc_type, dataset));
+        let main_index = get_main_index(doc_type, dataset);
+        try!(self.alias(&main_index, &vec![index.clone()], &last_indexes));
+        try!(self.alias("munin", &vec![main_index.to_string()], &vec![]));
+        for i in last_indexes {
+            try!(self.delete_index(&i))
+        }
+        Ok(())
+    }
+
+    fn is_existing_index(&self, name: &String) -> Result<bool, String> {
         curl::http::handle()
             .get(self.client.full_url(&name))
             .exec()
@@ -165,33 +156,65 @@ impl Rubber {
             .map(|res| res.get_code() == 200)
     }
 
-    pub fn alias(&self, alias: &String, add: &Vec<String>, remove: &Vec<String>) -> Result<(), String> {
-        let add_operations = add.iter().map(|x| AliasOperation{remove: None, add : Some(AliasParameter{index: x.clone(), alias: alias.clone()})});
-        let remove_operations = remove.iter().map(|x| AliasOperation{add: None, remove : Some(AliasParameter{index: x.clone(), alias: alias.clone()})});
-        let operations = AliasOperations{actions: add_operations.chain(remove_operations).collect()};
+    /// add a list of new indexes to the alias
+    /// remove a list of indexes from the alias
+    fn alias(&self, alias: &str, add: &Vec<String>, remove: &Vec<String>) -> Result<(), String> {
+        debug!("adding aliases for {}", alias);
+        let add_operations = add.iter().map(|x| {
+            AliasOperation {
+                remove: None,
+                add: Some(AliasParameter {
+                    index: x.clone(),
+                    alias: alias.to_string(),
+                }),
+            }
+        });
+        let remove_operations = remove.iter().map(|x| {
+            AliasOperation {
+                add: None,
+                remove: Some(AliasParameter {
+                    index: x.clone(),
+                    alias: alias.to_string(),
+                }),
+            }
+        });
+        let operations = AliasOperations {
+            actions: add_operations.chain(remove_operations).collect(),
+        };
         let json = serde_json::to_string(&operations).unwrap();
-        debug!("{}", json);
         let e = curl::http::handle()
-            .post(self.client.full_url("_aliases"), &json)
-            .exec();
+                    .post(self.client.full_url("_aliases"), &json)
+                    .exec();
         e.map_err(|e| e.to_string())
-            .and_then(|res| {if res.get_code() == 200 {Ok(())} else {error!("es response: {}", res); Err("failed".to_string())}})
+         .and_then(|res| {
+             info!("es response: {}",
+                   ::std::str::from_utf8(res.get_body()).unwrap());
+             if res.get_code() == 200 {
+                 Ok(())
+             } else {
+                 error!("es response: {}", res);
+                 Err("failed".to_string())
+             }
+         })
     }
 
-    pub fn delete_index(&mut self) -> Result<(), Box<::std::error::Error>> {
-        debug!("deleting index");
+    pub fn delete_index(&mut self, index: &String) -> Result<(), String> {
+        debug!("deleting index {}", &index);
         let res = self.client
-                      .delete_index(&self.index_name)
+                      .delete_index(&index)
                       .map(|res| res.acknowledged)
                       .unwrap_or(false);
         if !res {
-            Err(format!("Error deleting index {}", &self.index_name).into())
+            Err(format!("Error deleting index {}", &index).into())
         } else {
             Ok(())
         }
     }
 
-    pub fn bulk_index<T, I>(&mut self, mut iter: I) -> Result<u32, rs_es::error::EsError>
+    pub fn bulk_index<T, I>(&mut self,
+                            index: &String,
+                            mut iter: I)
+                            -> Result<u32, rs_es::error::EsError>
         where T: serde::Serialize + DocType,
               I: Iterator<Item = T>
     {
@@ -213,7 +236,7 @@ impl Rubber {
             }
             try!(self.client
                      .bulk(&chunk)
-                     .with_index(&self.index_name)
+                     .with_index(&index)
                      .with_doc_type(T::doc_type())
                      .send());
         }
@@ -221,11 +244,19 @@ impl Rubber {
         Ok(nb)
     }
 
-    pub fn index<I: Iterator<Item = Addr>>(&mut self,
-                                           iter: I)
-                                           -> Result<u32, rs_es::error::EsError> {
-        let mut nb = 0;
-        nb += try!(self.bulk_index(iter));
-        Ok(nb)
+    /// add all the element of 'iter' into elasticsearch
+    ///
+    /// To have zero downtime:
+    /// first all the elements are added in a temporary index and when all has been indexed
+    /// the index is published and the old index is removed
+    pub fn index<T, I>(&mut self, doc_type: &str, dataset: &str, iter: I) -> Result<u32, String>
+        where T: serde::Serialize + DocType,
+              I: Iterator<Item = T>
+    {
+        // TODO better error handling
+        let index = self.make_index(doc_type, dataset).unwrap();
+        let nb_elements = self.bulk_index(&index, iter).unwrap();
+        self.publish_index(doc_type, dataset, index).unwrap();
+        Ok(nb_elements)
     }
 }

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -75,7 +75,6 @@ impl Rubber {
     }
 
     fn create_index(&self, name: &String) -> Result<(), String> {
-        // TODO return an error
         debug!("creating index");
         // Note: for the moment I don't see an easy way to do this with rs_es
         let analysis = include_str!("../../../json/settings.json");
@@ -97,7 +96,6 @@ impl Rubber {
     }
 
     fn get_last_index(&self, doc_type: &str, dataset: &str) -> Result<Vec<String>, String> {
-
         debug!("get last index: {base_index}/_aliases",
                base_index = get_main_index(doc_type, dataset));
         curl::http::handle()
@@ -259,4 +257,5 @@ impl Rubber {
         self.publish_index(doc_type, dataset, index).unwrap();
         Ok(nb_elements)
     }
+
 }

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -35,8 +35,11 @@ extern crate rustc_serialize;
 extern crate docopt;
 extern crate mimir;
 extern crate rs_es;
+extern crate chrono;
 
 extern crate mimirsbrunn;
+extern crate serde;
+
 
 use std::collections::HashSet;
 use mimir::rubber::Rubber;
@@ -51,6 +54,7 @@ struct Args {
     flag_level: Vec<u32>,
     flag_connection_string: String,
     flag_way: bool,
+    flag_dataset: String,
 }
 
 static USAGE: &'static str = "
@@ -65,6 +69,7 @@ Options:
     -w, --way             Import ways
     -c, --connection-string=<connection-string>
                           Elasticsearch parameters, [default: http://localhost:9200/munin]
+    -d, --dataset=<dataset>         Name of the dataset, [default: fr]
 ";
 
 #[derive(Debug)]
@@ -232,52 +237,44 @@ fn streets(pbf: &mut OsmPbfReader) -> StreetsVec {
             .collect()
 
 }
-// TODO: template these two functions
-fn index_admin(es_cnx_string: &str, admins: AdminsVec) {
-    let mut rubber = Rubber::new(es_cnx_string);
-    match rubber.clean_db_by_doc_type(&["admin"]) {
-        Err(e) => panic!("failed to clean data for admin: {}", e),
-        Ok(nb) => info!("Nb of cleaned indexed admins: {}", nb),
-    }
-    match rubber.bulk_index(admins.iter()) {
-        Err(e) => panic!("failed to index admins of osm because: {}", e),
-        Ok(nb) => info!("Nb of indexed adminstrative regions: {}", nb),
-    }
+fn index<C>(es_cnx_string: &str, items: C, index_name: &str) -> Result<u32, rs_es::error::EsError>
+        where C: IntoIterator,
+              C::Item: serde::Serialize + mimir::DocType,
+{
+    let mut rubber = Rubber::new_with_index(es_cnx_string, index_name);
+    rubber.bulk_index(items.into_iter())
 }
 
-fn index_ways(es_cnx_string: &str, streets: StreetsVec) {
-    let mut rubber = Rubber::new(es_cnx_string);
-    match rubber.clean_db_by_doc_type(&["street"]) {
-        Err(e) => panic!("failed to clean data for street: {}", e),
-        Ok(nb) => info!("Nb of cleaned indexed streets: {}", nb),
-    }
-    match rubber.bulk_index(streets.iter()) {
-        Err(e) => panic!("failed to index streets of osm because: {}", e),
-        Ok(nb) => info!("Nb of indexed street: {}", nb),
-    }
-}
 
-fn index_settings(es_cnx_string: &str) {
+fn init_indexes(es_cnx_string: &str, type_: &str, dataset: &str,) -> Result<String, String> {
     let mut rubber = Rubber::new(es_cnx_string);
-    rubber.create_index();
+    let index_name = format!("{}_{}", type_, dataset);
+    if !rubber.is_existing_index(&index_name).unwrap() {
+        rubber.create_index_with_name(&index_name.to_string());
+        try!(rubber.alias(&type_.to_string(), &vec![index_name.clone()], &vec![]));
+        try!(rubber.alias(&"munin".to_string(), &vec![type_.to_string()], &vec![]));
+    }
+    Ok(index_name)
 }
 
 fn main() {
     mimir::logger_init().unwrap();
-    debug!("importing adminstrative region into Mimir");
     let args: Args = docopt::Docopt::new(USAGE)
                          .and_then(|d| d.decode())
                          .unwrap_or_else(|e| e.exit());
 
     let levels = args.flag_level.iter().cloned().collect();
     let mut parsed_pbf = parse_osm_pbf(&args.flag_input);
+    debug!("creation of indexes");
+    let index_name = init_indexes(&args.flag_connection_string, &"admin", &args.flag_dataset).unwrap();
 
-    let admins = administrative_regions(&mut parsed_pbf, levels);
-
-    index_settings(&args.flag_connection_string);
-    index_admin(&args.flag_connection_string, admins);
+    debug!("importing adminstrative region into Mimir");
+    let nb_admins = index(&args.flag_connection_string, administrative_regions(&mut parsed_pbf, levels), &index_name).unwrap();
+    info!("Nb of indexed admin: {}", nb_admins);
 
     if args.flag_way {
-        index_ways(&args.flag_connection_string, streets(&mut parsed_pbf));
+        let index_name = init_indexes(&args.flag_connection_string, &"way", &args.flag_dataset).unwrap();
+        let nb_street = index(&args.flag_connection_string, streets(&mut parsed_pbf), &index_name).unwrap();
+        info!("Nb of indexed street: {}", nb_street);
     }
 }

--- a/tests/bano2mimir_test.rs
+++ b/tests/bano2mimir_test.rs
@@ -29,6 +29,25 @@
 // www.navitia.io
 
 use std::process::Command;
+use hyper;
+use hyper::client::Client;
+use hyper::client::response::Response;
+//use rs_es;
+//use rs_es::EsResponse;
+use serde_json;
+use serde_json::value::Value;
+
+trait ToJson {
+    fn to_json(self) -> Value;
+}
+impl ToJson for Response {
+    fn to_json(self) -> Value {
+        match serde_json::from_reader(self) {
+            Ok(v) => v,
+            Err(e) => { assert!(false, "could not get json value from response: {:?}", e); panic!("should not be possible") }
+        }
+    }
+}
 
 /// Simple call to a BANO load into ES base
 /// Checks that we are able to find one object (a specific address)
@@ -37,21 +56,27 @@ pub fn bano2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
     info!("Launching {}", bano2mimir);
     let status = Command::new(bano2mimir)
                      .args(&["--input=./tests/sample-bano.csv".into(),
-                             format!("--connection-string={}/munin", es_wrapper.host())])
+                             format!("--connection-string={}", es_wrapper.host())])
                      .status()
                      .unwrap();
     assert!(status.success(), "`bano2mimir` failed {}", &status);
 
     es_wrapper.refresh();
+    let master_index = "munin"; // for the moment it's hard coded, but hopefully that will change
 
-    let res = ::curl::http::handle()
-                  .get(format!("{}/munin/_search?q=20", es_wrapper.host()))
-                  .exec()
-                  .unwrap();
-    assert!(res.get_code() == 200, "Error ES search: {}", res);
-    let body = ::std::str::from_utf8(res.get_body()).unwrap();
-    debug!("_search?q=20 :\n{}", body);
-    let value: ::serde_json::value::Value = ::serde_json::from_str(body).unwrap();
+    let client = Client::new();
+    let res = client.get(&format!("{host}/{index}/_search?q=20",
+                  host=es_wrapper.host(),
+                  index=master_index)).send().unwrap();
+    assert!(res.status == hyper::Ok);
+    let value = res.to_json();
+
     let nb_hits = value.lookup("hits.total").and_then(|v| v.as_u64()).unwrap_or(0);
     assert_eq!(nb_hits, 1);
+
+    // after an import, we should have 1 index, and some aliases to this index
+    let res = client.get(&format!("{host}/_aliases", host=es_wrapper.host()))
+                  .send()
+                  .unwrap();
+    assert!(res.status == hyper::Ok);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -35,6 +35,8 @@ extern crate rs_es;
 extern crate serde_json;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate mdo;
 
 use docker_wrapper::*;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -49,9 +49,8 @@ impl<'a> ElasticSearchWrapper<'a> {
     }
 
     pub fn init(&self) {
-        let mut rubber = mimir::rubber::Rubber::new(&format!("{}/_all",
-                                                                   self.docker_wrapper.host()));
-        rubber.delete_index().unwrap();
+        let mut rubber = mimir::rubber::Rubber::new(&self.docker_wrapper.host());
+        rubber.delete_index(&"_all".to_string()).unwrap();
     }
 
     //    A way to watch if indexes are built might be curl http://localhost:9200/_stats

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -30,7 +30,8 @@
 
 extern crate mimir;
 extern crate docker_wrapper;
-extern crate curl;
+extern crate hyper;
+extern crate rs_es;
 extern crate serde_json;
 #[macro_use]
 extern crate log;
@@ -58,11 +59,9 @@ impl<'a> ElasticSearchWrapper<'a> {
     // 	  should be == 0 if indexes are ok (no refresh needed)
     pub fn refresh(&self) {
         info!("Refreshing ES indexes");
-        let res = ::curl::http::handle()
-                      .get(format!("{}/_refresh", self.host()))
-                      .exec()
-                      .unwrap();
-        assert!(res.get_code() == 200, "Error ES refresh: {}", res);
+
+        let res = hyper::client::Client::new().get(&format!("{}/_refresh", self.host())).send().unwrap();
+        assert!(res.status == hyper::Ok, "Error ES refresh: {:?}", res);
     }
 
     pub fn new(docker_wrapper: &DockerWrapper) -> ElasticSearchWrapper {


### PR DESCRIPTION
now an alias is created for each dataset/document type, and aliases are
used for the search to manage 0 downtime data update


egg, after an update the indexes will be:
```
 ❯ http ":9200/_aliases"
HTTP/1.1 200 OK
Content-Length: 77
Content-Type: application/json; charset=UTF-8

{
    "munin_addr_fr_20160523_105906": {
        "aliases": {
            "munin": {}, 
            "munin_addr_fr": {}
        }
    }
}

```