### PR TITLE
Fix lat lon in ES

### DIFF
--- a/libs/bragi/src/api.rs
+++ b/libs/bragi/src/api.rs
@@ -130,8 +130,8 @@ impl ApiEndPoint {
                 let cnx = self.es_cnx_string.clone();
                 endpoint.handle(move |client, params| {
                     let coord = ::mimir::Coord::new(
-                        params.find("lat").and_then(|p| p.as_f64()).unwrap(),
                         params.find("lon").and_then(|p| p.as_f64()).unwrap(),
+                        params.find("lat").and_then(|p| p.as_f64()).unwrap(),
                     );
                     let mut rubber = Rubber::new(&cnx);
                     let model_autocomplete = rubber.get_address(&coord);

--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -102,7 +102,7 @@ impl ToGeom for mimir::Place {
 
 impl ToGeom for geo::Coordinate<f64> {
     fn to_geom(&self) -> geojson::Geometry {
-        geojson::Geometry::new(geojson::Value::Point(vec![self.y, self.x]))
+        geojson::Geometry::new(geojson::Value::Point(vec![self.x, self.y]))
     }
 }
 

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -486,13 +486,13 @@ pub struct AliasParameter {
 #[derive(Debug, Clone)]
 pub struct Coord(pub geo::Coordinate<f64>);
 impl Coord {
-    pub fn new(lat: f64, lon: f64) -> Coord {
-        Coord(geo::Coordinate { x: lat, y: lon })
-    }
-    pub fn lat(&self) -> f64 {
-        self.x
+    pub fn new(lon: f64, lat: f64) -> Coord {
+        Coord(geo::Coordinate { x: lon, y: lat })
     }
     pub fn lon(&self) -> f64 {
+        self.x
+    }
+    pub fn lat(&self) -> f64 {
         self.y
     }
     pub fn is_default(&self) -> bool {
@@ -522,8 +522,8 @@ impl serde::Serialize for Coord {
         S: serde::Serializer,
     {
         let mut ser = serializer.serialize_struct("Coord", 2)?;
-        ser.serialize_field("lat", &self.0.x)?;
-        ser.serialize_field("lon", &self.0.y)?;
+        ser.serialize_field("lon", &self.0.x)?;
+        ser.serialize_field("lat", &self.0.y)?;
         ser.end()
     }
 }
@@ -536,8 +536,8 @@ impl<'de> Deserialize<'de> for Coord {
         #[derive(Deserialize)]
         #[serde(field_identifier, rename_all = "lowercase")]
         enum Field {
-            Lat,
             Lon,
+            Lat,
         };
 
         struct CoordVisitor;
@@ -553,11 +553,11 @@ impl<'de> Deserialize<'de> for Coord {
             where
                 V: SeqAccess<'de>,
             {
-                let lat = seq.next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
                 let lon = seq.next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let lat = seq.next_element()?
                     .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                Ok(Coord::new(lat, lon))
+                Ok(Coord::new(lon, lat))
             }
 
             fn visit_map<V>(self, mut map: V) -> Result<Coord, V::Error>
@@ -584,7 +584,7 @@ impl<'de> Deserialize<'de> for Coord {
                 }
                 let lat = lat.ok_or_else(|| de::Error::missing_field("lat"))?;
                 let lon = lon.ok_or_else(|| de::Error::missing_field("lon"))?;
-                Ok(Coord::new(lat, lon))
+                Ok(Coord::new(lon, lat))
             }
         }
 

--- a/libs/osm_builder/src/lib.rs
+++ b/libs/osm_builder/src/lib.rs
@@ -33,7 +33,7 @@ extern crate mimir;
 extern crate osmpbfreader;
 use std::collections::BTreeMap;
 
-pub fn named_node(lat: f64, lon: f64, name: &'static str) -> (mimir::Coord, Option<String>) {
+pub fn named_node(lon: f64, lat: f64, name: &'static str) -> (mimir::Coord, Option<String>) {
     (mimir::Coord::new(lon, lat), Some(name.to_string()))
 }
 

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -28,7 +28,6 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 use mimir::Admin;
-use mimir::AdminType;
 use geo::contains::Contains;
 use geo;
 use std::iter::FromIterator;
@@ -184,6 +183,7 @@ fn test_up_down() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mimir::AdminType;
 
     fn p(x: f64, y: f64) -> ::geo::Point<f64> {
         ::geo::Point(::geo::Coordinate { x: x, y: y })

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -82,8 +82,8 @@ impl Bano {
         let addr_label = format!("{} ({})", addr_name, self.city);
         let street_id = format!("street:{}", self.fantoir().to_string());
         let mut admins = admins_geofinder.get(&geo::Coordinate {
-            x: self.lat,
-            y: self.lon,
+            x: self.lon,
+            y: self.lat,
         });
 
         // If we have an admin corresponding to the INSEE, we know
@@ -106,14 +106,14 @@ impl Bano {
             administrative_regions: admins,
             weight: weight,
             zip_codes: vec![self.zip.clone()],
-            coord: mimir::Coord::new(self.lat, self.lon),
+            coord: mimir::Coord::new(self.lon, self.lat),
         };
         mimir::Addr {
             id: format!("addr:{};{}", self.lon, self.lat),
             house_number: self.nb,
             street: street,
             label: addr_label,
-            coord: mimir::Coord::new(self.lat, self.lon),
+            coord: mimir::Coord::new(self.lon, self.lat),
             weight: weight,
             zip_codes: vec![self.zip.clone()],
         }

--- a/src/bin/ntfs2mimir.rs
+++ b/src/bin/ntfs2mimir.rs
@@ -85,7 +85,7 @@ fn to_mimir(
         id: format!("stop_area:{}", stop_area.id),
         label: stop_area.name.clone(),
         name: stop_area.name.clone(),
-        coord: mimir::Coord::new(stop_area.coord.lat, stop_area.coord.lon),
+        coord: mimir::Coord::new(stop_area.coord.lon, stop_area.coord.lat),
         commercial_modes: commercial_modes,
         physical_modes: physical_modes,
         administrative_regions: vec![],

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -69,8 +69,8 @@ impl OpenAddresse {
         let addr_label = format!("{} ({})", addr_name, self.city);
         let street_id = format!("street:{}", self.id); // TODO check if thats ok
         let admins = admins_geofinder.get(&geo::Coordinate {
-            x: self.lat,
-            y: self.lon,
+            x: self.lon,
+            y: self.lat,
         });
 
         let weight = admins
@@ -85,14 +85,14 @@ impl OpenAddresse {
             administrative_regions: admins,
             weight: weight,
             zip_codes: vec![self.postcode.clone()],
-            coord: mimir::Coord::new(self.lat, self.lon),
+            coord: mimir::Coord::new(self.lon, self.lat),
         };
         mimir::Addr {
             id: format!("addr:{};{}", self.lon, self.lat),
             house_number: self.number,
             street: street,
             label: addr_label,
-            coord: mimir::Coord::new(self.lat, self.lon),
+            coord: mimir::Coord::new(self.lon, self.lat),
             weight: weight,
             zip_codes: vec![self.postcode.clone()],
         }

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -116,7 +116,7 @@ impl GtfsStop {
         } else {
             Ok(mimir::Stop {
                 id: format!("stop_area:{}", self.stop_id), // prefix to match navitia's id
-                coord: mimir::Coord::new(self.stop_lat, self.stop_lon),
+                coord: mimir::Coord::new(self.stop_lon, self.stop_lat),
                 label: self.stop_name.clone(),
                 weight: 0.,
                 zip_codes: vec![],

--- a/src/boundaries.rs
+++ b/src/boundaries.rs
@@ -190,8 +190,8 @@ pub fn build_boundary(
                     .iter()
                     .map(|n| {
                         Point(Coordinate {
-                            x: n.lat(),
-                            y: n.lon(),
+                            x: n.lon(),
+                            y: n.lat(),
                         })
                     })
                     .collect();
@@ -202,8 +202,8 @@ pub fn build_boundary(
                 use geo::haversine_distance::HaversineDistance;
                 let p = |n: &osmpbfreader::Node| {
                     Point(Coordinate {
-                        x: n.lat(),
-                        y: n.lon(),
+                        x: n.lon(),
+                        y: n.lat(),
                     })
                 };
                 let distance =

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -118,7 +118,7 @@ pub fn administrative_regions(
                 .find(|r| r.role == "admin_centre")
                 .and_then(|r| objects.get(&r.member))
                 .and_then(|o| o.node())
-                .map(|node| mimir::Coord::new(node.lat(), node.lon()));
+                .map(|node| mimir::Coord::new(node.lon(), node.lat()));
             let (admin_id, insee_id) = match relation
                 .tags
                 .get("ref:INSEE")

--- a/src/osm_reader/osm_utils.rs
+++ b/src/osm_reader/osm_utils.rs
@@ -41,7 +41,7 @@ pub fn get_way_coord(
         .iter()
         .filter_map(|node_id| obj_map.get(&(*node_id).into()))
         .filter_map(|obj| obj.node())
-        .map(|node| mimir::Coord::new(node.lat(), node.lon()))
+        .map(|node| mimir::Coord::new(node.lon(), node.lat()))
         .next()
         .unwrap_or_else(mimir::Coord::default)
 }

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -219,7 +219,7 @@ fn parse_poi(
     let (id, coord) = match *osmobj {
         osmpbfreader::OsmObj::Node(ref node) => (
             format_poi_id("node", node.id.0),
-            mimir::Coord::new(node.lat(), node.lon()),
+            mimir::Coord::new(node.lon(), node.lat()),
         ),
         osmpbfreader::OsmObj::Way(ref way) => {
             (format_poi_id("way", way.id.0), get_way_coord(obj_map, way))

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -175,8 +175,8 @@ fn get_street_admin(
         .filter_map(|node_id| obj_map.get(&(*node_id).into()))
         .filter_map(|node_obj| node_obj.node())
         .map(|node| geo::Coordinate {
-            x: node.lat(),
-            y: node.lon(),
+            x: node.lon(),
+            y: node.lat(),
         })
         .next()
         .map_or(vec![], |c| admins_geofinder.get(&c))

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -92,7 +92,7 @@ pub fn rubber_zero_downtime_test(mut es: ::ElasticSearchWrapper) {
         administrative_regions: vec![],
         weight: 0.24,
         zip_codes: vec![],
-        coord: Coord::new(48.5110722f64, 2.68326290f64),
+        coord: Coord::new(2.68326290f64, 48.5110722f64),
     };
 
     info!("inserting bobette");
@@ -146,7 +146,7 @@ pub fn rubber_custom_id(mut es: ::ElasticSearchWrapper) {
         label: "my admin (zip_code)".to_string(),
         zip_codes: vec!["zip_code".to_string()],
         weight: Cell::new(0.42),
-        coord: Coord::new(48.5110722f64, 2.68326290f64),
+        coord: Coord::new(2.68326290f64, 48.5110722f64),
         boundary: None,
         admin_type: City,
     };
@@ -206,7 +206,7 @@ pub fn rubber_ghost_index_cleanup(mut es: ::ElasticSearchWrapper) {
         label: "my admin (zip_code)".to_string(),
         zip_codes: vec!["zip_code".to_string()],
         weight: Cell::new(0.42),
-        coord: Coord::new(48.5110722f64, 2.68326290f64),
+        coord: Coord::new(2.68326290f64, 48.5110722f64),
         boundary: None,
         admin_type: City,
     };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -30,6 +30,7 @@
 
 extern crate bragi;
 extern crate docker_wrapper;
+extern crate geo;
 extern crate hyper;
 extern crate iron;
 extern crate iron_test;
@@ -67,6 +68,7 @@ use std::process::Command;
 trait ToJson {
     fn to_json(self) -> Value;
 }
+
 impl ToJson for Response {
     fn to_json(self) -> Value {
         match serde_json::from_reader(self) {


### PR DESCRIPTION
## invert coordinate to have lon/lat in the right order in ElasticSearch

we handle coordinate as `x`/`y` internally, but it the end we want `lon`/`lat` and there was a classical swap between `lon` and `lat`.

The swap was not detected before because bragi swap again the coordinates so in bragi the coordinates are ok even if they are inversed in ES 🤣 

to clarify, now we always do `lon`=`x` and `lat`=`y`, and we always give first `lon` then `lat` in the coordinate constructor

WARNING, this is a breaking change, I don't see any (easy) way to make this retrocompatible, It will need a full reindex !