### PR TITLE
fix bulk bug

### DIFF
--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -368,6 +368,10 @@ impl Rubber {
         });
         loop {
             let chunk = actions.by_ref().take(chunk_size).collect::<Vec<_>>();
+
+            if chunk.is_empty() {
+                break;
+            }
             nb += chunk.len();
             try!(
                 self.es_client

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -235,3 +235,14 @@ fn get_munin_indexes(es: &::ElasticSearchWrapper) -> Vec<String> {
     let raw_indexes = json.as_object().unwrap();
     raw_indexes.keys().cloned().collect()
 }
+
+pub fn rubber_empty_bulk(mut es: ::ElasticSearchWrapper) {
+    // we don't want an empty bulk to crash
+    info!("running rubber_empty_bulk");
+    let dataset = "my_dataset";
+    // we index nothing
+    let result = es.rubber
+        .bulk_index(&dataset.into(), std::iter::empty::<Admin>());
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 0); // we have indexed nothing, but it's ok
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -335,6 +335,7 @@ fn all_tests() {
     rubber_test::rubber_zero_downtime_test(ElasticSearchWrapper::new(&docker_wrapper));
     rubber_test::rubber_custom_id(ElasticSearchWrapper::new(&docker_wrapper));
     rubber_test::rubber_ghost_index_cleanup(ElasticSearchWrapper::new(&docker_wrapper));
+    rubber_test::rubber_empty_bulk(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_bano_test::bragi_bano_test(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_osm_test::bragi_osm_test(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_three_cities_test::bragi_three_cities_test(ElasticSearchWrapper::new(&docker_wrapper));


### PR DESCRIPTION
when bulk inserting empty iterator (or if the number of elements to insert modulo `chunk_size` was 0 ), rubber was crashing
  