### PR TITLE
fix city association

### DIFF
--- a/libs/bragi/src/api.rs
+++ b/libs/bragi/src/api.rs
@@ -33,7 +33,9 @@ use iron::typemap::Key;
 use mimir::rubber::Rubber;
 use model;
 use model::v1::*;
-use params::{coord_param, dataset_param, get_param_array, paginate_param, shape_param, types_param};
+use params::{
+    coord_param, dataset_param, get_param_array, paginate_param, shape_param, types_param,
+};
 use prometheus;
 use prometheus::Encoder;
 use rustless;

--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -171,21 +171,16 @@ fn get_admin_type(adm: &mimir::Admin) -> String {
 }
 
 fn get_city_name(admins: &Vec<Rc<mimir::Admin>>) -> Option<String> {
-    // for the moment for the 'postcode' and the 'city', we take first admin
-    // that has a postcode
-    // TODO: change this (with a 'city tag in the admin ?')
     admins
         .iter()
-        .find(|a| !a.zip_codes.is_empty())
-        .or_else(|| admins.iter().next())
+        .find(|a| a.is_city())
         .map(|admin| admin.name.clone())
 }
 
 fn get_citycode(admins: &Vec<Rc<mimir::Admin>>) -> Option<String> {
     admins
         .iter()
-        .find(|a| !a.zip_codes.is_empty())
-        .or_else(|| admins.iter().next())
+        .find(|a| a.is_city())
         .map(|admin| admin.insee.clone())
 }
 

--- a/tests/bragi_osm_test.rs
+++ b/tests/bragi_osm_test.rs
@@ -103,6 +103,7 @@ fn zip_code_street_test(bragi: &BragiHandler) {
     assert_eq!(boundary, None);
 
     assert_eq!(le_clos["type"], "street");
+    assert_eq!(le_clos["city"], "Livry-sur-Seine");
     assert_eq!(le_clos["citycode"], "77255");
 }
 


### PR DESCRIPTION
now that the cities are correctly tagged, we can associate the object
(field `city`/`citycode`) to a street and not to the first admins

in our dataset the `city` field of the `rue saint antoine` was associated to `Quartier de l'Arsenal`