### PR TITLE
Address must have street name

### DIFF
--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -270,10 +270,12 @@ fn query(
 
     let result: SearchResult<serde_json::Value> = client
         .search_query()
-        .with_indexes(&indexes
-            .iter()
-            .map(|index| index.as_str())
-            .collect::<Vec<&str>>())
+        .with_indexes(
+            &indexes
+                .iter()
+                .map(|index| index.as_str())
+                .collect::<Vec<&str>>(),
+        )
         .with_query(&query)
         .with_from(offset)
         .with_size(limit)
@@ -315,10 +317,12 @@ pub fn features(
     let result: SearchResult<serde_json::Value> = try!(
         client
             .search_query()
-            .with_indexes(&indexes
-                .iter()
-                .map(|index| index.as_str())
-                .collect::<Vec<&str>>())
+            .with_indexes(
+                &indexes
+                    .iter()
+                    .map(|index| index.as_str())
+                    .collect::<Vec<&str>>()
+            )
             .with_query(&query)
             .send()
     );

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -437,10 +437,12 @@ impl Rubber {
         let result: SearchResult<serde_json::Value> = self
             .es_client
             .search_query()
-            .with_indexes(&indexes
-                .iter()
-                .map(|index| index.as_str())
-                .collect::<Vec<_>>())
+            .with_indexes(
+                &indexes
+                    .iter()
+                    .map(|index| index.as_str())
+                    .collect::<Vec<_>>(),
+            )
             .with_query(&query)
             .with_size(1)
             .send()?;

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -156,13 +156,14 @@ where
         info!("importing {:?}...", &f);
         let mut rdr = csv::ReaderBuilder::new().has_headers(false).from_path(&f)?;
 
-        let iter = rdr.deserialize().filter_map(|r| {
-            r.map_err(|e| info!("impossible to read line, error: {}", e))
-                .ok()
-                .map(|b: Bano|
-                    b.into_addr(&admins_by_insee, &admins_geofinder)
-                )
-        }).filter(|a| !a.street.street_name.is_empty());
+        let iter = rdr
+            .deserialize()
+            .filter_map(|r| {
+                r.map_err(|e| info!("impossible to read line, error: {}", e))
+                    .ok()
+                    .map(|b: Bano| b.into_addr(&admins_by_insee, &admins_geofinder))
+            })
+            .filter(|a| !a.street.street_name.is_empty());
         let nb = rubber
             .bulk_index(&addr_index, iter)
             .with_context(|_| format!("failed to bulk insert file {:?}", &f))?;

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -43,9 +43,9 @@ extern crate slog_scope;
 extern crate structopt;
 
 use failure::ResultExt;
-use mimir::MimirObject;
 use mimir::objects::Admin;
 use mimir::rubber::Rubber;
+use mimir::MimirObject;
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use std::collections::BTreeMap;
 use std::fs;
@@ -165,18 +165,17 @@ where
             })
             .filter(|a| {
                 !a.street.street_name.is_empty() || {
-                    info!("Address {}:{:?}:{:?} has no street name and has been ignored.", a.id, a.coord, a.street);
+                    info!(
+                        "Address {}:{:?}:{:?} has no street name and has been ignored.",
+                        a.id, a.coord, a.street
+                    );
                     false
                 }
             });
         let nb = rubber
             .bulk_index(&addr_index, iter)
             .with_context(|_| format!("failed to bulk insert file {:?}", &f))?;
-        info!(
-            "importing {:?}: {} addresses added.",
-            &f,
-            nb
-        );
+        info!("importing {:?}: {} addresses added.", &f, nb);
     }
     rubber
         .publish_index(dataset, addr_index)

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -156,10 +156,13 @@ where
         info!("importing {:?}...", &f);
         let mut rdr = csv::ReaderBuilder::new().has_headers(false).from_path(&f)?;
 
