### PR TITLE
set different MinimumShouldMatch per size of the query

### DIFF
--- a/json/settings.json
+++ b/json/settings.json
@@ -55,6 +55,7 @@
                         "type": "string",
                         "index_options": "docs",
                         "analyzer": "word",
+                        "copy_to": "full_label",
                         "fields": {
                             "prefix": {
                                 "type": "string",
@@ -65,6 +66,26 @@
                           }
                 },
                 "label": {
+                    "type": "string",
+                    "index_options": "docs",
+                    "analyzer": "word",
+                    "copy_to": "full_label",
+                    "fields": {
+                        "prefix": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "prefix",
+                            "search_analyzer": "word"
+                        },
+                        "ngram": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "ngram_with_synonyms",
+                            "search_analyzer": "ngram"
+                        }
+                    }
+                },
+                "full_label": {
                     "type": "string",
                     "index_options": "docs",
                     "analyzer": "word",
@@ -121,6 +142,26 @@
                     "type": "string",
                     "index_options": "docs",
                     "analyzer": "word",
+                    "copy_to": "full_label",
+                    "fields": {
+                        "prefix": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "prefix",
+                            "search_analyzer": "word"
+                        },
+                        "ngram": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "ngram_with_synonyms",
+                            "search_analyzer": "ngram"
+                        }
+                    }
+                },
+                "full_label": {
+                    "type": "string",
+                    "index_options": "docs",
+                    "analyzer": "word",
                     "fields": {
                         "prefix": {
                             "type": "string",
@@ -149,6 +190,7 @@
                         "type": "string",
                         "index_options": "docs",
                         "analyzer": "word",
+                        "copy_to": "full_label",
                         "fields": {
                             "prefix": {
                                 "type": "string",
@@ -168,6 +210,7 @@
                     "type": "string",
                     "index_options": "docs",
                     "analyzer": "word",
+                    "copy_to": "full_label",
                     "fields": {
                         "prefix": {
                             "type": "string",
@@ -187,6 +230,7 @@
                         "type": "string",
                         "index_options": "docs",
                         "analyzer": "word",
+                        "copy_to": "full_label",
                         "fields": {
                             "prefix": {
                                 "type": "string",
@@ -195,6 +239,25 @@
                                 "search_analyzer": "word"
                                 }
                           }
+                },
+                "full_label": {
+                    "type": "string",
+                    "index_options": "docs",
+                    "analyzer": "word",
+                    "fields": {
+                        "prefix": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "prefix",
+                            "search_analyzer": "word"
+                        },
+                        "ngram": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "ngram_with_synonyms",
+                            "search_analyzer": "ngram"
+                        }
+                    }
                 },
                 "weight": { "type": "double" },
                 "coord": {
@@ -215,10 +278,30 @@
                     "geohash_prefix": true,
                     "geohash_precision": "1m"
                 },
+                "full_label": {
+                    "type": "string",
+                    "index_options": "docs",
+                    "analyzer": "word",
+                    "fields": {
+                        "prefix": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "prefix",
+                            "search_analyzer": "word"
+                        },
+                        "ngram": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "ngram_with_synonyms",
+                            "search_analyzer": "ngram"
+                        }
+                    }
+                },
                 "label": {
                     "type": "string",
                     "index_options": "docs",
                     "analyzer": "word",
+                    "copy_to": "full_label",
                     "fields": {
                         "prefix": {
                             "type": "string",
@@ -247,6 +330,7 @@
                     "type": "string",
                     "index_options": "docs",
                     "analyzer": "word",
+                    "copy_to": "full_label",
                     "fields": {
                         "prefix": {
                             "type": "string",
@@ -301,6 +385,7 @@
               "type": "string",
               "index_options": "docs",
               "analyzer": "word",
+              "copy_to": "full_label",
               "fields": {
                 "prefix": {
                   "type": "string",
@@ -315,6 +400,25 @@
                   "search_analyzer": "ngram"
                 }
               }
+            },
+            "full_label": {
+                "type": "string",
+                "index_options": "docs",
+                "analyzer": "word",
+                "fields": {
+                    "prefix": {
+                        "type": "string",
+                        "index_options": "docs",
+                        "analyzer": "prefix",
+                        "search_analyzer": "word"
+                    },
+                    "ngram": {
+                        "type": "string",
+                        "index_options": "docs",
+                        "analyzer": "ngram_with_synonyms",
+                        "search_analyzer": "ngram"
+                    }
+                }
             },
             "administrative_regions": {
               "properties": {
@@ -342,6 +446,7 @@
               "type": "string",
               "index_options": "docs",
               "analyzer": "word",
+              "copy_to": "full_label",
               "fields": {
                 "prefix": {
                   "type": "string",


### PR DESCRIPTION
This should greatly improve the speed of bragi, chosen values are still a bit experimental, with these one there is 8 more failure on geocoder-tester but overall test are down to 104sec while they were taking 180 seconds before.

TODO:
  - [x] update comment

```
before: ============= 380 failed, 1712 passed, 1 skipped in 185.53 seconds =============
after: ============= 368 failed, 1724 passed, 1 skipped in 94.98 seconds ==============

```

poke @antoine-de  

This PR adds a new index, so bragi will require that all data have been re-indexed before working correctly. The previous version of bragi will still works even with the new indexes.