### PR TITLE
relax the minimum match filter

### DIFF
--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -102,7 +102,9 @@ fn build_query(q: &str,
     // for fuzzy search we also search by the prefix index (with a greater boost than ngram)
     // to have better results
     if match_type == MatchType::Fuzzy {
-        should_query.push(rs_q::build_match("label.prefix", q.to_string()).with_boost(1000).build());
+        should_query.push(rs_q::build_match("label.prefix", q.to_string())
+            .with_boost(1000)
+            .build());
     }
 
     if let &Some(ref c) = coord {

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -142,7 +142,7 @@ fn build_query(q: &str,
             // this way if the input has more fields than the documents
             // (additional information like the country, the region, ...)
             // they can be ignored
-            MinimumShouldMatch::from(vec![min_match(0, 90f64), min_match(4, 70f64)])
+            MinimumShouldMatch::from(vec![min_match(2, 90f64), min_match(4, 70f64)])
         }
         // for fuzzy search we lower our expectation and we accept 50% of token match
         MatchType::Fuzzy => MinimumShouldMatch::from(50f64),


### PR DESCRIPTION
when we search [0, 2] fields, we need to match 100% of them
when we search [0, 4] fields, we need to match 90% of them
when we [5, +] fields, we only need to match 70% on them 

this way if the has more fields than the documents (additional information like country, the region, ...) they can be ignored

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-minimum-should-match.html

we this on go from 938 fails on geocoding tester (on idf) to 881

Note: the impact on performance seems negligeable