-        let iter = rdr.deserialize().map(|r| {
-            let b: Bano = r.unwrap();
-            b.into_addr(&admins_by_insee, &admins_geofinder)
-        });
+        let iter = rdr.deserialize().filter_map(|r| {
+            r.map_err(|e| info!("impossible to read line, error: {}", e))
+                .ok()
+                .map(|b: Bano|
+                    b.into_addr(&admins_by_insee, &admins_geofinder)
+                )
+        }).filter(|a| !a.street.street_name.is_empty());
         let nb = rubber
             .bulk_index(&addr_index, iter)
             .with_context(|_| format!("failed to bulk insert file {:?}", &f))?;

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -124,11 +124,14 @@ where
     for f in files {
         info!("importing {:?}...", &f);
         let mut rdr = csv::ReaderBuilder::new().has_headers(true).from_path(&f)?;
-        let iter = rdr.deserialize().filter_map(|r| {
-            r.map_err(|e| info!("impossible to read line, error: {}", e))
-                .ok()
-                .map(|v: OpenAddresse| v.into_addr(&admins_geofinder))
-        }).filter(|a| !a.street.street_name.is_empty());
+        let iter = rdr
+            .deserialize()
+            .filter_map(|r| {
+                r.map_err(|e| info!("impossible to read line, error: {}", e))
+                    .ok()
+                    .map(|v: OpenAddresse| v.into_addr(&admins_geofinder))
+            })
+            .filter(|a| !a.street.street_name.is_empty());
         let nb = rubber
             .bulk_index(&addr_index, iter)
             .with_context(|_| format!("failed to bulk insert file {:?}", &f))?;

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -128,7 +128,7 @@ where
             r.map_err(|e| info!("impossible to read line, error: {}", e))
                 .ok()
                 .map(|v: OpenAddresse| v.into_addr(&admins_geofinder))
-        });
+        }).filter(|a| !a.street.street_name.is_empty());
         let nb = rubber
             .bulk_index(&addr_index, iter)
             .with_context(|_| format!("failed to bulk insert file {:?}", &f))?;

--- a/tests/bano2mimir_test.rs
+++ b/tests/bano2mimir_test.rs
@@ -34,7 +34,7 @@ use hyper::client::Client;
 use mdo::option::{bind, ret};
 
 /// Returns the total number of results in the ES
-fn get_total(es_wrapper: &::ElasticSearchWrapper) -> u64 {
+fn get_nb_elements(es_wrapper: &::ElasticSearchWrapper) -> u64 {
     let json = es_wrapper.search("*.*");
     json["hits"]["total"].as_u64().unwrap()
 }
@@ -120,7 +120,7 @@ pub fn bano2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
 
     // we should have imported 32 elements
     // (we shouldn't have the badly formated line)
-    let total = get_total(&es_wrapper);
+    let total = get_nb_elements(&es_wrapper);
     assert_eq!(total, 32);
 
     // We look for 'Fake-City' which should have been filtered since the street name is empty

--- a/tests/bano2mimir_test.rs
+++ b/tests/bano2mimir_test.rs
@@ -124,6 +124,8 @@ pub fn bano2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
     assert_eq!(total, 32);
 
     // We look for 'Fake-City' which should have been filtered since the street name is empty
-    let res: Vec<_> = es_wrapper.search_and_filter("Fake-City", |_| true).collect();
+    let res: Vec<_> = es_wrapper
+        .search_and_filter("Fake-City", |_| true)
+        .collect();
     assert_eq!(res.len(), 0);
 }

--- a/tests/bano2mimir_test.rs
+++ b/tests/bano2mimir_test.rs
@@ -33,6 +33,12 @@ use hyper;
 use hyper::client::Client;
 use mdo::option::{bind, ret};
 
+/// Returns the total number of results in the ES
+fn get_total(es_wrapper: &::ElasticSearchWrapper) -> u64 {
+    let json = es_wrapper.search("*.*");
+    json["hits"]["total"].as_u64().unwrap()
+}
+
 /// Simple call to a BANO load into ES base
 /// Checks that we are able to find one object (a specific address)
 pub fn bano2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
@@ -111,4 +117,13 @@ pub fn bano2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
         aliases,
         vec!["munin", "munin_addr", "munin_addr_fr", "munin_geo_data"]
     );
