### PR TITLE
mimir: Calculate stop_area weight by stop_point count

### DIFF
--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -144,7 +144,7 @@ impl<'a, R: std::io::Read + 'a> Iterator for StopPointIter<'a, R> {
                 let location_type = self.get_location_type(&r);
                 let visible = self.get_visible(&r);
                 let parent_station = self.get_parent_station(&r);
-                //if it's a stop, we update its stop_area counter                    
+                //if it's a stop point, we update its stop_area counter                    
                 if let (Some(0), Some(id)) = (location_type, parent_station) {
                     if !id.is_empty() {
                         *self.nb_stop_points.entry(format!("stop_area:{}", id)).or_insert(0) += 1;

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -263,7 +263,8 @@ fn test_load_stops() {
         .unwrap()
         .double_quote(true);
 
-    let stops: Vec<mimir::Stop> = StopPointIter::new(&mut rdr)
+    let mut nb_stop_points = HashMap::new();
+    let stops: Vec<mimir::Stop> = StopPointIter::new(&mut rdr, &mut nb_stop_points)
         .unwrap()
         .filter_map(|rc| rc.map_err(|e| println!("error at csv line decoding : {}", e)).ok())
         .collect();

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -121,12 +121,12 @@ impl<'a, R: std::io::Read + 'a> Iterator for StopPointIter<'a, R> {
     fn next(&mut self) -> Option<Self::Item> {
         fn get(record: &[String], pos: usize) -> csv::Result<&str> {
             record.get(pos)
-                  .map(|s| s.as_str())
-                  .ok_or_else(|| csv::Error::Decode(format!("Failed accessing record '{}'.", pos)))
+                .map(|s| s.as_str())
+                .ok_or_else(|| csv::Error::Decode(format!("Failed accessing record '{}'.", pos)))
         }
         fn parse_f64(s: &str) -> csv::Result<f64> {
             s.parse()
-             .map_err(|_| csv::Error::Decode(format!("Failed converting '{}' from str.", s)))
+                .map_err(|_| csv::Error::Decode(format!("Failed converting '{}' from str.", s)))
         }
 
         fn is_valid_stop_area(location_type: &Option<u8>, visible: &Option<u8>) -> csv::Result<()> {
@@ -238,12 +238,12 @@ fn main() {
     let mut nb_stop_points = HashMap::new();
 
     let mut stops: Vec<mimir::Stop> = StopPointIter::new(&mut rdr, &mut nb_stop_points)
-                                          .unwrap()
-                                          .filter_map(|rc| {
-                                              rc.map_err(|e| debug!("skip csv line because: {}", e))
-                                                .ok()
-                                          })
-                                          .collect();
+        .unwrap()
+        .filter_map(|rc| {
+            rc.map_err(|e| debug!("skip csv line because: {}", e))
+                .ok()
+        })
+        .collect();
 
     attach_stops_to_admins(stops.iter_mut(), &mut rubber, args.flag_city_level);
 
@@ -268,19 +268,17 @@ fn test_load_stops() {
     // SA:witout_lon: StopArea object without longitude coord
     // SA:station_no_city: StopArea far away, we won't be able to attach it to a city
     let mut rdr = csv::Reader::from_file("./tests/fixtures/stops.txt".to_string())
-                      .unwrap()
-                      .double_quote(true);
+        .unwrap()
+        .double_quote(true);
 
     let mut nb_stop_points = HashMap::new();
     let stops: Vec<mimir::Stop> = StopPointIter::new(&mut rdr, &mut nb_stop_points)
-                                      .unwrap()
-                                      .filter_map(|rc| {
-                                          rc.map_err(|e| {
-                                                println!("error at csv line decoding : {}", e)
-                                            })
-                                            .ok()
-                                      })
-                                      .collect();
+        .unwrap()
+        .filter_map(|rc| {
+            rc.map_err(|e| println!("error at csv line decoding : {}", e))
+                .ok()
+        })
+        .collect();
     assert_eq!(stops.len(), 5);
     let ids: Vec<_> = stops.iter().map(|s| s.id.clone()).sorted();
     assert_eq!(ids,

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -144,7 +144,7 @@ impl<'a, R: std::io::Read + 'a> Iterator for StopPointIter<'a, R> {
                 let location_type = self.get_location_type(&r);
                 let visible = self.get_visible(&r);
                 let parent_station = self.get_parent_station(&r);
-                //if it's a stop point, we update its stop_area counter                    
+                //if it's a stop point, we update its stop_area counter
                 if let (Some(0), Some(id)) = (location_type, parent_station) {
                     if !id.is_empty() {
                         *self.nb_stop_points.entry(format!("stop_area:{}", id)).or_insert(0) += 1;

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -144,9 +144,7 @@ impl<'a, R: std::io::Read + 'a> Iterator for StopPointIter<'a, R> {
                 let location_type = self.get_location_type(&r);
                 let visible = self.get_visible(&r);
                 let parent_station = self.get_parent_station(&r);
-                // For each stop_point with location_type = 0 and parent_type not empty
-                // insert stop_area code in the HashMap with value = 0 if absent
-                // and increment the weight by one
+                //if it's a stop, we update its stop_area counter                    
                 if let (Some(0), Some(id)) = (location_type, parent_station) {
                     if !id.is_empty() {
                         *self.nb_stop_points.entry(format!("stop_area:{}", id)).or_insert(0) += 1;

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -268,10 +268,12 @@ fn test_load_stops() {
         .unwrap()
         .filter_map(|rc| rc.map_err(|e| println!("error at csv line decoding : {}", e)).ok())
         .collect();
-    assert_eq!(stops.len(), 3);
+    assert_eq!(stops.len(), 5);
     let ids: Vec<_> = stops.iter().map(|s| s.id.clone()).sorted();
     assert_eq!(ids,
                vec!["stop_area:SA:main_station",
                     "stop_area:SA:second_station",
-                    "stop_area:SA:station_no_city"]);
+                    "stop_area:SA:station_no_city",
+                    "stop_area:SA:weight_1_station",
+                    "stop_area:SA:weight_3_station"]);
 }

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -42,6 +42,7 @@ use mimir::rubber::Rubber;
 use docopt::Docopt;
 use mimirsbrunn::utils::{format_label, get_zip_codes_from_admins};
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
+use std::collections::HashMap;
 
 const USAGE: &'static str = "
 Usage:
@@ -74,10 +75,12 @@ struct StopPointIter<'a, R: std::io::Read + 'a> {
     stop_name_pos: usize,
     location_type_pos: Option<usize>,
     stop_visible_pos: Option<usize>,
+    parent_station_pos: Option<usize>,
+    nb_stop_points: &'a mut HashMap<String, u32>
 }
 
 impl<'a, R: std::io::Read + 'a> StopPointIter<'a, R> {
-    fn new(r: &'a mut csv::Reader<R>) -> csv::Result<Self> {
+    fn new(r: &'a mut csv::Reader<R>, nb_stop_points: &'a mut HashMap<String, u32>) -> csv::Result<Self> {
         let headers = try!(r.headers());
         let get_optional_pos = |name| headers.iter().position(|s| s == name);
 
@@ -95,6 +98,8 @@ impl<'a, R: std::io::Read + 'a> StopPointIter<'a, R> {
             stop_name_pos: try!(get_pos("stop_name")),
             location_type_pos: get_optional_pos("location_type"),
             stop_visible_pos: get_optional_pos("visible"),
+            parent_station_pos: get_optional_pos("parent_station"),
+            nb_stop_points: nb_stop_points
         })
     }
     fn get_location_type(&self, record: &[String]) -> Option<u8> {
@@ -102,6 +107,10 @@ impl<'a, R: std::io::Read + 'a> StopPointIter<'a, R> {
     }
     fn get_visible(&self, record: &[String]) -> Option<u8> {
         self.stop_visible_pos.and_then(|pos| record.get(pos).and_then(|s| s.parse().ok()))
+    }
+    
+    fn get_parent_station<'b>(&self, record: &'b[String]) -> Option<&'b String> {
+        self.parent_station_pos.and_then(|pos| record.get(pos))
     }
 }
 
@@ -127,12 +136,19 @@ impl<'a, R: std::io::Read + 'a> Iterator for StopPointIter<'a, R> {
                 Ok(())
             }
         }
+        
         self.iter.next().map(|r| {
             r.and_then(|r| {
                 let location_type = self.get_location_type(&r);
                 let visible = self.get_visible(&r);
+                let parent_station = self.get_parent_station(&r);
+                if let (Some(0), Some(id)) = (location_type, parent_station) {
+                	if  !id.is_empty() {
+                		//Increment the count by one
+                		*self.nb_stop_points.entry(format!("stop_area:{}", id)).or_insert(0) +=1;
+                	}
+            	} 
                 try!(is_valid_stop_area(&location_type, &visible));
-
                 let stop_id = try!(get(&r, self.stop_id_pos));
                 let stop_lat = try!(get(&r, self.stop_lat_pos));
                 let stop_lat = try!(parse_f64(stop_lat));
@@ -194,6 +210,15 @@ fn attach_stops_to_admins<'a, It: Iterator<Item = &'a mut mimir::Stop>>(stops: I
           nb_unmatched,
           nb_matched + nb_unmatched);
 }
+                                                                        
+//Update weight value for each stop_area from HashMap.
+fn finalize_stop_area_weight<'a, It: Iterator<Item = &'a mut mimir::Stop>>(stops: It, nb_stop_points: &HashMap<String, u32>){
+    for stop in stops {
+    	if let Some(weight) = nb_stop_points.get(&stop.id) {
+        	stop.weight = *weight;
+    	}
+    }
+} 
 
 fn main() {
     mimir::logger_init().unwrap();
@@ -205,12 +230,16 @@ fn main() {
     let mut rubber = Rubber::new(&args.flag_connection_string);
     let mut rdr = csv::Reader::from_file(args.flag_input).unwrap().double_quote(true);
 
-    let mut stops: Vec<mimir::Stop> = StopPointIter::new(&mut rdr)
+	let mut nb_stop_points = HashMap::new();
+	
+    let mut stops: Vec<mimir::Stop> = StopPointIter::new(&mut rdr, &mut nb_stop_points)
         .unwrap()
         .filter_map(|rc| rc.map_err(|e| debug!("skip csv line because: {}", e)).ok())
         .collect();
 
     attach_stops_to_admins(stops.iter_mut(), &mut rubber, args.flag_city_level);
+    
+    finalize_stop_area_weight(stops.iter_mut(), &nb_stop_points);
 
     info!("Importing stops into Mimir");
     let nb_stops = rubber.index(&args.flag_dataset, stops.iter()).unwrap();

--- a/tests/bragi_stops_test.rs
+++ b/tests/bragi_stops_test.rs
@@ -77,6 +77,7 @@ pub fn bragi_stops_test(es_wrapper: ::ElasticSearchWrapper) {
 
     stop_filtered_by_dataset_test(&bragi);
     stop_all_data_test(&bragi);
+    stop_order_by_weight_test(&bragi);
 }
 
 
@@ -157,4 +158,18 @@ fn stop_all_data_test(bragi: &BragiHandler) {
     // search wiht _all_data = true
     let response = bragi.get("/autocomplete?q=14 juillet&_all_data=true");
     assert_eq!(response.len(), 2);
+}
+
+fn stop_order_by_weight_test(bragi: &BragiHandler) {
+    // The StopAreas are sorted by weight. stop_area:SA:weight_3_station having weight 3
+    // will be the first element in the result where as stop_area:SA:weight_1_station will always be second.  
+    let response = bragi.get("/autocomplete?q=weight&_all_data=true");
+    assert_eq!(response.len(), 2);
+    
+    let stop = response.first().unwrap();
+
+    assert_eq!(get_value(stop, "type"), "public_transport:stop_area");
+    assert_eq!(get_value(stop, "label"), "weight three");
+    assert_eq!(get_value(stop, "name"), "weight three");
+    assert_eq!(get_value(stop, "id"), "stop_area:SA:weight_3_station");
 }

--- a/tests/bragi_stops_test.rs
+++ b/tests/bragi_stops_test.rs
@@ -162,7 +162,7 @@ fn stop_all_data_test(bragi: &BragiHandler) {
 
 fn stop_order_by_weight_test(bragi: &BragiHandler) {
     // The StopAreas are sorted by weight. stop_area:SA:weight_3_station having weight 3
-    // will be the first element in the result where as stop_area:SA:weight_1_station will 
+    // will be the first element in the result where as stop_area:SA:weight_1_station will
     //always be second.
     let response = bragi.get("/autocomplete?q=weight&_all_data=true");
     assert_eq!(response.len(), 2);

--- a/tests/bragi_stops_test.rs
+++ b/tests/bragi_stops_test.rs
@@ -162,7 +162,8 @@ fn stop_all_data_test(bragi: &BragiHandler) {
 
 fn stop_order_by_weight_test(bragi: &BragiHandler) {
     // The StopAreas are sorted by weight. stop_area:SA:weight_3_station having weight 3
-    // will be the first element in the result where as stop_area:SA:weight_1_station will always be second.
+    // will be the first element in the result where as stop_area:SA:weight_1_station will 
+    //always be second.
     let response = bragi.get("/autocomplete?q=weight&_all_data=true");
     assert_eq!(response.len(), 2);
 

--- a/tests/bragi_stops_test.rs
+++ b/tests/bragi_stops_test.rs
@@ -173,4 +173,11 @@ fn stop_order_by_weight_test(bragi: &BragiHandler) {
     assert_eq!(get_value(stop, "label"), "weight three");
     assert_eq!(get_value(stop, "name"), "weight three");
     assert_eq!(get_value(stop, "id"), "stop_area:SA:weight_3_station");
+
+    let stop = response.last().unwrap();
+
+    assert_eq!(get_value(stop, "type"), "public_transport:stop_area");
+    assert_eq!(get_value(stop, "label"), "weight one");
+    assert_eq!(get_value(stop, "name"), "weight one");
+    assert_eq!(get_value(stop, "id"), "stop_area:SA:weight_1_station");
 }

--- a/tests/bragi_stops_test.rs
+++ b/tests/bragi_stops_test.rs
@@ -162,10 +162,10 @@ fn stop_all_data_test(bragi: &BragiHandler) {
 
 fn stop_order_by_weight_test(bragi: &BragiHandler) {
     // The StopAreas are sorted by weight. stop_area:SA:weight_3_station having weight 3
-    // will be the first element in the result where as stop_area:SA:weight_1_station will always be second.  
+    // will be the first element in the result where as stop_area:SA:weight_1_station will always be second.
     let response = bragi.get("/autocomplete?q=weight&_all_data=true");
     assert_eq!(response.len(), 2);
-    
+
     let stop = response.first().unwrap();
 
     assert_eq!(get_value(stop, "type"), "public_transport:stop_area");

--- a/tests/fixtures/stops.txt
+++ b/tests/fixtures/stops.txt
@@ -7,4 +7,9 @@ SA:witout_lon,1,"Alouettes",47.117836,,,1,,Europe/Paris,,BGT,,BGT:19
 SA:witout_lat,1,"ALPHONSE DAUDET",,1.829052,,1,,Europe/Paris,,OLS,,OLS:12
 SP:main_station,1,"République",47.099758,2.491858,,,SA:main_station,Europe/Paris,,BGT,,BGT:19
 SP:second_station,,"14 Juillet",47.123966,2.402522,,0,SA:second_station,Europe/Paris,,BGT,,BGT:19
-
+SP:weight_1_station_1,1,"sp weight",47.099758,2.491858,,,SA:weight_1_station,Europe/Paris,,BGT,,BGT:19
+SA:weight_1_station,1,"weight one",47.123966,2.402522,,1,,Europe/Paris,,BGT,,BGT:19
+SP:weight_3_station_1,1,"sp weight",47.099758,2.491858,,,SA:weight_3_station,Europe/Paris,,BGT,,BGT:19
+SP:weight_3_station_2,1,"sp weight",47.099758,2.491858,,,SA:weight_3_station,Europe/Paris,,BGT,,BGT:19
+SP:weight_3_station_3,1,"sp weight",47.099758,2.491858,,,SA:weight_3_station,Europe/Paris,,BGT,,BGT:19
+SA:weight_3_station,1,"weight three",47.123966,2.402522,,1,,Europe/Paris,,BGT,,BGT:19

--- a/tests/stops2mimir_test.rs
+++ b/tests/stops2mimir_test.rs
@@ -41,7 +41,7 @@ pub fn stops2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
                         &es_wrapper);
     // Test: Import of stops
     let res: Vec<_> = es_wrapper.search_and_filter("*", |_| true).collect();
-    assert_eq!(res.len(), 3);
+    assert_eq!(res.len(), 5);
     assert!(res.iter().all(|r| r.is_stop()));
 
     // Test: search for stop area not in ES base


### PR DESCRIPTION
This modification calculates weight of each StopArea which is the number of it's StopPoint. 