### PR TITLE
change the weight mechanism

### DIFF
--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -270,10 +270,12 @@ fn query(
 
     let result: SearchResult<serde_json::Value> = client
         .search_query()
-        .with_indexes(&indexes
-            .iter()
-            .map(|index| index.as_str())
-            .collect::<Vec<&str>>())
+        .with_indexes(
+            &indexes
+                .iter()
+                .map(|index| index.as_str())
+                .collect::<Vec<&str>>(),
+        )
         .with_query(&query)
         .with_from(offset)
         .with_size(limit)
@@ -315,10 +317,12 @@ pub fn features(
     let result: SearchResult<serde_json::Value> = try!(
         client
             .search_query()
-            .with_indexes(&indexes
-                .iter()
-                .map(|index| index.as_str())
-                .collect::<Vec<&str>>())
+            .with_indexes(
+                &indexes
+                    .iter()
+                    .map(|index| index.as_str())
+                    .collect::<Vec<&str>>()
+            )
             .with_query(&query)
             .send()
     );

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -437,10 +437,12 @@ impl Rubber {
         let result: SearchResult<serde_json::Value> = self
             .es_client
             .search_query()
-            .with_indexes(&indexes
-                .iter()
-                .map(|index| index.as_str())
-                .collect::<Vec<_>>())
+            .with_indexes(
+                &indexes
+                    .iter()
+                    .map(|index| index.as_str())
+                    .collect::<Vec<_>>(),
+            )
             .with_query(&query)
             .with_size(1)
             .send()?;

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -102,7 +102,6 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         let mut streets = streets(&mut osm_reader, &admins_geofinder)?;
 
         info!("computing city weight");
-        compute_admin_weight(&mut streets, &admins_geofinder);
 
         info!("computing street weight");
         compute_street_weight(&mut streets);

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -146,6 +146,20 @@ pub fn read_administrative_regions(
             } else {
                 mimir::AdminType::Unknown
             };
+
+            let weight = relation
+                .tags
+                .get("population")
+                .or(relation
+                    .refs
+                    .iter()
+                    .find(|r| r.role == "admin_centre")
+                    .and_then(|r| objects.get(&r.member))
+                    .and_then(|o| o.node())
+                    .and_then(|node| node.tags.get("population")))
+                .and_then(|p| p.parse().ok())
+                .unwrap_or(0.);
+
             let admin = mimir::Admin {
                 id: admin_id,
                 insee: insee_id.to_string(),
@@ -153,7 +167,7 @@ pub fn read_administrative_regions(
                 name: name.to_string(),
                 label: format!("{}{}", name.to_string(), format_zip_codes(&zip_codes)),
                 zip_codes: zip_codes,
-                weight: Cell::new(0.),
+                weight: Cell::new(weight),
                 coord: coord_center.unwrap_or_else(|| make_centroid(&boundary)),
                 boundary: boundary,
                 admin_type: admin_type,
@@ -162,6 +176,9 @@ pub fn read_administrative_regions(
             administrative_regions.push(admin);
         }
     }
+
+    compute_admin_weight(&mut administrative_regions);
+
     administrative_regions
 }
 
@@ -173,17 +190,10 @@ fn get_zone_type(level: u32, city_lvl: u32) -> Option<ZoneType> {
     }
 }
 
-pub fn compute_admin_weight(streets: &StreetsVec, admins_geofinder: &AdminGeoFinder) {
-    let mut max = 1.;
-    for st in streets {
-        for admin in &st.administrative_regions {
-            admin.weight.set(admin.weight.get() + 1.);
-            max = f64::max(max, admin.weight.get());
-        }
-    }
-
-    for admin in admins_geofinder.admins_without_boundary() {
-        admin.weight.set(admin.weight.get() / max);
+pub fn compute_admin_weight(admins: &mut [mimir::Admin]) {
+    let max = admins.iter().fold(1f64, |m, a| f64::max(m, a.weight.get()));
+    for ref mut a in admins {
+        a.weight.set(a.weight.get() / max);
     }
 }
 

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -150,14 +150,17 @@ pub fn read_administrative_regions(
             let weight = relation
                 .tags
                 .get("population")
-                .or(relation
-                    .refs
-                    .iter()
-                    .find(|r| r.role == "admin_centre")
-                    .and_then(|r| objects.get(&r.member))
-                    .and_then(|o| o.node())
-                    .and_then(|node| node.tags.get("population")))
                 .and_then(|p| p.parse().ok())
+                .or_else(|| {
+                    let rel = relation.refs.iter().find(|r| r.role == "admin_centre")?;
+                    objects
+                        .get(&rel.member)?
+                        .node()?
+                        .tags
+                        .get("population")?
+                        .parse()
+                        .ok()
+                })
                 .unwrap_or(0.);
 
             let admin = mimir::Admin {


### PR DESCRIPTION
now the weight is only the population of an admin, not the number of street in it.

This will clean the model by removing the uggly need for the `weight` to be a Cell (or the even complex `Weight` of the PR #224 

the results seems affected, but only a bit (at lest in france where the `population` tag is well filled)

geocoder results (run by [this script](https://github.com/antoine-de/geocoder-tester/blob/af68e546e1a05bf5feb29f62cb77c3b5ed681dd9/run_qwant.sh)):
`results_master_ctp` is the current master filled with osm for admin, streets and poi, and bano for addresses
`results_master_ctp_pop_weight_clean` is this PR with the same data

```diff
--- a/results_master_ctp/run.log
+++ b/results_master_ctp_pop_weight_clean/run.log
@@ -1,13 +1,13 @@
-testing master_ctp on http://10.100.31.91:4444/autocomplete
+testing master_ctp_pop_weight_clean on http://10.100.31.91:4444/autocomplete
 running test france_autre
-summary for france_autre ==== 1630 failed, 9386 passed, 1 skipped, 1066 deselected in 823.38 seconds ====
+summary for france_autre ==== 1643 failed, 9373 passed, 1 skipped, 1066 deselected in 626.05 seconds ====
 ++++++++++ result france_autre: 85% (/) (/11016)
 running test france_fautes
-summary for france_fautes ========== 196 failed, 756 passed, 11131 deselected in 155.50 seconds ==========
+summary for france_fautes ========== 196 failed, 756 passed, 11131 deselected in 133.80 seconds ==========
 ++++++++++ result france_fautes: 79% (/) (/952)
 running test france_admins
-summary for france_admins ============ 12 failed, 38 passed, 12033 deselected in 5.55 seconds ============
+summary for france_admins ============ 12 failed, 38 passed, 12033 deselected in 4.01 seconds ============
 ++++++++++ result france_admins: 76% (/) (/50)
 running test france_poi
-summary for france_poi =========== 49 failed, 15 passed, 12019 deselected in 10.65 seconds ============
-++++++++++ result france_poi: 23% (/) (/64)
+summary for france_poi ============ 48 failed, 16 passed, 12019 deselected in 8.62 seconds ============
+++++++++++ result france_poi: 25% (/) (/64)
```

the few tests lost does not seems very important.


If you merge this PR, I will clean the #224 PR to remove the complex type on the `weight` (so this one does not change the `Cell` type to reduce conflicts
