### PR TITLE
cleanup old useless indexes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 cache: cargo
 before_script: 
-  - cargo install -f rustfmt
+  - cargo install -f rustfmt --vers 0.7.1  # the 0.8.0 is buggy, for the moment we fix the version
   - export PATH=$PATH:$HOME/.cargo/bin
 rust:
   - stable

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -178,7 +178,7 @@ impl Rubber {
                     Ok(value.as_object()
                         .map(|aliases| {
                             aliases.keys()
-                                // new_index is not an old index
+                                // we don't want to remove the newly created index
                                 .filter(|i| i.as_str() != new_index)
                                 .cloned()
                                 .collect()

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -176,12 +176,12 @@ impl Rubber {
                     let value: serde_json::Value = try!(res.read_response()
                         .map_err(|e| e.to_string()));
                     Ok(value.as_object()
-                        .and_then(|aliases| {
-                            Some(aliases.keys()
+                        .map(|aliases| {
+                            aliases.keys()
                                 // new_index is not an old index
                                 .filter(|i| i.as_str() != new_index)
                                 .cloned()
-                                .collect())
+                                .collect()
                         })
                         .unwrap_or_else(|| {
                             info!("no previous index to delete for type {} and dataset {}",

--- a/tests/bano2mimir_test.rs
+++ b/tests/bano2mimir_test.rs
@@ -46,7 +46,6 @@ pub fn bano2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
     let res: Vec<_> = es_wrapper.search_and_filter("20", |_| true).collect();
     assert_eq!(res.len(), 2);
 
-
     // after an import, we should have 1 index, and some aliases to this index
     let client = Client::new();
     let res = client.get(&format!("{host}/_aliases", host = es_wrapper.host()))

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -171,7 +171,8 @@ pub fn rubber_custom_id(mut es: ::ElasticSearchWrapper) {
 }
 
 /// test that rubber correctly cleanup ghost indexes
-/// (indexes that are not aliases to anything, for example if an import has been stopped in the middle)
+/// (indexes that are not aliases to anything, for example
+/// if an import has been stopped in the middle)
 pub fn rubber_ghost_index_cleanup(mut es: ::ElasticSearchWrapper) {
     // we create a ghost ES index
     let client = hyper::client::Client::new();

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -33,6 +33,7 @@ use mimir::{Street, Admin, Coord, MimirObject};
 use mimir::rubber::Rubber;
 use std;
 use std::cell::Cell;
+use hyper;
 
 fn check_has_elt(es: &::ElasticSearchWrapper, fun: Box<Fn(&Value)>) {
     let search = es.search("*:*"); // we get all documents in the base
@@ -167,4 +168,59 @@ pub fn rubber_custom_id(mut es: ::ElasticSearchWrapper) {
         assert_eq!(es_coord.find("lon"), Some(&Value::F64(2.68326290)));
     };
     check_has_elt(&es, Box::new(check_admin));
+}
+
+/// test that rubber correctly cleanup ghost indexes
+/// (indexes that are not aliases to anything, for example if an import has been stopped in the middle)
+pub fn rubber_ghost_index_cleanup(mut es: ::ElasticSearchWrapper) {
+    // we create a ghost ES index
+    let client = hyper::client::Client::new();
+    let old_idx_name = "munin_admin_fr_20170313_113227_006297916";
+    let res = client.put(&format!("{host}/{idx}", host = es.host(), idx = old_idx_name))
+        .send()
+        .unwrap();
+
+    assert_eq!(res.status, hyper::Ok);
+    info!("result: {:?}", res);
+
+    es.refresh();
+    assert_eq!(get_munin_indexes(&es), [old_idx_name.to_string()]);
+
+    let admin = Admin {
+        id: "admin:bob".to_string(),
+        insee: "insee:dummy".to_string(),
+        level: 8,
+        name: "my admin".to_string(),
+        label: "my admin (zip_code)".to_string(),
+        zip_codes: vec!["zip_code".to_string()],
+        weight: Cell::new(42),
+        coord: Coord::new(48.5110722f64, 2.68326290f64),
+        boundary: None,
+    };
+
+    // we index our admin
+    let result = es.rubber.index("fr", std::iter::once(admin));
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 1); // we have indexed 1 element
+
+    es.refresh(); // we need to refresh the index to be sure to get the elt;
+
+    // we should have only one index, and it should not be the previous one
+    assert_eq!(get_munin_indexes(&es).len(), 1);
+    assert!(!get_munin_indexes(&es).contains(&old_idx_name.to_string()));
+}
+
+// return the list of the munin indexes
+fn get_munin_indexes(es: &::ElasticSearchWrapper) -> Vec<String> {
+    use super::ToJson;
+    let client = hyper::client::Client::new();
+    let res = client.get(&format!("{host}/_aliases", host = es.host()))
+        .send()
+        .unwrap();
+    assert_eq!(res.status, hyper::Ok);
+
+    let json = res.to_json();
+    let raw_indexes = json.as_object().unwrap();
+    raw_indexes.keys().cloned().collect()
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -285,6 +285,7 @@ fn all_tests() {
     );
     rubber_test::rubber_zero_downtime_test(ElasticSearchWrapper::new(&docker_wrapper));
     rubber_test::rubber_custom_id(ElasticSearchWrapper::new(&docker_wrapper));
+    rubber_test::rubber_ghost_index_cleanup(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_bano_test::bragi_bano_test(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_osm_test::bragi_osm_test(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_three_cities_test::bragi_three_cities_test(ElasticSearchWrapper::new(&docker_wrapper));


### PR DESCRIPTION
sometimes when a process fail some 'ghost' indexes remain, we now clean
them up