### PR TITLE
Add administrative regions in bragi

### DIFF
--- a/libs/bragi/src/model.rs.in
+++ b/libs/bragi/src/model.rs.in
@@ -31,6 +31,7 @@
 use mimir;
 
 use geojson;
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Geocoding {
@@ -51,6 +52,8 @@ pub struct Properties {
     pub geocoding: GeocodingResponse,
 }
 
+
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GeocodingResponse {
     pub id: String,
@@ -67,7 +70,7 @@ pub struct GeocodingResponse {
     //pub county: Option<String>,
     //pub state: Option<String>,
     //pub country: Option<String>,
-    //pub admin: Option<HashMap<String, String>>,
+    pub administrative_region: Option<HashMap<String, String>>,
     //pub geohash: Option<String>
 }
 
@@ -122,6 +125,7 @@ impl From<mimir::Admin> for GeocodingResponse {
             housenumber: None,
             street: None,
             city: None,
+            administrative_region: None,
         }
     }
 }
@@ -131,8 +135,15 @@ impl From<mimir::Street> for GeocodingResponse {
         let type_ = "street".to_string();
         let name = Some(other.street_name);
         let label = Some(other.name);
-        let (postcode, city) = other.administrative_region.map_or((None, None), |admin| {
-            (Some(admin.zip_code), Some(admin.name))
+        let (postcode, city, admin_map) = other.administrative_region.map_or((None, None, None), |admin| {
+            let mut admin_map: HashMap<String, String> = HashMap::new();
+            admin_map.insert("admin_level".to_string(), admin.level.to_string());
+            let coord = admin.coord.map_or("".to_string(), |coord| {
+                format!("{};{}", coord.lat, coord.lon)
+            });
+            admin_map.insert("coord".to_string(), coord);
+            
+            (Some(admin.zip_code), Some(admin.name), Some(admin_map))
         });
 
         GeocodingResponse {
@@ -144,6 +155,7 @@ impl From<mimir::Street> for GeocodingResponse {
             housenumber: None,
             street: None,
             city: city,
+            administrative_region: admin_map,
         }
     }
 }
@@ -155,10 +167,17 @@ impl From<mimir::Addr> for GeocodingResponse {
         let label = Some(other.name);
         let housenumber = Some(other.house_number);
         let street_name = Some(other.street.name);
-        let (postcode, city) = other.street.administrative_region.map_or((None, None), |admin| {
-            (Some(admin.zip_code), Some(admin.name))
+        let (postcode, city, admin_map) = other.street.administrative_region.map_or((None, None, None), |admin| {
+            let mut admin_map: HashMap<String, String> = HashMap::new();
+            let coord = admin.coord.map_or("".to_string(), |coord| {
+                format!("{};{}", coord.lat, coord.lon)
+            });
+            admin_map.insert("coord".to_string(), coord);
+            admin_map.insert("admin_level".to_string(), admin.level.to_string());
+            
+            (Some(admin.zip_code), Some(admin.name), Some(admin_map))
         });
-
+        
         GeocodingResponse {
             id: other.id,
             place_type: type_,
@@ -168,6 +187,7 @@ impl From<mimir::Addr> for GeocodingResponse {
             housenumber: housenumber,
             street: street_name,
             city: city,
+            administrative_region: admin_map, 
         }
     }
 }

--- a/libs/bragi/src/model.rs.in
+++ b/libs/bragi/src/model.rs.in
@@ -67,7 +67,7 @@ pub struct GeocodingResponse {
     //pub county: Option<String>,
     //pub state: Option<String>,
     //pub country: Option<String>,
-    pub administrative_regions: Option<Vec<mimir::Admin>>,
+    pub administrative_regions: Vec<mimir::Admin>,
     //pub geohash: Option<String>
 }
 
@@ -122,7 +122,7 @@ impl From<mimir::Admin> for GeocodingResponse {
             housenumber: None,
             street: None,
             city: None,
-            administrative_regions: None,
+            administrative_regions: vec![],
         }
     }
 }
@@ -132,8 +132,8 @@ impl From<mimir::Street> for GeocodingResponse {
         let type_ = "street".to_string();
         let name = Some(other.street_name);
         let label = Some(other.name);
-        let (postcode, city, admins) = other.administrative_region.map_or((None, None, None), |admin| {
-            (Some(admin.zip_code.clone()), Some(admin.name.clone()), Some(vec![admin]))
+        let (postcode, city, admins) = other.administrative_region.map_or((None, None, vec![]), |admin| {
+            (Some(admin.zip_code.clone()), Some(admin.name.clone()), vec![admin])
         });
 
         GeocodingResponse {
@@ -157,10 +157,9 @@ impl From<mimir::Addr> for GeocodingResponse {
         let label = Some(other.name);
         let housenumber = Some(other.house_number);
         let street_name = Some(other.street.name);
-        let (postcode, city, admins) = other.street.administrative_region.map_or((None, None, None), |admin| {
-            (Some(admin.zip_code.clone()), Some(admin.name.clone()), Some(vec![admin]))
+        let (postcode, city, admins) = other.street.administrative_region.map_or((None, None, vec![]), |admin| {
+            (Some(admin.zip_code.clone()), Some(admin.name.clone()), vec![admin])
         });
-        
         GeocodingResponse {
             id: other.id,
             place_type: type_,

--- a/libs/bragi/src/model.rs.in
+++ b/libs/bragi/src/model.rs.in
@@ -31,7 +31,6 @@
 use mimir;
 
 use geojson;
-use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Geocoding {
@@ -52,8 +51,6 @@ pub struct Properties {
     pub geocoding: GeocodingResponse,
 }
 
-
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GeocodingResponse {
     pub id: String,
@@ -70,7 +67,7 @@ pub struct GeocodingResponse {
     //pub county: Option<String>,
     //pub state: Option<String>,
     //pub country: Option<String>,
-    pub administrative_region: Option<HashMap<String, String>>,
+    pub administrative_regions: Option<Vec<mimir::Admin>>,
     //pub geohash: Option<String>
 }
 
@@ -125,7 +122,7 @@ impl From<mimir::Admin> for GeocodingResponse {
             housenumber: None,
             street: None,
             city: None,
-            administrative_region: None,
+            administrative_regions: None,
         }
     }
 }
@@ -135,15 +132,8 @@ impl From<mimir::Street> for GeocodingResponse {
         let type_ = "street".to_string();
         let name = Some(other.street_name);
         let label = Some(other.name);
-        let (postcode, city, admin_map) = other.administrative_region.map_or((None, None, None), |admin| {
-            let mut admin_map: HashMap<String, String> = HashMap::new();
-            admin_map.insert("admin_level".to_string(), admin.level.to_string());
-            let coord = admin.coord.map_or("".to_string(), |coord| {
-                format!("{};{}", coord.lat, coord.lon)
-            });
-            admin_map.insert("coord".to_string(), coord);
-            
-            (Some(admin.zip_code), Some(admin.name), Some(admin_map))
+        let (postcode, city, admins) = other.administrative_region.map_or((None, None, None), |admin| {
+            (Some(admin.zip_code.clone()), Some(admin.name.clone()), Some(vec![admin]))
         });
 
         GeocodingResponse {
@@ -155,7 +145,7 @@ impl From<mimir::Street> for GeocodingResponse {
             housenumber: None,
             street: None,
             city: city,
-            administrative_region: admin_map,
+            administrative_regions: admins,
         }
     }
 }
@@ -167,15 +157,8 @@ impl From<mimir::Addr> for GeocodingResponse {
         let label = Some(other.name);
         let housenumber = Some(other.house_number);
         let street_name = Some(other.street.name);
-        let (postcode, city, admin_map) = other.street.administrative_region.map_or((None, None, None), |admin| {
-            let mut admin_map: HashMap<String, String> = HashMap::new();
-            let coord = admin.coord.map_or("".to_string(), |coord| {
-                format!("{};{}", coord.lat, coord.lon)
-            });
-            admin_map.insert("coord".to_string(), coord);
-            admin_map.insert("admin_level".to_string(), admin.level.to_string());
-            
-            (Some(admin.zip_code), Some(admin.name), Some(admin_map))
+        let (postcode, city, admins) = other.street.administrative_region.map_or((None, None, None), |admin| {
+            (Some(admin.zip_code.clone()), Some(admin.name.clone()), Some(vec![admin]))
         });
         
         GeocodingResponse {
@@ -187,7 +170,7 @@ impl From<mimir::Addr> for GeocodingResponse {
             housenumber: housenumber,
             street: street_name,
             city: city,
-            administrative_region: admin_map, 
+            administrative_regions: admins, 
         }
     }
 }


### PR DESCRIPTION
http://jira.canaltp.fr/browse/NAVP-592

add more admin details in street and address:

[x] tested with address  
[x] cannot test with street

```json
{
  "Autocomplete": {
    "type": "FeatureCollection",
    "geocoding": {
      "version": "0.1.0",
      "query": ""
    },
    "features": [
      {
        "type": "Feature",
        "geometry": {
          "coordinates": [
            2.3266459999999993,
            48.803326
          ],
          "type": "Point"
        },
        "properties": {
          "geocoding": {
            "id": "addr:2.326646;48.803326",
            "type": "house",
            "label": "22 Rue Guy de Gouyon du Verger, (Arcueil)",
            "name": "22 Rue Guy de Gouyon du Verger, (Arcueil)",
            "housenumber": "22",
            "street": "Rue Guy de Gouyon du Verger, (Arcueil)",
            "postcode": "94110",
            "city": "Arcueil",
            "administrative_regions": [
              {
                "id": "admin:fr:94003",
                "insee": "94003",
                "level": 8,
                "name": "Arcueil",
                "zip_code": "94110",
                "weight": 1,
                "coord": {
                  "lat": 48.80211180000001,
                  "lon": 2.3320691999999994
                }
              }
            ]
          }
        }
      }
    ]
  }
}
```