### PR TITLE
better api status code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
 name = "bragi"
 version = "1.2.0"
 dependencies = [
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "git-version 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/libs/bragi/Cargo.toml
+++ b/libs/bragi/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = "1"
 prometheus = {version= "0.3", features = ["process"]}
 hyper = "0.10"
 heck = "0.3"
+failure = "0.1"
 
 [dependencies.logger]
 git = "https://github.com/iron/logger.git"

--- a/libs/bragi/src/api.rs
+++ b/libs/bragi/src/api.rs
@@ -29,8 +29,8 @@
 // www.navitia.io
 use super::query;
 use hyper::mime::Mime;
-use iron::typemap::Key;
 use iron::status::Status as IronStatus;
+use iron::typemap::Key;
 use mimir::rubber::Rubber;
 use model;
 use model::v1::*;
@@ -105,13 +105,13 @@ impl ApiEndPoint {
                     CustomError {
                         short: "validation error".to_string(),
                         long: format!("invalid arguments {:?}", val_err.reason),
-                        status: IronStatus::BadRequest
+                        status: IronStatus::BadRequest,
                     }
                 } else {
                     CustomError {
                         short: "bad_request".to_string(),
                         long: format!("bad request, error: {}", error),
-                        status: IronStatus::BadRequest
+                        status: IronStatus::BadRequest,
                     }
                 };
                 let mut resp = rustless::Response::from(
@@ -218,7 +218,8 @@ impl ApiEndPoint {
                         params.find("lat").and_then(|p| p.as_f64()).unwrap(),
                     );
                     let mut rubber = Rubber::new(&cnx);
-                    let model_autocomplete = rubber.get_address(&coord).map_err(model::BragiError::from);
+                    let model_autocomplete =
+                        rubber.get_address(&coord).map_err(model::BragiError::from);
 
                     let response = model::v1::AutocompleteResponse::from(model_autocomplete);
                     render(client, response)

--- a/libs/bragi/src/api.rs
+++ b/libs/bragi/src/api.rs
@@ -30,6 +30,7 @@
 use super::query;
 use hyper::mime::Mime;
 use iron::typemap::Key;
+use iron::status::Status as IronStatus;
 use mimir::rubber::Rubber;
 use model;
 use model::v1::*;
@@ -39,7 +40,7 @@ use params::{
 use prometheus;
 use prometheus::Encoder;
 use rustless;
-use rustless::server::{header, status};
+use rustless::server::header;
 use rustless::{Api, Nesting};
 use serde;
 use serde_json;
@@ -72,10 +73,11 @@ fn render<T>(
     obj: T,
 ) -> Result<rustless::Client, rustless::ErrorResponse>
 where
-    T: serde::Serialize,
+    T: serde::Serialize + model::v1::HasStatus,
 {
     client.set_json_content_type();
     client.set_header(header::AccessControlAllowOrigin::Any);
+    client.set_status(obj.status());
     client.text(serde_json::to_string(&obj).unwrap())
 }
 
@@ -103,15 +105,17 @@ impl ApiEndPoint {
                     CustomError {
                         short: "validation error".to_string(),
                         long: format!("invalid arguments {:?}", val_err.reason),
+                        status: IronStatus::BadRequest
                     }
                 } else {
                     CustomError {
                         short: "bad_request".to_string(),
                         long: format!("bad request, error: {}", error),
+                        status: IronStatus::BadRequest
                     }
                 };
                 let mut resp = rustless::Response::from(
-                    status::StatusCode::BadRequest,
+                    err.status,
                     Box::new(serde_json::to_string(&err).unwrap()),
                 );
                 resp.set_json_content_type();
@@ -214,7 +218,7 @@ impl ApiEndPoint {
                         params.find("lat").and_then(|p| p.as_f64()).unwrap(),
                     );
                     let mut rubber = Rubber::new(&cnx);
-                    let model_autocomplete = rubber.get_address(&coord);
+                    let model_autocomplete = rubber.get_address(&coord).map_err(model::BragiError::from);
 
                     let response = model::v1::AutocompleteResponse::from(model_autocomplete);
                     render(client, response)
@@ -232,16 +236,13 @@ impl ApiEndPoint {
                 });
 
                 let cnx = self.es_cnx_string.clone();
-                endpoint.handle(move |mut client, params| {
+                endpoint.handle(move |client, params| {
                     let id = params.find("id").unwrap().as_str().unwrap();
                     let pt_datasets = get_param_array(params, "pt_dataset");
                     let all_data = params
                         .find("_all_data")
                         .map_or(false, |val| val.as_bool().unwrap());
                     let features = query::features(&pt_datasets, all_data, &cnx, &id);
-                    if features.is_err() {
-                        client.set_status(status::StatusCode::NotFound);
-                    }
                     let response = model::v1::AutocompleteResponse::from(features);
                     render(client, response)
                 })

--- a/libs/bragi/src/lib.rs
+++ b/libs/bragi/src/lib.rs
@@ -51,6 +51,9 @@ extern crate slog;
 #[macro_use]
 extern crate slog_scope;
 
+#[macro_use]
+extern crate failure;
+
 use iron::prelude::Chain;
 use iron::Iron;
 use rustless::Application;

--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -32,8 +32,8 @@ use geo;
 use geojson;
 use heck::SnakeCase;
 use mimir;
-use std::rc::Rc;
 use rs_es::error::EsError;
+use std::rc::Rc;
 
 #[derive(Fail, Debug)]
 pub enum BragiError {
@@ -376,9 +376,9 @@ pub struct Coord {
 
 pub mod v1 {
     use super::BragiError;
+    use iron;
     use mimir;
     use rs_es;
-    use iron;
 
     pub trait HasStatus {
         fn status(&self) -> iron::status::Status;
@@ -451,7 +451,6 @@ pub mod v1 {
         }
     }
 
-
     impl From<Result<Vec<mimir::Place>, BragiError>> for AutocompleteResponse {
         fn from(r: Result<Vec<mimir::Place>, BragiError>) -> AutocompleteResponse {
             match r {
@@ -463,10 +462,12 @@ pub mod v1 {
                         BragiError::ObjectNotFound => iron::status::Status::NotFound,
                         BragiError::IndexNotFound => iron::status::Status::NotFound,
                         BragiError::Es(es_error) => match es_error {
-                            rs_es::error::EsError::HttpError(_) => iron::status::Status::ServiceUnavailable,
+                            rs_es::error::EsError::HttpError(_) => {
+                                iron::status::Status::ServiceUnavailable
+                            }
                             _ => iron::status::Status::InternalServerError,
-                        }
-                    }
+                        },
+                    },
                 }),
             }
         }

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -269,15 +269,15 @@ fn query(
         .ok();
 
     let result: SearchResult<serde_json::Value> = client
-            .search_query()
-            .with_indexes(&indexes
-                .iter()
-                .map(|index| index.as_str())
-                .collect::<Vec<&str>>())
-            .with_query(&query)
-            .with_from(offset)
-            .with_size(limit)
-            .send()?;
+        .search_query()
+        .with_indexes(&indexes
+            .iter()
+            .map(|index| index.as_str())
+            .collect::<Vec<&str>>())
+        .with_query(&query)
+        .with_from(offset)
+        .with_size(limit)
+        .send()?;
 
     timer.map(|t| t.observe_duration());
 

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -542,7 +542,10 @@ impl Coord {
         self.lat() == 0. && self.lon() == 0.
     }
     pub fn is_valid(&self) -> bool {
-        !self.is_default() && -90. <= self.lat() && self.lat() <= 90. && -180. <= self.lon()
+        !self.is_default()
+            && -90. <= self.lat()
+            && self.lat() <= 90.
+            && -180. <= self.lon()
             && self.lon() <= 180.
     }
 }
@@ -596,9 +599,11 @@ impl<'de> Deserialize<'de> for Coord {
             where
                 V: SeqAccess<'de>,
             {
-                let lon = seq.next_element()?
+                let lon = seq
+                    .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let lat = seq.next_element()?
+                let lat = seq
+                    .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(1, &self))?;
                 Ok(Coord::new(lon, lat))
             }

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -372,7 +372,8 @@ impl Rubber {
         &self,
         base_index: &str,
     ) -> Result<BTreeMap<String, Vec<String>>, Error> {
-        let res = self.get(&format!("{}*/_aliases", base_index))
+        let res = self
+            .get(&format!("{}*/_aliases", base_index))
             .with_context(|_| format!("Error occurred when getting {}*/_aliases", base_index))?;
         match res.status {
             StatusCode::Ok => {
@@ -412,7 +413,8 @@ impl Rubber {
     ) -> Result<Vec<String>, Error> {
         let base_index = get_main_type_and_dataset_index::<T>(dataset);
         // we don't want to remove the newly created index
-        Ok(self.get_all_aliased_index(&base_index)?
+        Ok(self
+            .get_all_aliased_index(&base_index)?
             .into_iter()
             .map(|(k, _)| k)
             .filter(|i| i.as_str() != new_index.name)
@@ -430,7 +432,8 @@ impl Rubber {
             .with_must(geo_distance)
             .build();
 
-        let result: SearchResult<serde_json::Value> = self.es_client
+        let result: SearchResult<serde_json::Value> = self
+            .es_client
             .search_query()
             .with_indexes(&indexes
                 .iter()
@@ -508,7 +511,8 @@ impl Rubber {
             actions: add_operations.chain(remove_operations).collect(),
         };
         let json = serde_json::to_string(&operations)?;
-        let res = self.post("_aliases", &json)
+        let res = self
+            .post("_aliases", &json)
             .context("Error occurred when POSTing: _alias")?;
         match res.status {
             StatusCode::Ok => Ok(()),
@@ -518,7 +522,8 @@ impl Rubber {
 
     pub fn delete_index(&mut self, index: &String) -> Result<(), Error> {
         debug!("deleting index {}", &index);
-        let res = self.es_client
+        let res = self
+            .es_client
             .delete_index(&index)
             .map(|res| res.acknowledged)
             .unwrap_or(false);
@@ -581,7 +586,8 @@ impl Rubber {
         I: Iterator<Item = T>,
     {
         // TODO better error handling
-        let index = self.make_index(dataset)
+        let index = self
+            .make_index(dataset)
             .with_context(|_| format!("Error occurred when making index: {}", dataset))?;
         let nb_elements = self.bulk_index(&index, iter)?;
         self.publish_index(dataset, index)?;
@@ -607,7 +613,8 @@ impl Rubber {
         for<'de> T: MimirObject + serde::de::Deserialize<'de> + std::fmt::Debug,
     {
         let mut result: Vec<T> = vec![];
-        let mut scan: ScanResult<T> = self.es_client
+        let mut scan: ScanResult<T> = self
+            .es_client
             .search_query()
             .with_indexes(&[&index])
             .with_size(1000)

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -106,7 +106,8 @@ impl AdminGeoFinder {
 
     /// Iterates on all the admins with a not None boundary.
     pub fn admins<'a>(&'a self) -> Box<Iterator<Item = Admin> + 'a> {
-        let iter = self.admins
+        let iter = self
+            .admins
             .get(&Rect::from_float(
                 std::f32::NEG_INFINITY,
                 std::f32::INFINITY,
@@ -124,7 +125,8 @@ impl AdminGeoFinder {
 
     /// Iterates on all the `Rc<Admin>` in the structure as returned by `get`.
     pub fn admins_without_boundary<'a>(&'a self) -> Box<Iterator<Item = Rc<Admin>> + 'a> {
-        let iter = self.admins
+        let iter = self
+            .admins
             .get(&Rect::from_float(
                 std::f32::NEG_INFINITY,
                 std::f32::INFINITY,

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -109,7 +109,9 @@ impl GtfsStop {
             Err(StopConversionErr::NotStopArea)
         } else if self.visible == Some(0) {
             Err(StopConversionErr::InvisibleStop)
-        } else if self.stop_lat <= MIN_LAT || self.stop_lat >= MAX_LAT || self.stop_lon <= MIN_LON
+        } else if self.stop_lat <= MIN_LAT
+            || self.stop_lat >= MAX_LAT
+            || self.stop_lon <= MIN_LON
             || self.stop_lon >= MAX_LON
         {
             //Here we return an error message
@@ -158,7 +160,8 @@ fn run(args: Args) -> Result<(), failure::Error> {
 
     let mut rdr = csv::Reader::from_path(&args.input)?;
     let mut nb_stop_points = HashMap::new();
-    let mut stops: Vec<mimir::Stop> = rdr.deserialize()
+    let mut stops: Vec<mimir::Stop> = rdr
+        .deserialize()
         .filter_map(|rc| rc.map_err(|e| warn!("skip csv line: {}", e)).ok())
         .filter_map(|stop: GtfsStop| {
             stop.incr_stop_point(&mut nb_stop_points);
@@ -181,7 +184,8 @@ fn test_load_stops() {
     let mut rdr = csv::Reader::from_path("./tests/fixtures/stops.txt".to_string()).unwrap();
 
     let mut nb_stop_points = HashMap::new();
-    let stops: Vec<mimir::Stop> = rdr.deserialize()
+    let stops: Vec<mimir::Stop> = rdr
+        .deserialize()
         .filter_map(Result::ok)
         .filter_map(|stop: GtfsStop| {
             stop.incr_stop_point(&mut nb_stop_points);

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -200,7 +200,8 @@ pub fn format_zip_codes(zip_codes: &[String]) -> String {
 }
 
 pub fn read_zip_codes(tags: &osmpbfreader::Tags) -> Vec<String> {
-    let zip_code = tags.get("addr:postcode")
+    let zip_code = tags
+        .get("addr:postcode")
         .or_else(|| tags.get("postal_code"))
         .map_or("", |val| &val[..]);
     zip_code

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -63,14 +63,16 @@ pub fn streets(
                 way.tags.get("highway").map_or(false, |v| !v.is_empty())
                     && way.tags.get("name").map_or(false, |v| !v.is_empty())
             }
-            osmpbfreader::OsmObj::Relation(ref rel) => rel.tags
+            osmpbfreader::OsmObj::Relation(ref rel) => rel
+                .tags
                 .get("type")
                 .map_or(false, |v| v == "associatedStreet"),
             _ => false,
         }
     }
     info!("reading pbf...");
-    let objs_map = pbf.get_objs_and_deps(is_valid_obj)
+    let objs_map = pbf
+        .get_objs_and_deps(is_valid_obj)
         .context("Error occurred when reading pbf")?;
     info!("reading pbf done.");
     let mut street_rel: StreetWithRelationSet = BTreeSet::new();

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -126,7 +126,8 @@ fn attach_stops_to_admins<'a, It: Iterator<Item = &'a mut mimir::Stop>>(
 fn merge_collection<T: Ord>(target: &mut Vec<T>, source: Vec<T>) {
     use std::collections::BTreeSet;
     let tmp = replace(target, vec![]);
-    *target = tmp.into_iter()
+    *target = tmp
+        .into_iter()
         .chain(source)
         .collect::<BTreeSet<_>>()
         .into_iter()

--- a/tests/bragi_filter_types_test.rs
+++ b/tests/bragi_filter_types_test.rs
@@ -223,3 +223,15 @@ fn stop_area_that_does_not_exists(bragi: &BragiHandler) {
     let result_body = iron_test::response::extract_body_to_string(response);
     assert!(result_body.contains("Unable to find object"));
 }
+
+fn stop_area_invalid_index(bragi: &BragiHandler) {
+    // if the index does not exists, we get a 404 with "impossible to find object"
+    let response = bragi
+        .raw_get("/features/stop_area:SA:second_station::AA?pt_dataset=invalid_dataset")
+        .unwrap();
+
+    assert_eq!(response.status, Some(NotFound));
+
+    let result_body = iron_test::response::extract_body_to_string(response);
+    assert!(result_body.contains("Impossible to find object"));
+}

--- a/tests/bragi_poi_test.rs
+++ b/tests/bragi_poi_test.rs
@@ -90,7 +90,8 @@ fn poi_admin_address_test(bragi: &BragiHandler) {
 
     // the first element returned should be the poi 'Le-Mée-sur-Seine Courtilleraies'
     let poi = geocodings.first().unwrap();
-    let properties = poi.get("properties")
+    let properties = poi
+        .get("properties")
         .and_then(|json| json.as_array())
         .unwrap();
     let keys = [

--- a/tests/bragi_stops_test.rs
+++ b/tests/bragi_stops_test.rs
@@ -116,7 +116,8 @@ fn stop_attached_to_admin_test(bragi: &BragiHandler) {
     // this stop area is in the boundary of the admin 'Vaux-le-Pénil',
     // it should have been associated to it
     assert_eq!(get_value(stop, "city"), "Vaux-le-Pénil");
-    let admins = stop.get("administrative_regions")
+    let admins = stop
+        .get("administrative_regions")
         .and_then(|a| a.as_array());
     assert_eq!(admins.map(|a| a.len()).unwrap_or(0), 1);
 }
@@ -133,7 +134,8 @@ fn stop_no_admin_test(bragi: &BragiHandler) {
     assert_eq!(get_value(stop, "name"), "Far west station");
     assert_eq!(get_value(stop, "id"), "stop_area:SA:station_no_city");
     assert_eq!(get_value(stop, "city"), "");
-    let admins = stop.get("administrative_regions")
+    let admins = stop
+        .get("administrative_regions")
         .and_then(|a| a.as_array());
     assert_eq!(admins.map(|a| a.len()).unwrap_or(0), 0);
 }

--- a/tests/canonical_import_process_test.rs
+++ b/tests/canonical_import_process_test.rs
@@ -30,6 +30,7 @@
 
 extern crate mimir;
 extern crate serde_json;
+extern crate iron;
 use super::count_types;
 use super::get_poi_type_ids;
 use super::get_types;
@@ -148,4 +149,16 @@ fn melun_test(bragi: &BragiHandler) {
     assert_eq!(poi_addr["street"], "Rue de la Reine Blanche");
     assert_eq!(poi_addr["postcode"], "77288");
     assert_eq!(poi_addr["city"], "Melun");
+}
+
+pub fn bragi_invalid_es_test(es_wrapper: ::ElasticSearchWrapper) {
+    let bragi = BragiHandler::new(format!("http://invalid_es_url/munin"));
+
+    // the status does not check the ES connexion, so for the status all is good
+    let resp = bragi.raw_get("/status").unwrap();
+    assert_eq!(resp.status, Some(iron::status::Status::Ok));
+
+    // the autocomplete gives a 503
+    let resp = bragi.raw_get("/autocomplete?q=toto").unwrap();
+    assert_eq!(resp.status, Some(iron::status::Status::ServiceUnavailable));
 }

--- a/tests/canonical_import_process_test.rs
+++ b/tests/canonical_import_process_test.rs
@@ -28,9 +28,9 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
+extern crate iron;
 extern crate mimir;
 extern crate serde_json;
-extern crate iron;
 use super::count_types;
 use super::get_poi_type_ids;
 use super::get_types;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -369,4 +369,5 @@ fn all_tests() {
     canonical_import_process_test::canonical_import_process_test(ElasticSearchWrapper::new(
         &docker_wrapper,
     ));
+    canonical_import_process_test::bragi_invalid_es_test(ElasticSearchWrapper::new(&docker_wrapper));
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -125,7 +125,8 @@ impl<'a> ElasticSearchWrapper<'a> {
     /// simple search on an index
     /// assert that the result is OK and transform it to a json Value
     pub fn search(&self, word: &str) -> serde_json::Value {
-        let res = self.rubber
+        let res = self
+            .rubber
             .get(&format!("munin/_search?q={}", word))
             .unwrap();
         assert!(res.status == hyper::Ok);
@@ -133,7 +134,8 @@ impl<'a> ElasticSearchWrapper<'a> {
     }
 
     pub fn search_on_global_stop_index(&self, word: &str) -> serde_json::Value {
-        let res = self.rubber
+        let res = self
+            .rubber
             .get(&format!("munin_global_stops/_search?q={}", word))
             .unwrap();
         assert!(res.status == hyper::Ok);
@@ -199,7 +201,8 @@ impl<'a> ElasticSearchWrapper<'a> {
                             v.into_iter()
                                 .filter_map(|json| {
                                     into_object(json).and_then(|obj| {
-                                        let doc_type = obj.get("_type")
+                                        let doc_type = obj
+                                            .get("_type")
                                             .and_then(|doc_type| doc_type.as_str())
                                             .map(|doc_type| doc_type.into());
 
@@ -369,5 +372,7 @@ fn all_tests() {
     canonical_import_process_test::canonical_import_process_test(ElasticSearchWrapper::new(
         &docker_wrapper,
     ));
-    canonical_import_process_test::bragi_invalid_es_test(ElasticSearchWrapper::new(&docker_wrapper));
+    canonical_import_process_test::bragi_invalid_es_test(ElasticSearchWrapper::new(
+        &docker_wrapper,
+    ));
 }


### PR DESCRIPTION
before the could get `200` response with an error message.

Use `Failure` in bragi to get better error.

we now have:

for `/autocomplete`:
no es => ServiceUnavailable (503)
other error => InternalError (500)

`/features`
no object => NotFound 404
no index (invalid `pt_dataset` parameter) => NotFound 404 (different
message)
no es => ServiceUnavailable (503)
other error => InternalError (500)

`/status` => always 200 if bragi is up

Warming this is a breaking change !
but I think it's cleaner and I don't know of integration that this might
break. the only other solution I see is to do another api version but
that seems a bit overkill

related to https://github.com/CanalTP/mimirsbrunn/issues/179