### PR TITLE
rename street_name to name

### DIFF
--- a/json/addr_settings.json
+++ b/json/addr_settings.json
@@ -115,7 +115,7 @@
                 "street": {
                     "properties": {
                         "id": { "type": "string", "index": "no" },
-                        "street_name": { "type": "string" },
+                        "name": { "type": "string" },
                         "administrative_regions": {
                             "properties": {
                                 "id": { "type": "string", "index": "no" },

--- a/json/street_settings.json
+++ b/json/street_settings.json
@@ -51,7 +51,7 @@
         "street": {
             "properties": {
                 "id": { "type": "string", "index": "no" },
-                "street_name": { "type": "string" },
+                "name": { "type": "string" },
                 "zip_codes": {
                     "type": "string",
                     "index_options": "docs",

--- a/libs/bragi/src/api.rs
+++ b/libs/bragi/src/api.rs
@@ -33,7 +33,9 @@ use iron::typemap::Key;
 use mimir::rubber::Rubber;
 use model;
 use model::v1::*;
-use params::{coord_param, dataset_param, get_param_array, paginate_param, shape_param, types_param};
+use params::{
+    coord_param, dataset_param, get_param_array, paginate_param, shape_param, types_param,
+};
 use prometheus;
 use prometheus::Encoder;
 use rustless;

--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -192,7 +192,7 @@ fn get_citycode(admins: &Vec<Rc<mimir::Admin>>) -> Option<String> {
 impl From<mimir::Street> for GeocodingResponse {
     fn from(other: mimir::Street) -> GeocodingResponse {
         let type_ = "street".to_string();
-        let name = Some(other.street_name);
+        let name = Some(other.name);
         let label = Some(other.label);
         let admins = other.administrative_regions;
         let city = get_city_name(&admins);
@@ -223,11 +223,8 @@ impl From<mimir::Addr> for GeocodingResponse {
         let type_ = "house".to_string();
         let label = Some(other.label);
         let housenumber = Some(other.house_number.to_string());
-        let street_name = Some(other.street.street_name.to_string());
-        let name = Some(format!(
-            "{} {}",
-            other.house_number, other.street.street_name
-        ));
+        let street_name = Some(other.street.name.to_string());
+        let name = Some(format!("{} {}", other.house_number, other.street.name));
         let admins = other.street.administrative_regions;
         let city = get_city_name(&admins);
         let postcode = if other.zip_codes.is_empty() {

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -436,7 +436,11 @@ impl MimirObject for Admin {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Street {
     pub id: String,
-    pub street_name: String,
+    #[deprecated]
+    #[serde(default)]
+    pub street_name: String, // deprecated field only there for retrocompatibility, to remove once migration is complete
+    #[serde(default)]
+    pub name: String,
     pub administrative_regions: Vec<Rc<Admin>>,
     pub label: String,
     pub weight: f64,

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -103,7 +103,8 @@ impl Bano {
 
         let street = mimir::Street {
             id: street_id,
-            street_name: self.street,
+            street_name: self.street.clone(),
+            name: self.street,
             label: street_name.to_string(),
             administrative_regions: admins,
             weight: weight,

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -81,7 +81,8 @@ impl OpenAddresse {
 
         let street = mimir::Street {
             id: street_id,
-            street_name: self.street,
+            street_name: self.street.clone(),
+            name: self.street,
             label: street_name.to_string(),
             administrative_regions: admins,
             weight: weight,

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -99,6 +99,7 @@ pub fn streets(
                 ret ret(street_list.push(mimir::Street {
                     id: way.id.0.to_string(),
                     street_name: way_name.to_string(),
+                    name: way_name.to_string(),
                     label: format_label(&admin, way_name),
                     weight: 0.,
                     zip_codes: get_zip_codes_from_admins(&admin),
@@ -159,6 +160,7 @@ pub fn streets(
             ret ret(street_list.push(mimir::Street {
                 id: way.id.0.to_string(),
                 street_name: way_name.to_string(),
+                name: way_name.to_string(),
                 label: format_label(&admins, way_name),
                 weight: 0.,
                 zip_codes: get_zip_codes_from_admins(&admins),

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -53,7 +53,7 @@ fn check_has_bob(es: &::ElasticSearchWrapper) {
         );
         let es_bob = es_elt.pointer("/_source").unwrap();
         assert_eq!(es_bob.pointer("/id"), Some(&json!("bob")));
-        assert_eq!(es_bob.pointer("/street_name"), Some(&json!("bob's street")));
+        assert_eq!(es_bob.pointer("/name"), Some(&json!("bob's street")));
         assert_eq!(es_bob.pointer("/label"), Some(&json!("bob's name")));
         assert_eq!(es_bob.pointer("/weight"), Some(&json!(0.42)));
     };
@@ -70,6 +70,7 @@ pub fn rubber_zero_downtime_test(mut es: ::ElasticSearchWrapper) {
     let bob = Street {
         id: "bob".to_string(),
         street_name: "bob's street".to_string(),
+        name: "bob's street".to_string(),
         label: "bob's name".to_string(),
         administrative_regions: vec![],
         weight: 0.42,
@@ -90,6 +91,7 @@ pub fn rubber_zero_downtime_test(mut es: ::ElasticSearchWrapper) {
     let bobette = Street {
         id: "bobette".to_string(),
         street_name: "bobette's street".to_string(),
+        name: "bobette's street".to_string(),
         label: "bobette's name".to_string(),
         administrative_regions: vec![],
         weight: 0.24,
@@ -122,10 +124,7 @@ pub fn rubber_zero_downtime_test(mut es: ::ElasticSearchWrapper) {
         );
         let es_bob = es_elt.pointer("/_source").unwrap();
         assert_eq!(es_bob.pointer("/id"), Some(&json!("bobette")));
-        assert_eq!(
-            es_bob.pointer("/street_name"),
-            Some(&json!("bobette's street"))
-        );
+        assert_eq!(es_bob.pointer("/name"), Some(&json!("bobette's street")));
         assert_eq!(es_bob.pointer("/label"), Some(&json!("bobette's name")));
         assert_eq!(es_bob.pointer("/weight"), Some(&json!(0.24)));
 


### PR DESCRIPTION
fixes https://github.com/CanalTP/mimirsbrunn/issues/212

rename Street's `street_name` to `name`

since it's a breaking change, for the moment the fields are dupplicated,
and `street_name` is deprecated

Note: the `street_name` field has been removed from the mapping as we don't care how ES indexes it