### PR TITLE
Import OpenAddresses

### DIFF
--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -58,7 +58,7 @@ pub struct OpenAddresse {
     pub city: String,
     pub number: String,
     pub unit: String,
-    pub hash: String,
+    pub hash: Option<String>,
     pub lat: f64,
     pub lon: f64,
 }

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -28,17 +28,17 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate structopt_derive;
-extern crate structopt;
 extern crate csv;
+extern crate geo;
+#[macro_use]
+extern crate log;
 extern crate mimir;
 extern crate mimirsbrunn;
 #[macro_use]
-extern crate log;
-extern crate geo;
+extern crate serde_derive;
+extern crate structopt;
+#[macro_use]
+extern crate structopt_derive;
 
 use std::path::Path;
 use mimir::rubber::Rubber;
@@ -64,10 +64,7 @@ pub struct OpenAddresse {
 }
 
 impl OpenAddresse {
-    pub fn into_addr(
-        self,
-        admins_geofinder: &AdminGeoFinder,
-    ) -> mimir::Addr {
+    pub fn into_addr(self, admins_geofinder: &AdminGeoFinder) -> mimir::Addr {
         let street_name = format!("{} ({})", self.street, self.city);
         let addr_name = format!("{} {}", self.number, self.street);
         let addr_label = format!("{} ({})", addr_name, self.city);
@@ -77,10 +74,10 @@ impl OpenAddresse {
             y: self.lon,
         });
 
-        let weight = admins.iter().find(|a| a.level == 8).map_or(
-            0.,
-            |a| a.weight.get(),
-        );
+        let weight = admins
+            .iter()
+            .find(|a| a.level == 8)
+            .map_or(0., |a| a.weight.get());
 
         let street = mimir::Street {
             id: street_id,
@@ -109,16 +106,15 @@ where
 {
     let mut rubber = Rubber::new(cnx_string);
 
-    let admins = rubber.get_admins_from_dataset(dataset).unwrap_or_else(
-        |err| {
+    let admins = rubber
+        .get_admins_from_dataset(dataset)
+        .unwrap_or_else(|err| {
             info!(
                 "Administratives regions not found in es db for dataset {}. (error: {})",
-                dataset,
-                err
+                dataset, err
             );
             vec![]
-        },
-    );
+        });
     let admins_geofinder = admins.iter().cloned().collect();
 
     let addr_index = rubber.make_index(Addr::doc_type(), dataset).unwrap();

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -157,7 +157,7 @@ struct Args {
 }
 
 fn main() {
-    mimir::logger_init().unwrap();
+    mimir::logger_init();
     info!("importing open addresses into Mimir");
 
     let args = Args::from_args();

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -1,0 +1,182 @@
+// Copyright © 2018, Canal TP and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+//     the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+//     powered by Canal TP (www.canaltp.fr).
+// Help us simplify mobility and open public transport:
+//     a non ending quest to the responsive locomotion way of traveling!
+//
+// LICENCE: This program is free software; you can redistribute it
+// and/or modify it under the terms of the GNU Affero General Public
+// License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program. If not, see
+// <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// IRC #navitia on freenode
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate structopt_derive;
+extern crate structopt;
+extern crate csv;
+extern crate mimir;
+extern crate mimirsbrunn;
+#[macro_use]
+extern crate log;
+extern crate geo;
+
+use std::path::Path;
+use mimir::rubber::Rubber;
+use mimir::objects::{Addr, MimirObject};
+use mimirsbrunn::admin_geofinder::AdminGeoFinder;
+use std::fs;
+use structopt::StructOpt;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub struct OpenAddresse {
+    pub id: String,
+    pub street: String,
+    pub postcode: String,
+    pub district: String,
+    pub region: String,
+    pub city: String,
+    pub number: String,
+    pub unit: String,
+    pub hash: String,
+    pub lat: f64,
+    pub lon: f64,
+}
+
+impl OpenAddresse {
+    pub fn into_addr(
+        self,
+        admins_geofinder: &AdminGeoFinder,
+    ) -> mimir::Addr {
+        let street_name = format!("{} ({})", self.street, self.city);
+        let addr_name = format!("{} {}", self.number, self.street);
+        let addr_label = format!("{} ({})", addr_name, self.city);
+        let street_id = format!("street:{}", self.id); // TODO check if thats ok
+        let admins = admins_geofinder.get(&geo::Coordinate {
+            x: self.lat,
+            y: self.lon,
+        });
+
+        let weight = admins.iter().find(|a| a.level == 8).map_or(
+            0.,
+            |a| a.weight.get(),
+        );
+
+        let street = mimir::Street {
+            id: street_id,
+            street_name: self.street,
+            label: street_name.to_string(),
+            administrative_regions: admins,
+            weight: weight,
+            zip_codes: vec![self.postcode.clone()],
+            coord: mimir::Coord::new(self.lat, self.lon),
+        };
+        mimir::Addr {
+            id: format!("addr:{};{}", self.lon, self.lat),
+            house_number: self.number,
+            street: street,
+            label: addr_label,
+            coord: mimir::Coord::new(self.lat, self.lon),
+            weight: weight,
+            zip_codes: vec![self.postcode.clone()],
+        }
+    }
+}
+
+fn index_oa<I>(cnx_string: &str, dataset: &str, files: I)
+where
+    I: Iterator<Item = std::path::PathBuf>,
+{
+    let mut rubber = Rubber::new(cnx_string);
+
+    let admins = rubber.get_admins_from_dataset(dataset).unwrap_or_else(
+        |err| {
+            info!(
+                "Administratives regions not found in es db for dataset {}. (error: {})",
+                dataset,
+                err
+            );
+            vec![]
+        },
+    );
+    let admins_geofinder = admins.iter().cloned().collect();
+
+    let addr_index = rubber.make_index(Addr::doc_type(), dataset).unwrap();
+    info!("Add data in elasticsearch db.");
+    for f in files {
+        info!("importing {:?}...", &f);
+        let mut rdr = csv::ReaderBuilder::new()
+            .has_headers(true)
+            .from_path(&f)
+            .unwrap();
+
+        let iter = rdr.deserialize().map(|r| {
+            let b: OpenAddresse = r.unwrap();
+            b.into_addr(&admins_geofinder)
+        });
+        match rubber.bulk_index(&addr_index, iter) {
+            Err(e) => panic!("failed to bulk insert file {:?} because: {}", &f, e),
+            Ok(nb) => info!("importing {:?}: {} addresses added.", &f, nb),
+        }
+    }
+    rubber
+        .publish_index(Addr::doc_type(), dataset, addr_index, Addr::is_geo_data())
+        .unwrap();
+}
+
+#[derive(StructOpt, Debug)]
+struct Args {
+    /// openaddresses files. Can be either a directory or a file.
+    #[structopt(short = "i", long = "input")]
+    input: String,
+    /// Elasticsearch parameters.
+    #[structopt(short = "c", long = "connection-string",
+                default_value = "http://localhost:9200/munin")]
+    connection_string: String,
+    /// Name of the dataset.
+    #[structopt(short = "d", long = "dataset", default_value = "fr")]
+    dataset: String,
+}
+
+fn main() {
+    mimir::logger_init().unwrap();
+    info!("importing open addresses into Mimir");
+
+    let args = Args::from_args();
+
+    let file_path = Path::new(&args.input);
+    if file_path.is_dir() {
+        let paths: std::fs::ReadDir = fs::read_dir(&args.input).unwrap();
+        index_oa(
+            &args.connection_string,
+            &args.dataset,
+            paths.map(|p| p.unwrap().path()),
+        );
+    } else {
+        index_oa(
+            &args.connection_string,
+            &args.dataset,
+            std::iter::once(std::path::PathBuf::from(&args.input)),
+        );
+    }
+}

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -125,10 +125,10 @@ where
             .has_headers(true)
             .from_path(&f)
             .unwrap();
-
-        let iter = rdr.deserialize().map(|r| {
-            let b: OpenAddresse = r.unwrap();
-            b.into_addr(&admins_geofinder)
+        let iter = rdr.deserialize().filter_map(|r| {
+            r.map_err(|e| info!("impossible to read line, error: {}", e))
+                .ok()
+                .map(|v: OpenAddresse| v.into_addr(&admins_geofinder))
         });
         match rubber.bulk_index(&addr_index, iter) {
             Err(e) => panic!("failed to bulk insert file {:?} because: {}", &f, e),

--- a/tests/fixtures/sample-oa.csv
+++ b/tests/fixtures/sample-oa.csv
@@ -8,4 +8,5 @@ LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH
 13.3891903,52.518889,34,Dorotheenstraße,,Berlin,,,10117,,6e93eaafadd1a45c
 13.3897137,52.5186699,35,Dorotheenstraße,,Berlin,,,10117,,025c011f388aa2b2
 13.3894677,52.5186535,37,Dorotheenstraße,,Berlin,,,10117,,d76a05fc52856e17
+13.3894677,52.518658,42,Dorotheenstraße,,Berlin,,,10117,line_without_hash_should_work,
 ,,,,,,,,,badly_formated_line,

--- a/tests/fixtures/sample-oa.csv
+++ b/tests/fixtures/sample-oa.csv
@@ -8,3 +8,4 @@ LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH
 13.3891903,52.518889,34,Dorotheenstraße,,Berlin,,,10117,,6e93eaafadd1a45c
 13.3897137,52.5186699,35,Dorotheenstraße,,Berlin,,,10117,,025c011f388aa2b2
 13.3894677,52.5186535,37,Dorotheenstraße,,Berlin,,,10117,,d76a05fc52856e17
+,,,,,,,,,badly_formated_line,

--- a/tests/fixtures/sample-oa.csv
+++ b/tests/fixtures/sample-oa.csv
@@ -1,0 +1,10 @@
+LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH
+13.4193129,52.5235445,72,Otto-Braun-Straße,,Berlin,,,10178,,7dd34e4c6cc4cdcd
+13.3960675,52.5194301,3,Dorotheenstraße,,Berlin,,,10117,,58563cdf7c46ef4d
+13.3940601,52.5193514,16,Dorotheenstraße,,Berlin,,,10117,,47efc998880565c7
+13.3917783,52.5192125,26,Dorotheenstraße,,Berlin,,,10117,,96c3d317c4fc9f1a
+13.3914051,52.5189387,27,Dorotheenstraße,,Berlin,,,10117,,0eb02d64f941bf90
+13.3898511,52.518665,33,Dorotheenstraße,,Berlin,,,10117,,fde2c164f68b5a3f
+13.3891903,52.518889,34,Dorotheenstraße,,Berlin,,,10117,,6e93eaafadd1a45c
+13.3897137,52.5186699,35,Dorotheenstraße,,Berlin,,,10117,,025c011f388aa2b2
+13.3894677,52.5186535,37,Dorotheenstraße,,Berlin,,,10117,,d76a05fc52856e17

--- a/tests/openaddresses2mimir_test.rs
+++ b/tests/openaddresses2mimir_test.rs
@@ -46,7 +46,9 @@ pub fn oa2mimir_simple_test(es_wrapper: ::ElasticSearchWrapper) {
         &es_wrapper,
     );
 
-    let res: Vec<_> = es_wrapper.search_and_filter("72 Otto-Braun-Straße", |_| true).collect();
+    let res: Vec<_> = es_wrapper
+        .search_and_filter("72 Otto-Braun-Straße", |_| true)
+        .collect();
     assert_eq!(res.len(), 1);
 
     // after an import, we should have 1 index, and some aliases to this index
@@ -64,12 +66,12 @@ pub fn oa2mimir_simple_test(es_wrapper: ::ElasticSearchWrapper) {
 
     // our index should be aliased by the master_index + an alias over the document type + dataset
     let aliases = mdo! {
-         s =<< raw_indexes.get(first_indexes.first().unwrap());
-         s =<< s.as_object();
-         s =<< s.get("aliases");
-         s =<< s.as_object();
-         ret ret(s.keys().cloned().collect())
-     }.unwrap_or_else(Vec::new);
+        s =<< raw_indexes.get(first_indexes.first().unwrap());
+        s =<< s.as_object();
+        s =<< s.get("aliases");
+        s =<< s.as_object();
+        ret ret(s.keys().cloned().collect())
+    }.unwrap_or_else(Vec::new);
     // for the moment 'munin' is hard coded, but hopefully that will change
     assert_eq!(
         aliases,

--- a/tests/openaddresses2mimir_test.rs
+++ b/tests/openaddresses2mimir_test.rs
@@ -1,0 +1,114 @@
+// Copyright © 2018, Canal TP and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+//     the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+//     powered by Canal TP (www.canaltp.fr).
+// Help us simplify mobility and open public transport:
+//     a non ending quest to the responsive locomotion way of traveling!
+//
+// LICENCE: This program is free software; you can redistribute it
+// and/or modify it under the terms of the GNU Affero General Public
+// License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program. If not, see
+// <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// IRC #navitia on freenode
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+
+use hyper;
+use hyper::client::Client;
+use mdo::option::{bind, ret};
+use super::ToJson;
+
+/// Simple call to a OA load into ES base
+/// Checks that we are able to find one object (a specific address)
+pub fn oa2mimir_simple_test(es_wrapper: ::ElasticSearchWrapper) {
+    let oa2mimir = concat!(env!("OUT_DIR"), "/../../../openaddresses2mimir");
+    ::launch_and_assert(
+        oa2mimir,
+        vec![
+            "--input=./tests/fixtures/sample-oa.csv".into(),
+            format!("--connection-string={}", es_wrapper.host()),
+        ],
+        &es_wrapper,
+    );
+
+    let res: Vec<_> = es_wrapper.search_and_filter("72 Otto-Braun-Straße", |_| true).collect();
+    assert_eq!(res.len(), 1);
+
+    // after an import, we should have 1 index, and some aliases to this index
+    let client = Client::new();
+    let res = client
+        .get(&format!("{host}/_aliases", host = es_wrapper.host()))
+        .send()
+        .unwrap();
+    assert_eq!(res.status, hyper::Ok);
+
+    let json = res.to_json();
+    let raw_indexes = json.as_object().unwrap();
+    let first_indexes: Vec<String> = raw_indexes.keys().cloned().collect();
+    assert_eq!(first_indexes.len(), 1);
+
+    // our index should be aliased by the master_index + an alias over the document type + dataset
+    let aliases = mdo! {
+         s =<< raw_indexes.get(first_indexes.first().unwrap());
+         s =<< s.as_object();
+         s =<< s.get("aliases");
+         s =<< s.as_object();
+         ret ret(s.keys().cloned().collect())
+     }.unwrap_or_else(Vec::new);
+    // for the moment 'munin' is hard coded, but hopefully that will change
+    assert_eq!(
+        aliases,
+        vec!["munin", "munin_addr", "munin_addr_fr", "munin_geo_data"]
+    );
+
+    // then we import again the open addresse file:
+    ::launch_and_assert(
+        oa2mimir,
+        vec![
+            "--input=./tests/fixtures/sample-oa.csv".into(),
+            format!("--connection-string={}", es_wrapper.host()),
+        ],
+        &es_wrapper,
+    );
+
+    // we should still have only one index (but a different one)
+    let res = client
+        .get(&format!("{host}/_aliases", host = es_wrapper.host()))
+        .send()
+        .unwrap();
+    assert_eq!(res.status, hyper::Ok);
+
+    let json = res.to_json();
+    let raw_indexes = json.as_object().unwrap();
+    let final_indexes: Vec<String> = raw_indexes.keys().cloned().collect();
+
+    assert_eq!(final_indexes.len(), 1);
+    assert!(final_indexes != first_indexes);
+
+    let aliases = mdo! {
+        s =<< raw_indexes.get(final_indexes.first().unwrap());
+        s =<< s.as_object();
+        s =<< s.get("aliases");
+        s =<< s.as_object();
+        ret ret(s.keys().cloned().collect())
+    }.unwrap_or_else(Vec::new);
+    assert_eq!(
+        aliases,
+        vec!["munin", "munin_addr", "munin_addr_fr", "munin_geo_data"]
+    );
+}

--- a/tests/openaddresses2mimir_test.rs
+++ b/tests/openaddresses2mimir_test.rs
@@ -113,4 +113,8 @@ pub fn oa2mimir_simple_test(es_wrapper: ::ElasticSearchWrapper) {
         aliases,
         vec!["munin", "munin_addr", "munin_addr_fr", "munin_geo_data"]
     );
+
+    // we should have imported 10 elements (we should have the one without hash, but not the badly formated line)
+    let res: Vec<_> = es_wrapper.search_and_filter("*.*", |_| true).collect();
+    assert_eq!(res.len(), 10);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -56,6 +56,7 @@ mod bragi_poi_test;
 mod bragi_stops_test;
 mod bragi_filter_types_test;
 mod bragi_synonyms_test;
+mod openaddresses2mimir_test;
 
 use docker_wrapper::*;
 use serde_json::Map;
@@ -343,4 +344,5 @@ fn all_tests() {
     bragi_stops_test::bragi_stops_test(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_filter_types_test::bragi_filter_types_test(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_synonyms_test::bragi_synonyms_test(ElasticSearchWrapper::new(&docker_wrapper));
+    openaddresses2mimir_test::oa2mimir_simple_test(ElasticSearchWrapper::new(&docker_wrapper));
 }


### PR DESCRIPTION
connector to import data from https://openaddresses.io/, so now you can have addresses from all around the world :world_map: 


you can use this to import french data too if you want, but beware that it's the [ban](https://adresse.data.gouv.fr/), not [bano](http://openstreetmap.fr/bano).

(and it's a bit cumbersome since openaddresse split the files by regions)