### PR TITLE
for geocoding admin

### DIFF
--- a/libs/bragi/src/model.in.rs
+++ b/libs/bragi/src/model.in.rs
@@ -152,7 +152,7 @@ fn get_city_name(admins: &Vec<Rc<mimir::Admin>>) -> Option<String> {
     admins.iter()
         .find(|a| !a.zip_codes.is_empty())
         .or_else(|| admins.iter().next())
-        .map(|admin| admin.label.clone())
+        .map(|admin| admin.name.clone())
 }
 
 impl From<mimir::Street> for GeocodingResponse {

--- a/tests/bragi_test.rs
+++ b/tests/bragi_test.rs
@@ -451,7 +451,7 @@ pub fn bragi_tests(es_wrapper: ::ElasticSearchWrapper) {
     assert_eq!(get_value(stop, "id"), "stop_area:SA:second_station");
     // this stop area is in the boundary of the admin 'Vaux-le-Pénil',
     // it should have been associated to it
-    assert_eq!(get_value(stop, "city"), "Vaux-le-Pénil (77000)");
+    assert_eq!(get_value(stop, "city"), "Vaux-le-Pénil");
     let admins = stop.get("administrative_regions").and_then(|a| a.as_array());
     assert_eq!(admins.map(|a| a.len()).unwrap_or(0), 1);
 


### PR DESCRIPTION
in the 'city' field there should be only the city name, not the label

Note: the field is not used in navitia, it's only for geocodejson
compatibility