### PR TITLE
Search on word and not prefix on zip code

### DIFF
--- a/json/settings.json
+++ b/json/settings.json
@@ -87,7 +87,7 @@
                     "properties": {
                         "id": { "type": "string", "index": "no" },
                         "street_name": { "type": "string" },
-                        "administrative_region": {
+                        "administrative_regions": {
                             "properties": {
                                 "id": { "type": "string", "index": "no" },
                                 "level": { "type": "long", "index": "no" },
@@ -136,7 +136,7 @@
                         }
                     }
                 },
-                "administrative_region": {
+                "administrative_regions": {
                     "properties": {
                         "id": { "type": "string", "index": "no" },
                         "level": { "type": "long", "index": "no" },
@@ -234,7 +234,7 @@
                         }
                     }
                 },
-                "administrative_region": {
+                "administrative_regions": {
                     "properties": {
                         "id": { "type": "string", "index": "no" },
                         "level": { "type": "long", "index": "no" },
@@ -316,7 +316,7 @@
                 }
               }
             },
-            "administrative_region": {
+            "administrative_regions": {
               "properties": {
                 "id": {
                   "type": "string",

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -107,7 +107,7 @@ fn build_query(q: &str,
     // Priorization by query string
     let mut string_should = vec![Query::build_match("label", q).with_boost(1.).build(),
                                  Query::build_match("label.prefix", q).with_boost(1.).build(),
-                                 Query::build_match("zip_codes.prefix", q).with_boost(1.).build()];
+                                 Query::build_match("zip_codes", q).with_boost(1.).build()];
     if let MatchType::Fuzzy = match_type {
         string_should.push(Query::build_match("label.ngram", q).with_boost(1.).build());
     }
@@ -149,8 +149,7 @@ fn build_query(q: &str,
         // WITH the cross_fields match type, the request will be spilted into terms to match
         // "label" and "zip_codes"
         MatchType::Prefix => {
-            Query::build_multi_match(vec!["label.prefix".to_string(),
-                                          "zip_codes.prefix".to_string()],
+            Query::build_multi_match(vec!["label.prefix".to_string(), "zip_codes".to_string()],
                                      q.to_string())
                 .with_type(rs_es::query::full_text::MatchQueryType::CrossFields)
                 .with_operator("and")
@@ -164,8 +163,7 @@ fn build_query(q: &str,
         // Very long requests:
         //     Caisse Primaire d'Assurance Maladie de Haute Garonne, 33 Rue du Lot, 31100 Toulouse
         MatchType::Fuzzy => {
-            Query::build_multi_match(vec!["label.ngram".to_string(),
-                                          "zip_codes.prefix".to_string()],
+            Query::build_multi_match(vec!["label.ngram".to_string(), "zip_codes".to_string()],
                                      q.to_string())
                 .with_minimum_should_match(MinimumShouldMatch::from(40f64))
                 .build()


### PR DESCRIPTION
That's a bit worst on geocoder-tester (361 -> 394), but remove strange artefacts around zip prefix and house number