### PR TITLE
Add a global stops index

### DIFF
--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -194,6 +194,8 @@ pub struct Stop {
     pub administrative_regions: Vec<Rc<Admin>>,
     pub weight: f64,
     pub zip_codes: Vec<String>,
+    #[serde(default)]
+    pub coverages: Vec<String>,
 }
 
 impl MimirObject for Stop {

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -132,7 +132,7 @@ impl Rubber {
         )
     }
 
-    fn create_index(&self, name: &String) -> Result<(), String> {
+    pub fn create_index(&self, name: &String) -> Result<(), String> {
         debug!("creating index");
         // Note: in rs_es it can be done with MappingOperation but for the moment I think
         // storing the mapping in json is more convenient

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -29,7 +29,7 @@
 // www.navitia.io
 
 
-use super::objects::{MimirObject, Admin};
+use super::objects::{Admin, MimirObject};
 use chrono;
 use hyper;
 use hyper::status::StatusCode;
@@ -38,8 +38,10 @@ use rs_es;
 use rs_es::EsResponse;
 use serde_json;
 use rs_es::operations::search::ScanResult;
-
-use super::objects::{AliasOperations, AliasOperation, AliasParameter};
+use serde;
+use std;
+use std::collections::BTreeMap;
+use super::objects::{AliasOperation, AliasOperations, AliasParameter};
 use rs_es::units::Duration;
 
 const SYNONYMS: [&'static str; 17] = [
@@ -71,14 +73,22 @@ pub struct Rubber {
 
 /// return the index associated to the given type and dataset
 /// this will be an alias over another real index
-fn get_main_type_and_dataset_index(doc_type: &str, dataset: &str) -> String {
+pub fn get_main_type_and_dataset_index(doc_type: &str, dataset: &str) -> String {
     format!("munin_{}_{}", doc_type, dataset)
 }
 
 /// return the index associated to the given type
 /// this will be an alias over another real index
-fn get_main_type_index(doc_type: &str) -> String {
+pub fn get_main_type_index(doc_type: &str) -> String {
     format!("munin_{}", doc_type)
+}
+
+pub fn get_date_index_name(base_index_name: &str) -> String {
+    format!(
+        "{}_{}",
+        base_index_name,
+        chrono::Utc::now().format("%Y%m%d_%H%M%S_%f")
+    )
 }
 
 impl Rubber {
@@ -115,8 +125,7 @@ impl Rubber {
     }
 
     pub fn make_index(&self, doc_type: &str, dataset: &str) -> Result<String, String> {
-        let current_time = chrono::Utc::now().format("%Y%m%d_%H%M%S_%f");
-        let index_name = format!("munin_{}_{}_{}", doc_type, dataset, current_time);
+        let index_name = get_date_index_name(&get_main_type_and_dataset_index(doc_type, dataset));
         info!("creating index {}", index_name);
         self.create_index(&index_name.to_string()).map(
             |_| index_name,
@@ -155,6 +164,47 @@ impl Rubber {
             })
     }
 
+    // get all aliases for a doc_type/dataset
+    // return a map with each index as key and all their aliases
+    pub fn get_all_aliased_index(
+        &self,
+        base_index: &str,
+    ) -> Result<BTreeMap<String, Vec<String>>, String> {
+        self.get(&format!("{}*/_aliases", base_index))
+            .map_err(|e| e.to_string())
+            .and_then(|res| match res.status {
+                StatusCode::Ok => {
+                    let value: serde_json::Value =
+                        try!(res.read_response().map_err(|e| e.to_string()));
+                    Ok(
+                        value
+                            .as_object()
+                            .map(|all_aliases| {
+                                all_aliases
+                                    .iter()
+                                    .filter_map(|(i, a)| {
+                                        a.pointer("/aliases").and_then(|a| a.as_object()).map(
+                                        |aliases| {
+                                            (i.clone(), aliases.keys().cloned().collect())
+                                        },
+                                    )
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_else(|| {
+                                info!("no aliases for {}", base_index);
+                                BTreeMap::new()
+                            }),
+                    )
+                }
+                StatusCode::NotFound => {
+                    info!("impossible to find alias {}", base_index);
+                    Ok(BTreeMap::new())
+                }
+                _ => Err(format!("invalid elasticsearch response: {:?}", res)),
+            })
+    }
+
     // get the last indexes for this doc_type/dataset
     // Note: to be resilient to ghost ES indexes, we return all indexes for this doc_type/dataset
     // but the new index
@@ -165,41 +215,14 @@ impl Rubber {
         dataset: &str,
     ) -> Result<Vec<String>, String> {
         let base_index = get_main_type_and_dataset_index(doc_type, dataset);
-        self.get(&format!("{}*/_aliases", base_index))
-            .map_err(|e| e.to_string())
-            .and_then(|res| match res.status {
-                StatusCode::Ok => {
-                    let value: serde_json::Value =
-                        try!(res.read_response().map_err(|e| e.to_string()));
-                    Ok(
-                        value
-                            .as_object()
-                            .map(|aliases| {
-                                aliases.keys()
-                                // we don't want to remove the newly created index
-                                .filter(|i| i.as_str() != new_index)
-                                .cloned()
-                                .collect()
-                            })
-                            .unwrap_or_else(|| {
-                                info!(
-                                    "no previous index to delete for type {} and dataset {}",
-                                    doc_type,
-                                    dataset
-                                );
-                                vec![]
-                            }),
-                    )
-                }
-                StatusCode::NotFound => {
-                    info!(
-                        "impossible to find alias {}, no last index to remove",
-                        base_index
-                    );
-                    Ok(vec![])
-                }
-                _ => Err(format!("invalid elasticsearch response: {:?}", res)),
-            })
+        // we don't want to remove the newly created index
+        Ok(
+            self.get_all_aliased_index(&base_index)?
+                .into_iter()
+                .map(|(k, _)| k)
+                .filter(|i| i.as_str() != new_index)
+                .collect(),
+        )
     }
 
     /// publish the index as the new index for this doc_type and this dataset
@@ -257,7 +280,12 @@ impl Rubber {
 
     /// add a list of new indexes to the alias
     /// remove a list of indexes from the alias
-    fn alias(&self, alias: &str, add: &Vec<String>, remove: &Vec<String>) -> Result<(), String> {
+    pub fn alias(
+        &self,
+        alias: &str,
+        add: &Vec<String>,
+        remove: &Vec<String>,
+    ) -> Result<(), String> {
         info!(
             "for {}, adding alias {:?}, removing {:?}",
             alias,
@@ -384,14 +412,20 @@ impl Rubber {
         self.get_admins_from_index(&get_main_type_index(Admin::doc_type()))
     }
 
-    fn get_admins_from_index(&mut self, index: &str) -> Result<Vec<Admin>, rs_es::error::EsError> {
-        let mut result: Vec<Admin> = vec![];
-        let mut scan: ScanResult<Admin> = try!(
+    pub fn get_all_objects_from_index<T>(
+        &mut self,
+        index: &str,
+    ) -> Result<Vec<T>, rs_es::error::EsError>
+    where
+        for<'de> T: MimirObject + serde::de::Deserialize<'de> + std::fmt::Debug,
+    {
+        let mut result: Vec<T> = vec![];
+        let mut scan: ScanResult<T> = try!(
             self.es_client
                 .search_query()
                 .with_indexes(&[&index])
                 .with_size(1000)
-                .with_types(&[&Admin::doc_type()])
+                .with_types(&[&T::doc_type()])
                 .scan(&Duration::minutes(1))
         );
         loop {
@@ -409,6 +443,10 @@ impl Rubber {
         }
         try!(scan.close(&mut self.es_client));
         Ok(result)
+    }
+
+    fn get_admins_from_index(&mut self, index: &str) -> Result<Vec<Admin>, rs_es::error::EsError> {
+        self.get_all_objects_from_index(index)
     }
 }
 

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -208,7 +208,7 @@ fn update_global_stop_index<'a, It: Iterator<Item = &'a mimir::Stop>>(
         .map(|(index, _)| index);
 
     let all_other_es_stops: Vec<_> = stops_indexes
-        .map(|index| get_all_stops(rubber, index).unwrap()) // TODO no unwrap
+        .map(|index| get_all_stops(rubber, index).unwrap())
         .flat_map(|stops| stops.into_iter())
         .collect();
 

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -301,6 +301,7 @@ fn test_load_stops() {
     assert_eq!(
         ids,
         vec![
+            "stop_area:SA:known_by_all_dataset",
             "stop_area:SA:main_station",
             "stop_area:SA:second_station",
             "stop_area:SA:station_no_city",
@@ -309,5 +310,8 @@ fn test_load_stops() {
         ]
     );
     let weights: Vec<_> = ids.iter().map(|id| nb_stop_points.get(id)).collect();
-    assert_eq!(weights, vec![Some(&1), Some(&1), None, Some(&1), Some(&3)]);
+    assert_eq!(
+        weights,
+        vec![None, Some(&1), Some(&1), None, Some(&1), Some(&3)]
+    );
 }

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -233,7 +233,7 @@ fn update_global_stop_index<'a, It: Iterator<Item = &'a mimir::Stop>>(
 // publish the global stop index
 // alias the new index to the global stop alias, and remove the old index
 fn publish_global_index(rubber: &mut Rubber, new_global_index: &str) -> Result<(), String> {
-    let last_global_indexes = rubber
+    let last_global_indexes: Vec<_> = rubber
         .get_all_aliased_index(GLOBAL_STOP_INDEX_NAME)?
         .into_iter()
         .map(|(k, _)| k)

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -43,9 +43,12 @@ extern crate log;
 use std::rc::Rc;
 use mimir::rubber::Rubber;
 use mimirsbrunn::utils::{format_label, get_zip_codes_from_admins};
+use mimir::MimirObject;
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use std::collections::HashMap;
 use structopt::StructOpt;
+
+const GLOBAL_STOP_INDEX_NAME: &'static str = "munin_global_stops";
 
 #[derive(Debug, StructOpt)]
 struct Args {
@@ -98,6 +101,7 @@ impl GtfsStop {
                 zip_codes: vec![],
                 administrative_regions: vec![],
                 name: self.stop_name,
+                coverages: vec![],
             })
         } else {
             None
@@ -151,17 +155,98 @@ fn attach_stops_to_admins<'a, It: Iterator<Item = &'a mut mimir::Stop>>(
     );
 }
 
-// Update weight value for each stop_area from HashMap.
-fn finalize_stop_area_weight<'a, It: Iterator<Item = &'a mut mimir::Stop>>(
+// Update weight value for each stop_area from HashMap and stop's coverage
+fn finalize_stop_area<'a, It: Iterator<Item = &'a mut mimir::Stop>>(
     stops: It,
     nb_stop_points: &HashMap<String, u32>,
+    dataset: &str,
 ) {
     let max = *nb_stop_points.values().max().unwrap_or(&1) as f64;
     for stop in stops {
         if let Some(weight) = nb_stop_points.get(&stop.id) {
             stop.weight = *weight as f64 / max;
         }
+        stop.coverages.push(dataset.to_string());
     }
+}
+
+/// merge the stops from all the different indexes
+/// for the moment the merge is very simple and uses only the ID
+/// (and we take the data from the first stop inserted)
+fn merge_stops<It: IntoIterator<Item = mimir::Stop>>(
+    stops: It,
+) -> Box<Iterator<Item = mimir::Stop>> {
+    let mut stops_by_id = HashMap::<String, mimir::Stop>::new();
+    for mut stop in stops.into_iter() {
+        let cov = std::mem::replace(&mut stop.coverages, vec![]);
+        stops_by_id
+            .entry(stop.id.clone())
+            .or_insert(stop)
+            .coverages
+            .extend(cov.into_iter());
+    }
+    Box::new(stops_by_id.into_iter().map(|(_, v)| v))
+}
+
+fn get_all_stops(rubber: &mut Rubber, index: String) -> Result<Vec<mimir::Stop>, String> {
+    rubber.get_all_objects_from_index(&index).map_err(
+        |e| e.to_string(),
+    )
+}
+
+fn update_global_stop_index<'a, It: Iterator<Item = &'a mimir::Stop>>(
+    rubber: &mut Rubber,
+    stops: It,
+    dataset: &str,
+) -> Result<String, String> {
+    let dataset_index =
+        mimir::rubber::get_main_type_and_dataset_index(mimir::Stop::doc_type(), dataset);
+    let stops_indexes = rubber
+        .get_all_aliased_index(&mimir::rubber::get_main_type_index(mimir::Stop::doc_type()))?
+        .into_iter()
+        .filter(|&(_, ref aliases)| !aliases.contains(&dataset_index))
+        .map(|(index, _)| index);
+
+    let all_other_es_stops: Vec<_> = stops_indexes
+        .map(|index| get_all_stops(rubber, index).unwrap()) // TODO no unwrap
+        .flat_map(|stops| stops.into_iter())
+        .collect();
+
+    let all_es_stops = all_other_es_stops.into_iter().chain(
+        stops.into_iter().cloned(),
+    );
+
+    let all_merged_stops = merge_stops(all_es_stops);
+    let es_index_name = mimir::rubber::get_date_index_name(GLOBAL_STOP_INDEX_NAME);
+
+    let nb_stops_added = rubber
+        .bulk_index(&es_index_name, all_merged_stops)
+        .map_err(|e| e.to_string())?;
+    info!("{} stops added in the global index", nb_stops_added);
+    // create global index
+    // fill structure for each stop indexes
+    Ok(es_index_name)
+}
+
+// publish the global stop index
+// alias the new index to the global stop alias, and remove the old index
+fn publish_global_index(rubber: &mut Rubber, new_global_index: &str) -> Result<(), String> {
+    let last_global_indexes = rubber
+        .get_all_aliased_index(GLOBAL_STOP_INDEX_NAME)?
+        .into_iter()
+        .map(|(k, _)| k)
+        .filter(|k| k != new_global_index)
+        .collect();
+    rubber.alias(
+        GLOBAL_STOP_INDEX_NAME,
+        &vec![new_global_index.to_string()],
+        &last_global_indexes,
+    )?;
+
+    for index in last_global_indexes {
+        rubber.delete_index(&index)?;
+    }
+    Ok(())
 }
 
 fn main() {
@@ -188,12 +273,15 @@ fn main() {
 
     attach_stops_to_admins(stops.iter_mut(), &mut rubber, args.city_level);
 
-    finalize_stop_area_weight(stops.iter_mut(), &nb_stop_points);
+    finalize_stop_area(stops.iter_mut(), &nb_stop_points, &args.dataset);
+
+    let global_index = update_global_stop_index(&mut rubber, stops.iter(), &args.dataset).unwrap();
 
     info!("Importing {} stops into Mimir", stops.len());
     let nb_stops = rubber.index(&args.dataset, stops.iter()).unwrap();
-
     info!("Nb of indexed stops: {}", nb_stops);
+
+    publish_global_index(&mut rubber, &global_index).unwrap();
 }
 
 #[test]

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -219,6 +219,8 @@ fn update_global_stop_index<'a, It: Iterator<Item = &'a mimir::Stop>>(
     let all_merged_stops = merge_stops(all_es_stops);
     let es_index_name = mimir::rubber::get_date_index_name(GLOBAL_STOP_INDEX_NAME);
 
+    rubber.create_index(&es_index_name)?;
+
     let nb_stops_added = rubber
         .bulk_index(&es_index_name, all_merged_stops)
         .map_err(|e| e.to_string())?;

--- a/tests/bragi_stops_test.rs
+++ b/tests/bragi_stops_test.rs
@@ -39,7 +39,7 @@ pub fn bragi_stops_test(es_wrapper: ::ElasticSearchWrapper) {
     let bragi = BragiHandler::new(format!("{}/munin", es_wrapper.host()));
 
     // ******************************************
-    // we the OSM dataset, three-cities bano dataset and a stop file
+    // we import the OSM dataset, three-cities bano dataset and 2 stop files
     // the current dataset are thus (load order matters):
     // - osm_fixture.osm.pbf
     // - bano-three_cities

--- a/tests/fixtures/stops.txt
+++ b/tests/fixtures/stops.txt
@@ -13,3 +13,4 @@ SP:weight_3_station_1,1,"sp weight",47.099758,2.491858,,,SA:weight_3_station,Eur
 SP:weight_3_station_2,1,"sp weight",47.099758,2.491858,,,SA:weight_3_station,Europe/Paris,,BGT,,BGT:19
 SP:weight_3_station_3,1,"sp weight",47.099758,2.491858,,,SA:weight_3_station,Europe/Paris,,BGT,,BGT:19
 SA:weight_3_station,1,"weight three",47.123966,2.402522,,1,,Europe/Paris,,BGT,,BGT:19
+SA:known_by_all_dataset,1,"All known stop, but different name",48.6,2.8,,1,,Europe/Paris,,BGT,,BGT:19

--- a/tests/fixtures/stops_dataset2.txt
+++ b/tests/fixtures/stops_dataset2.txt
@@ -1,2 +1,3 @@
 stop_id,visible,stop_name,stop_lat,stop_lon,zone_id,location_type,parent_station,stop_timezone,equipment_id,contributor_id,geometry_id,frame_id
 SA:second_station:dataset2,,"14 Juillet",48.527463,2.6796462,,1,,Europe/Paris,,BGT,,BGT:19
+SA:known_by_all_dataset,1,"All known stop",48.6,2.8,,1,,Europe/Paris,,BGT,,BGT:19

--- a/tests/stops2mimir_test.rs
+++ b/tests/stops2mimir_test.rs
@@ -102,13 +102,10 @@ pub fn stops2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
                     "stop_area:SA:second_station:dataset2" => {
                         assert_eq!(stop.coverages, vec!["dataset2"])
                     }
-                    _ => {
-                        print!("{}: {:?}", stop.id, stop);
-                        assert_eq!(stop.coverages, vec!["dataset1"])
-                    }
+                    _ => assert_eq!(stop.coverages, vec!["dataset1"]),
                 }
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 }

--- a/tests/stops2mimir_test.rs
+++ b/tests/stops2mimir_test.rs
@@ -40,12 +40,13 @@ pub fn stops2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
         vec![
             "--input=./tests/fixtures/stops.txt".into(),
             format!("--connection-string={}", es_wrapper.host()),
+            "--dataset=dataset1".into(),
         ],
         &es_wrapper,
     );
     // Test: Import of stops
     let res: Vec<_> = es_wrapper.search_and_filter("*", |_| true).collect();
-    assert_eq!(res.len(), 5);
+    assert_eq!(res.len(), 6);
     assert!(res.iter().all(|r| r.is_stop()));
 
     // Test: search for stop area not in ES base
@@ -61,4 +62,52 @@ pub fn stops2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
     assert!(res.len() == 1);
     assert_eq!(res[0].label(), "République");
     assert!(res[0].admins().is_empty());
+
+    // we also test that all the stops have been imported in the global index
+    let res: Vec<_> = es_wrapper
+        .search_and_filter_on_global_stop_index("*", |_| true)
+        .collect();
+    assert_eq!(res.len(), 6);
+    assert!(res.iter().all(|r| r.is_stop()));
+
+    // we then import another stop fixture
+    ::launch_and_assert(
+        stops2mimir,
+        vec![
+            "--input=./tests/fixtures/stops_dataset2.txt".into(),
+            format!("--connection-string={}", es_wrapper.host()),
+            "--dataset=dataset2".into(),
+        ],
+        &es_wrapper,
+    );
+
+    // we should now have 7 stops as there are 2 stops in dataset2, but one (SA:known_by_all_dataset) is merged
+    let res: Vec<_> = es_wrapper
+        .search_and_filter_on_global_stop_index("*", |_| true)
+        .collect();
+    assert_eq!(res.len(), 7);
+    for s in res {
+        match s {
+            mimir::Place::Stop(stop) => {
+                match stop.id.as_ref() {
+                    "stop_area:SA:known_by_all_dataset" => {
+                        assert_eq!(stop.coverages, vec!["dataset1", "dataset2"]);
+                        // we don't control which label is taken
+                        assert!(
+                            vec!["All known stop", "All known stop, but different name"]
+                                .contains(&stop.label.as_ref())
+                        );
+                    }
+                    "stop_area:SA:second_station:dataset2" => {
+                        assert_eq!(stop.coverages, vec!["dataset2"])
+                    }
+                    _ => {
+                        print!("{}: {:?}", stop.id, stop);
+                        assert_eq!(stop.coverages, vec!["dataset1"])
+                    }
+                }
+            }
+            _ => assert!(false),
+        }
+    }
 }

--- a/tests/stops2mimir_test.rs
+++ b/tests/stops2mimir_test.rs
@@ -81,7 +81,8 @@ pub fn stops2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
         &es_wrapper,
     );
 
-    // we should now have 7 stops as there are 2 stops in dataset2, but one (SA:known_by_all_dataset) is merged
+    // we should now have 7 stops as there are 2 stops in dataset2,
+    // but one (SA:known_by_all_dataset) is merged
     let res: Vec<_> = es_wrapper
         .search_and_filter_on_global_stop_index("*", |_| true)
         .collect();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -132,7 +132,8 @@ impl<'a> ElasticSearchWrapper<'a> {
         res.to_json()
     }
 
-    pub fn search_and_filter<'b, F>( &self,
+    pub fn search_and_filter<'b, F>(
+        &self,
         word: &str,
         predicate: F,
     ) -> Box<Iterator<Item = mimir::Place> + 'b>
@@ -142,7 +143,8 @@ impl<'a> ElasticSearchWrapper<'a> {
         self.search_and_filter_on_index(word, predicate, false)
     }
 
-    pub fn search_and_filter_on_global_stop_index<'b, F>( &self,
+    pub fn search_and_filter_on_global_stop_index<'b, F>(
+        &self,
         word: &str,
         predicate: F,
     ) -> Box<Iterator<Item = mimir::Place> + 'b>
@@ -156,7 +158,7 @@ impl<'a> ElasticSearchWrapper<'a> {
         &self,
         word: &str,
         predicate: F,
-        search_on_global_stops: bool
+        search_on_global_stops: bool,
     ) -> Box<Iterator<Item = mimir::Place> + 'b>
     where
         F: 'b + FnMut(&mimir::Place) -> bool,
@@ -177,9 +179,9 @@ impl<'a> ElasticSearchWrapper<'a> {
         }
         let json = if search_on_global_stops {
             self.search_on_global_stop_index(word)
-            } else {
-                self.search(word)
-            };
+        } else {
+            self.search(word)
+        };
         get(json, "hits")
             .and_then(|json| get(json, "hits"))
             .and_then(|hits| {


### PR DESCRIPTION
As a step to have an auto-completion working cross navitia's coverages, when we import a stop we aggregate all the stops in a unique index.

For the moment the stops are 'merged' only if they got the same ID (that will likely change) and we retain the data only from one of the merged stop.

An additional stop field has been added, `coverages` with the list of the stop's coverage.

This will make it possible for bragi to filter a query on a set of coverage.

There is not the bragi part in this PR