+
+    // we should have imported 32 elements
+    // (we shouldn't have the badly formated line)
+    let total = get_total(&es_wrapper);
+    assert_eq!(total, 32);
+
+    // We look for 'Fake-City' which should have been filtered since the street name is empty
+    let res: Vec<_> = es_wrapper.search_and_filter("Fake-City", |_| true).collect();
+    assert_eq!(res.len(), 0);
 }

--- a/tests/fixtures/sample-bano.csv
+++ b/tests/fixtures/sample-bano.csv
@@ -30,5 +30,5 @@
 751124517P-8Z,8Z,Rue Hector Malot,75012,Paris,O+O,48.845692,2.375752
 751124517P-9,9,Rue Hector Malot,75012,Paris,OSM,48.845801,2.375630
 420424517P-20,20,Rue Hector Malot,42042,Trifouilli-les-Oies,OSM,50.0,2.0
-420424517P-20,20,,42042,Fake-City,OSM,50.0,2.0
+777777777Z-77,77,,77042,Fake-City,OSM,50.0,2.0
 ,,,,,,,,,badly_formated_line,

--- a/tests/fixtures/sample-bano.csv
+++ b/tests/fixtures/sample-bano.csv
@@ -30,3 +30,5 @@
 751124517P-8Z,8Z,Rue Hector Malot,75012,Paris,O+O,48.845692,2.375752
 751124517P-9,9,Rue Hector Malot,75012,Paris,OSM,48.845801,2.375630
 420424517P-20,20,Rue Hector Malot,42042,Trifouilli-les-Oies,OSM,50.0,2.0
+420424517P-20,20,,42042,Fake-City,OSM,50.0,2.0
+,,,,,,,,,badly_formated_line,

--- a/tests/fixtures/sample-oa.csv
+++ b/tests/fixtures/sample-oa.csv
@@ -9,4 +9,5 @@ LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH
 13.3897137,52.5186699,35,Dorotheenstraße,,Berlin,,,10117,,025c011f388aa2b2
 13.3894677,52.5186535,37,Dorotheenstraße,,Berlin,,,10117,,d76a05fc52856e17
 13.3894677,52.518658,42,Dorotheenstraße,,Berlin,,,10117,line_without_hash_should_work,
+13.3894677,52.518658,42,,,Fake-City,,,10117,line_without_hash_should_work,
 ,,,,,,,,,badly_formated_line,

--- a/tests/openaddresses2mimir_test.rs
+++ b/tests/openaddresses2mimir_test.rs
@@ -118,4 +118,8 @@ pub fn oa2mimir_simple_test(es_wrapper: ::ElasticSearchWrapper) {
     // (we should have the one without hash, but not the badly formated line)
     let res: Vec<_> = es_wrapper.search_and_filter("*.*", |_| true).collect();
     assert_eq!(res.len(), 10);
+
+    // We look for 'Fake-City' which should have been filtered since the street name is empty
+    let res: Vec<_> = es_wrapper.search_and_filter("Fake-City", |_| true).collect();
+    assert_eq!(res.len(), 0);
 }

--- a/tests/openaddresses2mimir_test.rs
+++ b/tests/openaddresses2mimir_test.rs
@@ -120,6 +120,8 @@ pub fn oa2mimir_simple_test(es_wrapper: ::ElasticSearchWrapper) {
     assert_eq!(res.len(), 10);
 
     // We look for 'Fake-City' which should have been filtered since the street name is empty
-    let res: Vec<_> = es_wrapper.search_and_filter("Fake-City", |_| true).collect();
+    let res: Vec<_> = es_wrapper
+        .search_and_filter("Fake-City", |_| true)
+        .collect();
     assert_eq!(res.len(), 0);
 }


### PR DESCRIPTION
Some addresses have a void street.name field.
They shouldn't be imported since they decrease the reverse geocoding quality and furthermore are not 'searchable' in the autocomplete.

This PR filters these addresses + adds the corresponding tests.

PS: commit 4998fcd32ddfd95269d25f1eb06f6658bc3b5bc0 fails the `cargo fmt --all -- --check` so I format it the correct way