### PR TITLE
stricter types in Rubber

### DIFF
--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -75,7 +75,7 @@ pub struct Rubber {
 }
 
 pub struct TypedIndex<T> {
-    pub name: String,
+    name: String,
     _type: PhantomData<T>,
 }
 
@@ -579,7 +579,7 @@ impl Rubber {
         // TODO better error handling
         let index = self.make_index(dataset)?;
         let nb_elements = self.bulk_index(&index, iter).map_err(|e| e.to_string())?;
-        self.publish_index::<T>(dataset, index)?;
+        self.publish_index(dataset, index)?;
         Ok(nb_elements)
     }
 

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -76,14 +76,14 @@ pub struct Rubber {
 
 pub struct TypedIndex<T> {
     pub name: String,
-    _type: PhantomData<T>
+    _type: PhantomData<T>,
 }
 
 impl<T> TypedIndex<T> {
     pub fn new(name: String) -> TypedIndex<T> {
         TypedIndex {
             name: name,
-            _type: PhantomData
+            _type: PhantomData,
         }
     }
 }
@@ -443,7 +443,7 @@ impl Rubber {
     pub fn publish_index<T: MimirObject>(
         &mut self,
         dataset: &str,
-        index: TypedIndex<T>
+        index: TypedIndex<T>,
     ) -> Result<(), String> {
         debug!("publishing index");
         let last_indexes = try!(self.get_last_index(&index, dataset));
@@ -587,9 +587,7 @@ impl Rubber {
         &mut self,
         dataset: &str,
     ) -> Result<Vec<Admin>, rs_es::error::EsError> {
-        self.get_all_objects_from_index(&get_main_type_and_dataset_index::<Admin>(
-            dataset,
-        ))
+        self.get_all_objects_from_index(&get_main_type_and_dataset_index::<Admin>(dataset))
     }
 
     pub fn get_all_admins(&mut self) -> Result<Vec<Admin>, rs_es::error::EsError> {

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -40,6 +40,7 @@ use rs_es::operations::search::ScanResult;
 use serde;
 use std;
 use std::collections::BTreeMap;
+use std::marker::PhantomData;
 use super::objects::{AliasOperation, AliasOperations, AliasParameter, Coord, Place};
 use rs_es::units::Duration;
 use rs_es::units as rs_u;
@@ -73,16 +74,30 @@ pub struct Rubber {
     http_client: hyper::client::Client,
 }
 
+pub struct TypedIndex<T> {
+    pub name: String,
+    _type: PhantomData<T>
+}
+
+impl<T> TypedIndex<T> {
+    pub fn new(name: String) -> TypedIndex<T> {
+        TypedIndex {
+            name: name,
+            _type: PhantomData
+        }
+    }
+}
+
 /// return the index associated to the given type and dataset
 /// this will be an alias over another real index
-pub fn get_main_type_and_dataset_index(doc_type: &str, dataset: &str) -> String {
-    format!("munin_{}_{}", doc_type, dataset)
+pub fn get_main_type_and_dataset_index<T: MimirObject>(dataset: &str) -> String {
+    format!("munin_{}_{}", T::doc_type(), dataset)
 }
 
 /// return the index associated to the given type
 /// this will be an alias over another real index
-pub fn get_main_type_index(doc_type: &str) -> String {
-    format!("munin_{}", doc_type)
+pub fn get_main_type_index<T: MimirObject>() -> String {
+    format!("munin_{}", T::doc_type())
 }
 
 pub fn get_date_index_name(base_index_name: &str) -> String {
@@ -265,11 +280,11 @@ impl Rubber {
         rs_es::do_req(result)
     }
 
-    pub fn make_index(&self, doc_type: &str, dataset: &str) -> Result<String, String> {
-        let index_name = get_date_index_name(&get_main_type_and_dataset_index(doc_type, dataset));
+    pub fn make_index<T: MimirObject>(&self, dataset: &str) -> Result<TypedIndex<T>, String> {
+        let index_name = get_date_index_name(&get_main_type_and_dataset_index::<T>(dataset));
         info!("creating index {}", index_name);
-        self.create_index(&index_name.to_string())
-            .map(|_| index_name)
+        self.create_index(&index_name.to_string())?;
+        Ok(TypedIndex::new(index_name))
     }
 
     pub fn create_index(&self, name: &String) -> Result<(), String> {
@@ -385,18 +400,17 @@ impl Rubber {
     // get the last indexes for this doc_type/dataset
     // Note: to be resilient to ghost ES indexes, we return all indexes for this doc_type/dataset
     // but the new index
-    fn get_last_index(
+    fn get_last_index<T: MimirObject>(
         &self,
-        new_index: &str,
-        doc_type: &str,
+        new_index: &TypedIndex<T>,
         dataset: &str,
     ) -> Result<Vec<String>, String> {
-        let base_index = get_main_type_and_dataset_index(doc_type, dataset);
+        let base_index = get_main_type_and_dataset_index::<T>(dataset);
         // we don't want to remove the newly created index
         Ok(self.get_all_aliased_index(&base_index)?
             .into_iter()
             .map(|(k, _)| k)
-            .filter(|i| i.as_str() != new_index)
+            .filter(|i| i.as_str() != new_index.name)
             .collect())
     }
 
@@ -426,23 +440,21 @@ impl Rubber {
     /// publish the index as the new index for this doc_type and this dataset
     /// move the index alias of the doc_type and the dataset to point to this indexes
     /// and remove the old index
-    pub fn publish_index(
+    pub fn publish_index<T: MimirObject>(
         &mut self,
-        doc_type: &str,
         dataset: &str,
-        index: String,
-        is_geo_data: bool,
+        index: TypedIndex<T>
     ) -> Result<(), String> {
         debug!("publishing index");
-        let last_indexes = try!(self.get_last_index(&index, doc_type, dataset));
+        let last_indexes = try!(self.get_last_index(&index, dataset));
 
-        let dataset_index = get_main_type_and_dataset_index(doc_type, dataset);
-        try!(self.alias(&dataset_index, &vec![index.clone()], &last_indexes,));
+        let dataset_index = get_main_type_and_dataset_index::<T>(dataset);
+        try!(self.alias(&dataset_index, &vec![index.name.clone()], &last_indexes,));
 
-        let type_index = get_main_type_index(doc_type);
+        let type_index = get_main_type_index::<T>();
         try!(self.alias(&type_index, &vec![dataset_index.clone()], &last_indexes,));
 
-        if is_geo_data {
+        if T::is_geo_data() {
             try!(self.alias("munin_geo_data", &vec![type_index.to_string()], &vec![],));
             try!(self.alias("munin", &vec!["munin_geo_data".to_string()], &vec![],));
         } else {
@@ -515,7 +527,7 @@ impl Rubber {
 
     pub fn bulk_index<T, I>(
         &mut self,
-        index: &String,
+        index: &TypedIndex<T>,
         iter: I,
     ) -> Result<usize, rs_es::error::EsError>
     where
@@ -541,7 +553,7 @@ impl Rubber {
             try!(
                 self.es_client
                     .bulk(&chunk)
-                    .with_index(&index)
+                    .with_index(&index.name)
                     .with_doc_type(T::doc_type())
                     .send()
             );
@@ -565,9 +577,9 @@ impl Rubber {
         I: Iterator<Item = T>,
     {
         // TODO better error handling
-        let index = try!(self.make_index(T::doc_type(), dataset));
-        let nb_elements = try!(self.bulk_index(&index, iter).map_err(|e| e.to_string()));
-        try!(self.publish_index(T::doc_type(), dataset, index, T::is_geo_data(),));
+        let index = self.make_index(dataset)?;
+        let nb_elements = self.bulk_index(&index, iter).map_err(|e| e.to_string())?;
+        self.publish_index::<T>(dataset, index)?;
         Ok(nb_elements)
     }
 
@@ -575,14 +587,13 @@ impl Rubber {
         &mut self,
         dataset: &str,
     ) -> Result<Vec<Admin>, rs_es::error::EsError> {
-        self.get_all_objects_from_index(&get_main_type_and_dataset_index(
-            Admin::doc_type(),
+        self.get_all_objects_from_index(&get_main_type_and_dataset_index::<Admin>(
             dataset,
         ))
     }
 
     pub fn get_all_admins(&mut self) -> Result<Vec<Admin>, rs_es::error::EsError> {
-        self.get_all_objects_from_index(&get_main_type_index(Admin::doc_type()))
+        self.get_all_objects_from_index(&get_main_type_index::<Admin>())
     }
 
     pub fn get_all_objects_from_index<T>(

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -164,9 +164,7 @@ where
             Ok(nb) => info!("importing {:?}: {} addresses added.", &f, nb),
         }
     }
-    rubber
-        .publish_index(dataset, addr_index)
-        .unwrap();
+    rubber.publish_index(dataset, addr_index).unwrap();
 }
 
 #[derive(StructOpt, Debug)]

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -42,7 +42,7 @@ extern crate structopt_derive;
 
 use std::path::Path;
 use mimir::rubber::Rubber;
-use mimir::objects::{Addr, Admin, MimirObject};
+use mimir::objects::{Addr, Admin};
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use std::fs;
 use std::rc::Rc;
@@ -146,7 +146,7 @@ where
         })
         .collect();
 
-    let addr_index = rubber.make_index(Addr::doc_type(), dataset).unwrap();
+    let addr_index = rubber.make_index::<Addr>(dataset).unwrap();
     info!("Add data in elasticsearch db.");
     for f in files {
         info!("importing {:?}...", &f);
@@ -165,7 +165,7 @@ where
         }
     }
     rubber
-        .publish_index(Addr::doc_type(), dataset, addr_index, Addr::is_geo_data())
+        .publish_index(dataset, addr_index)
         .unwrap();
 }
 

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -146,7 +146,7 @@ where
         })
         .collect();
 
-    let addr_index = rubber.make_index::<Addr>(dataset).unwrap();
+    let addr_index = rubber.make_index(dataset).unwrap();
     info!("Add data in elasticsearch db.");
     for f in files {
         info!("importing {:?}...", &f);

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -42,7 +42,7 @@ extern crate structopt_derive;
 
 use std::path::Path;
 use mimir::rubber::Rubber;
-use mimir::objects::{Addr, Admin};
+use mimir::objects::Admin;
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use std::fs;
 use std::rc::Rc;

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -134,9 +134,7 @@ where
             Ok(nb) => info!("importing {:?}: {} addresses added.", &f, nb),
         }
     }
-    rubber
-        .publish_index(dataset, addr_index)
-        .unwrap();
+    rubber.publish_index(dataset, addr_index).unwrap();
 }
 
 #[derive(StructOpt, Debug)]

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -116,7 +116,7 @@ where
         });
     let admins_geofinder = admins.into_iter().collect();
 
-    let addr_index = rubber.make_index::<Addr>(dataset).unwrap();
+    let addr_index = rubber.make_index(dataset).unwrap();
     info!("Add data in elasticsearch db.");
     for f in files {
         info!("importing {:?}...", &f);

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -42,7 +42,7 @@ extern crate structopt_derive;
 
 use std::path::Path;
 use mimir::rubber::Rubber;
-use mimir::objects::{Addr, MimirObject};
+use mimir::objects::Addr;
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use std::fs;
 use structopt::StructOpt;
@@ -116,7 +116,7 @@ where
         });
     let admins_geofinder = admins.into_iter().collect();
 
-    let addr_index = rubber.make_index(Addr::doc_type(), dataset).unwrap();
+    let addr_index = rubber.make_index::<Addr>(dataset).unwrap();
     info!("Add data in elasticsearch db.");
     for f in files {
         info!("importing {:?}...", &f);
@@ -135,7 +135,7 @@ where
         }
     }
     rubber
-        .publish_index(Addr::doc_type(), dataset, addr_index, Addr::is_geo_data())
+        .publish_index(dataset, addr_index)
         .unwrap();
 }
 

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -42,7 +42,6 @@ extern crate structopt_derive;
 
 use std::path::Path;
 use mimir::rubber::Rubber;
-use mimir::objects::Addr;
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use std::fs;
 use structopt::StructOpt;

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -29,9 +29,9 @@
 // www.navitia.io
 
 use std::rc::Rc;
-use mimir::rubber::Rubber;
+use mimir::rubber::{Rubber, TypedIndex};
 use utils::{format_label, get_zip_codes_from_admins};
-use mimir::{self, MimirObject};
+use mimir;
 use admin_geofinder::AdminGeoFinder;
 use std::collections::HashMap;
 use std::mem::replace;
@@ -147,9 +147,9 @@ fn update_global_stop_index<'a, It: Iterator<Item = &'a mimir::Stop>>(
     dataset: &str,
 ) -> Result<String, String> {
     let dataset_index =
-        mimir::rubber::get_main_type_and_dataset_index(mimir::Stop::doc_type(), dataset);
+        mimir::rubber::get_main_type_and_dataset_index::<mimir::Stop>(dataset);
     let stops_indexes = rubber
-        .get_all_aliased_index(&mimir::rubber::get_main_type_index(mimir::Stop::doc_type()))?
+        .get_all_aliased_index(&mimir::rubber::get_main_type_index::<mimir::Stop>())?
         .into_iter()
         .filter(|&(_, ref aliases)| !aliases.contains(&dataset_index))
         .map(|(index, _)| index);
@@ -167,14 +167,15 @@ fn update_global_stop_index<'a, It: Iterator<Item = &'a mimir::Stop>>(
     let es_index_name = mimir::rubber::get_date_index_name(GLOBAL_STOP_INDEX_NAME);
 
     rubber.create_index(&es_index_name)?;
+    let typed_index = TypedIndex::new(es_index_name);
 
     let nb_stops_added = rubber
-        .bulk_index(&es_index_name, all_merged_stops)
+        .bulk_index(&typed_index, all_merged_stops)
         .map_err(|e| e.to_string())?;
     info!("{} stops added in the global index", nb_stops_added);
     // create global index
     // fill structure for each stop indexes
-    Ok(es_index_name)
+    Ok(typed_index.name)
 }
 
 // publish the global stop index

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -146,8 +146,7 @@ fn update_global_stop_index<'a, It: Iterator<Item = &'a mimir::Stop>>(
     stops: It,
     dataset: &str,
 ) -> Result<String, String> {
-    let dataset_index =
-        mimir::rubber::get_main_type_and_dataset_index::<mimir::Stop>(dataset);
+    let dataset_index = mimir::rubber::get_main_type_and_dataset_index::<mimir::Stop>(dataset);
     let stops_indexes = rubber
         .get_all_aliased_index(&mimir::rubber::get_main_type_index::<mimir::Stop>())?
         .into_iter()

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -166,7 +166,7 @@ fn update_global_stop_index<'a, It: Iterator<Item = &'a mimir::Stop>>(
     let es_index_name = mimir::rubber::get_date_index_name(GLOBAL_STOP_INDEX_NAME);
 
     rubber.create_index(&es_index_name)?;
-    let typed_index = TypedIndex::new(es_index_name);
+    let typed_index = TypedIndex::new(es_index_name.clone());
 
     let nb_stops_added = rubber
         .bulk_index(&typed_index, all_merged_stops)
@@ -174,7 +174,7 @@ fn update_global_stop_index<'a, It: Iterator<Item = &'a mimir::Stop>>(
     info!("{} stops added in the global index", nb_stops_added);
     // create global index
     // fill structure for each stop indexes
-    Ok(typed_index.name)
+    Ok(es_index_name)
 }
 
 // publish the global stop index

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -31,7 +31,7 @@
 use serde_json::value::Value;
 use mimir::{Admin, Coord, MimirObject, Street};
 use mimir::AdminType::City;
-use mimir::rubber::Rubber;
+use mimir::rubber::{self, Rubber};
 use std;
 use std::cell::Cell;
 use hyper;
@@ -272,13 +272,13 @@ fn get_munin_indexes(es: &::ElasticSearchWrapper) -> Vec<String> {
     raw_indexes.keys().cloned().collect()
 }
 
-pub fn rubber_empty_bulk(mut es: ::ElasticSearchWrapper) {
+fn rubber_empty_bulk(mut es: ::ElasticSearchWrapper) {
     // we don't want an empty bulk to crash
     info!("running rubber_empty_bulk");
-    let dataset = "my_dataset";
+    let dataset = rubber::TypedIndex::<Admin>::new("my_dataset".into());
     // we index nothing
     let result = es.rubber
-        .bulk_index(&dataset.into(), std::iter::empty::<Admin>());
+        .bulk_index(&dataset, std::iter::empty::<Admin>());
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0); // we have indexed nothing, but it's ok
 }

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -272,7 +272,7 @@ fn get_munin_indexes(es: &::ElasticSearchWrapper) -> Vec<String> {
     raw_indexes.keys().cloned().collect()
 }
 
-fn rubber_empty_bulk(mut es: ::ElasticSearchWrapper) {
+pub fn rubber_empty_bulk(mut es: ::ElasticSearchWrapper) {
     // we don't want an empty bulk to crash
     info!("running rubber_empty_bulk");
     let dataset = rubber::TypedIndex::<Admin>::new("my_dataset".into());

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -277,8 +277,7 @@ fn rubber_empty_bulk(mut es: ::ElasticSearchWrapper) {
     info!("running rubber_empty_bulk");
     let dataset = rubber::TypedIndex::<Admin>::new("my_dataset".into());
     // we index nothing
-    let result = es.rubber
-        .bulk_index(&dataset, std::iter::empty::<Admin>());
+    let result = es.rubber.bulk_index(&dataset, std::iter::empty::<Admin>());
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0); // we have indexed nothing, but it's ok
 }


### PR DESCRIPTION
a common pattern while using Rubber is (the example is taken from `bano2mimir`):
```rust
let addr_index = rubber.make_index(Addr::doc_type(), dataset)?;
rubber.bulk_index(&addr_index, iter)?;
rubber.publish_index(Addr::doc_type(), dataset, addr_index, Addr::is_geo_data())?
```

it feels error prone to write it like this.

This PR add a `TypedIndex<T: MimirObject>` for more compil time check

The same code is now written
```rust
let addr_index = rubber.make_index(dataset)?; // <- since we bulk insert addresses, the compiler knows it's a TypedIndex<Addr>
rubber.bulk_index(&addr_index, iter)?;
rubber.publish_index(dataset, addr_index)?
```

with explicit types it is
```rust
let addr_index = rubber.make_index::<Addr>(dataset)?;
rubber.bulk_index::<Addr>(&addr_index, iter)?;
rubber.publish_index::<Addr>(dataset, addr_index)?
```



I think this has even more meaning since the next version of elastic search will be able to store only one type per index (as mimir does) [well the types are even prone to disapear](https://www.elastic.co/guide/en/elasticsearch/reference/6.x/removal-of-types.html)