### PR TITLE
persist insee_id in admin

### DIFF
--- a/libs/mimir/src/objects.rs.in
+++ b/libs/mimir/src/objects.rs.in
@@ -69,6 +69,7 @@ pub struct Coord {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Admin {
     pub id: String,
+    pub insee: String,
     pub level: u32,
     pub name: String,
     pub zip_code: String,

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -152,10 +152,9 @@ fn administrative_regions(pbf: &mut OsmPbfReader, levels: HashSet<u32>) -> Admin
                                                }
                                            })
                                        });
-
-            let admin_id = match relation.tags.get("ref:INSEE") {
-                Some(val) => format!("admin:fr:{}", val.trim_left_matches('0')),
-                None => format!("admin:osm:{}", relation.id),
+            let (admin_id, insee_id) = match relation.tags.get("ref:INSEE") {
+                Some(val) => (format!("admin:fr:{}", val.trim_left_matches('0')), val.trim_left_matches('0')),
+                None => (format!("admin:osm:{}", relation.id), ""),
             };
             let zip_code = match relation.tags.get("addr:postcode") {
                 Some(val) => &val[..],
@@ -164,6 +163,7 @@ fn administrative_regions(pbf: &mut OsmPbfReader, levels: HashSet<u32>) -> Admin
             let boundary = mimirsbrunn::boundaries::build_boundary(&relation, &objects);
             let admin = mimir::Admin {
                 id: admin_id,
+                insee: insee_id.to_string(),
                 level: level,
                 name: name.to_string(),
                 zip_code: zip_code.to_string(),

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -128,6 +128,7 @@ pub fn rubber_custom_id(mut es: ::ElasticSearchWrapper) {
 
     let admin = Admin {
         id: "admin:bob".to_string(),
+        insee: "insee:dummy".to_string(),
         level: 8,
         name: "my admin".to_string(),
         zip_code: "zip_code".to_string(),
@@ -150,6 +151,7 @@ pub fn rubber_custom_id(mut es: ::ElasticSearchWrapper) {
         let es_source = es_elt.find("_source").unwrap();
         assert_eq!(es_elt.find("_id"), es_source.find("id"));
         assert_eq!(es_elt.find("_id"), Some(&to_value("admin:bob")));
+        assert_eq!(es_source.find("insee"), Some(&to_value("insee:dummy")));
     };
     check_has_elt(&es, Box::new(check_admin));
 }


### PR DESCRIPTION
according to the demand in this ticket: http://jira.canaltp.fr/browse/NAVP-592, we have to stock insee_id in admin
