### PR TITLE
Better search

### DIFF
--- a/json/addr_settings.json
+++ b/json/addr_settings.json
@@ -115,7 +115,7 @@
                 "street": {
                     "properties": {
                         "id": { "type": "string", "index": "no" },
-                        "street_name": { "type": "string" },
+                        "name": { "type": "string" },
                         "administrative_regions": {
                             "properties": {
                                 "id": { "type": "string", "index": "no" },

--- a/json/addr_settings.json
+++ b/json/addr_settings.json
@@ -72,6 +72,19 @@
                     "geohash_prefix": true,
                     "geohash_precision": "1m"
                 },
+                "name": {
+                    "type": "string",
+                    "index_options": "docs",
+                    "analyzer": "word",
+                    "fields": {
+                        "prefix": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "prefix",
+                            "search_analyzer": "word"
+                        }
+                    }
+                },
                 "label": {
                     "type": "string",
                     "index_options": "docs",
@@ -115,7 +128,7 @@
                 "street": {
                     "properties": {
                         "id": { "type": "string", "index": "no" },
-                        "name": { "type": "string" },
+                        "street_name": { "type": "string" },
                         "administrative_regions": {
                             "properties": {
                                 "id": { "type": "string", "index": "no" },

--- a/json/addr_settings.json
+++ b/json/addr_settings.json
@@ -95,13 +95,19 @@
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "search_analyzer": "word",
+                            "norms": {
+                                "enabled": false
+                            }
                         },
                         "ngram": {
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram"
+                            "search_analyzer": "ngram",
+                            "norms": {
+                                "enabled": false
+                            }
                         }
                     }
                 },
@@ -114,13 +120,19 @@
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "search_analyzer": "word",
+                            "norms": {
+                                "enabled": false
+                            }
                         },
                         "ngram": {
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram"
+                            "search_analyzer": "ngram",
+                            "norms": {
+                                "enabled": false
+                            }
                         }
                     }
                 },

--- a/json/admin_settings.json
+++ b/json/admin_settings.json
@@ -52,6 +52,19 @@
             "properties": {
                 "id": { "type": "string", "index": "no" },
                 "level": { "type": "long", "index": "no" },
+                "name": {
+                    "type": "string",
+                    "index_options": "docs",
+                    "analyzer": "word",
+                    "fields": {
+                        "prefix": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "prefix",
+                            "search_analyzer": "word"
+                        }
+                    }
+                },
                 "zip_codes": {
                     "type": "string",
                     "index_options": "docs",

--- a/json/admin_settings.json
+++ b/json/admin_settings.json
@@ -95,13 +95,19 @@
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "search_analyzer": "word",
+                            "norms": {
+                                "enabled": false
+                            }
                         },
                         "ngram": {
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram"
+                            "search_analyzer": "ngram",
+                            "norms": {
+                                "enabled": false
+                            }
                         }
                     }
                 },
@@ -114,13 +120,19 @@
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "search_analyzer": "word",
+                            "norms": {
+                                "enabled": false
+                            }
                         },
                         "ngram": {
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram"
+                            "search_analyzer": "ngram",
+                            "norms": {
+                                "enabled": false
+                            }
                         }
                     }
                 },

--- a/json/poi_settings.json
+++ b/json/poi_settings.json
@@ -51,7 +51,19 @@
         "poi": {
             "properties": {
                 "id": { "type": "string", "index": "no" },
-                "name": { "type": "string" },
+                "name": {
+                    "type": "string",
+                    "index_options": "docs",
+                    "analyzer": "word",
+                    "fields": {
+                        "prefix": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "prefix",
+                            "search_analyzer": "word"
+                        }
+                    }
+                },
                 "zip_codes": {
                     "type": "string",
                     "index_options": "docs",

--- a/json/poi_settings.json
+++ b/json/poi_settings.json
@@ -93,13 +93,19 @@
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "search_analyzer": "word",
+                            "norms": {
+                                "enabled": false
+                            }
                         },
                         "ngram": {
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram"
+                            "search_analyzer": "ngram",
+                            "norms": {
+                                "enabled": false
+                            }
                         }
                     }
                 },
@@ -113,13 +119,19 @@
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "search_analyzer": "word",
+                            "norms": {
+                                "enabled": false
+                            }
                         },
                         "ngram": {
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram"
+                            "search_analyzer": "ngram",
+                            "norms": {
+                                "enabled": false
+                            }
                         }
                     }
                 },

--- a/json/stop_settings.json
+++ b/json/stop_settings.json
@@ -87,13 +87,19 @@
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "search_analyzer": "word",
+                            "norms": {
+                                "enabled": false
+                            }
                         },
                         "ngram": {
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram"
+                            "search_analyzer": "ngram",
+                            "norms": {
+                                "enabled": false
+                            }
                         }
                     }
                 },
@@ -106,13 +112,19 @@
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "search_analyzer": "word",
+                            "norms": {
+                                "enabled": false
+                            }
                         },
                         "ngram": {
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram"
+                            "search_analyzer": "ngram",
+                            "norms": {
+                                "enabled": false
+                            }
                         }
                     }
                 },

--- a/json/street_settings.json
+++ b/json/street_settings.json
@@ -51,7 +51,7 @@
         "street": {
             "properties": {
                 "id": { "type": "string", "index": "no" },
-                "street_name": { "type": "string" },
+                "name": { "type": "string" },
                 "zip_codes": {
                     "type": "string",
                     "index_options": "docs",

--- a/json/street_settings.json
+++ b/json/street_settings.json
@@ -94,13 +94,19 @@
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "search_analyzer": "word",
+                            "norms": {
+                                "enabled": false
+                            }
                         },
                         "ngram": {
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram"
+                            "search_analyzer": "ngram",
+                            "norms": {
+                                "enabled": false
+                            }
                         }
                     }
                 },
@@ -113,13 +119,19 @@
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "search_analyzer": "word",
+                            "norms": {
+                                "enabled": false
+                            }
                         },
                         "ngram": {
                             "type": "string",
                             "index_options": "docs",
                             "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram"
+                            "search_analyzer": "ngram",
+                            "norms": {
+                                "enabled": false
+                            }
                         }
                     }
                 },

--- a/json/street_settings.json
+++ b/json/street_settings.json
@@ -51,7 +51,19 @@
         "street": {
             "properties": {
                 "id": { "type": "string", "index": "no" },
-                "name": { "type": "string" },
+                "name": {
+                    "type": "string",
+                    "index_options": "docs",
+                    "analyzer": "word",
+                    "fields": {
+                        "prefix": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "prefix",
+                            "search_analyzer": "word"
+                        }
+                    }
+                },
                 "zip_codes": {
                     "type": "string",
                     "index_options": "docs",

--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -205,7 +205,7 @@ fn get_citycode(admins: &Vec<Arc<mimir::Admin>>) -> Option<String> {
 impl From<mimir::Street> for GeocodingResponse {
     fn from(other: mimir::Street) -> GeocodingResponse {
         let type_ = "street".to_string();
-        let name = Some(other.street_name);
+        let name = Some(other.name);
         let label = Some(other.label);
         let admins = other.administrative_regions;
         let city = get_city_name(&admins);
@@ -236,11 +236,8 @@ impl From<mimir::Addr> for GeocodingResponse {
         let type_ = "house".to_string();
         let label = Some(other.label);
         let housenumber = Some(other.house_number.to_string());
-        let street_name = Some(other.street.street_name.to_string());
-        let name = Some(format!(
-            "{} {}",
-            other.house_number, other.street.street_name
-        ));
+        let street_name = Some(other.street.name.to_string());
+        let name = Some(format!("{} {}", other.house_number, other.street.name));
         let admins = other.street.administrative_regions;
         let city = get_city_name(&admins);
         let postcode = if other.zip_codes.is_empty() {

--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -237,7 +237,7 @@ impl From<mimir::Addr> for GeocodingResponse {
         let label = Some(other.label);
         let housenumber = Some(other.house_number.to_string());
         let street_name = Some(other.street.name.to_string());
-        let name = Some(format!("{} {}", other.house_number, other.street.name));
+        let name = Some(other.name.to_string());
         let admins = other.street.administrative_regions;
         let city = get_city_name(&admins);
         let postcode = if other.zip_codes.is_empty() {

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -143,13 +143,13 @@ fn build_query(
     }
     let type_query = Query::build_bool()
         .with_should(vec![
-            match_type_with_boost::<Addr>(12.),
-            match_type_with_boost::<Admin>(11.),
-            match_type_with_boost::<Stop>(10.),
-            match_type_with_boost::<Poi>(2.),
+            match_type_with_boost::<Addr>(20.),
+            match_type_with_boost::<Admin>(19.),
+            match_type_with_boost::<Stop>(18.),
+            match_type_with_boost::<Poi>(1.5),
             match_type_with_boost::<Street>(1.),
         ])
-        .with_boost(20.)
+        .with_boost(30.)
         .build();
 
     // Priorization by query string

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -154,6 +154,7 @@ fn build_query(
 
     // Priorization by query string
     let mut string_should = vec![
+        Query::build_match("name", q).with_boost(1.).build(),
         Query::build_match("label", q).with_boost(1.).build(),
         Query::build_match("label.prefix", q).with_boost(1.).build(),
         Query::build_match("zip_codes", q).with_boost(1.).build(),

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -32,6 +32,7 @@ use geo;
 use serde;
 use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::{SerializeStruct, Serializer};
+use std::cell::Cell;
 use std::cmp::Ordering;
 use std::fmt;
 use std::rc::Rc;
@@ -435,7 +436,11 @@ impl MimirObject for Admin {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Street {
     pub id: String,
-    pub street_name: String,
+    #[deprecated]
+    #[serde(default)]
+    pub street_name: String, // deprecated field only there for retrocompatibility, to remove once migration is complete
+    #[serde(default)]
+    pub name: String,
     pub administrative_regions: Vec<Arc<Admin>>,
     pub label: String,
     pub weight: f64,

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -480,6 +480,8 @@ impl Members for Street {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Addr {
     pub id: String,
+    #[serde(default)]
+    pub name: String,
     pub house_number: String,
     pub street: Street,
     pub label: String,

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -103,7 +103,8 @@ impl Bano {
 
         let street = mimir::Street {
             id: street_id,
-            street_name: self.street,
+            street_name: self.street.clone(),
+            name: self.street,
             label: street_name.to_string(),
             administrative_regions: admins,
             weight: weight,

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -113,6 +113,7 @@ impl Bano {
         };
         mimir::Addr {
             id: format!("addr:{};{}", self.lon, self.lat),
+            name: addr_name,
             house_number: self.nb,
             street: street,
             label: addr_label,

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -88,6 +88,7 @@ impl OpenAddresse {
         };
         mimir::Addr {
             id: format!("addr:{};{}", self.lon, self.lat),
+            name: addr_name,
             house_number: self.number,
             street: street,
             label: addr_label,

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -78,7 +78,8 @@ impl OpenAddresse {
 
         let street = mimir::Street {
             id: street_id,
-            street_name: self.street,
+            street_name: self.street.clone(),
+            name: self.street,
             label: street_name.to_string(),
             administrative_regions: admins,
             weight: weight,

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -101,6 +101,7 @@ pub fn streets(
                 ret ret(street_list.push(mimir::Street {
                     id: way.id.0.to_string(),
                     street_name: way_name.to_string(),
+                    name: way_name.to_string(),
                     label: format_label(&admin, way_name),
                     weight: 0.,
                     zip_codes: get_zip_codes_from_admins(&admin),
@@ -161,6 +162,7 @@ pub fn streets(
             ret ret(street_list.push(mimir::Street {
                 id: way.id.0.to_string(),
                 street_name: way_name.to_string(),
+                name: way_name.to_string(),
                 label: format_label(&admins, way_name),
                 weight: 0.,
                 zip_codes: get_zip_codes_from_admins(&admins),

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -52,7 +52,7 @@ fn check_has_bob(es: &::ElasticSearchWrapper) {
         );
         let es_bob = es_elt.pointer("/_source").unwrap();
         assert_eq!(es_bob.pointer("/id"), Some(&json!("bob")));
-        assert_eq!(es_bob.pointer("/street_name"), Some(&json!("bob's street")));
+        assert_eq!(es_bob.pointer("/name"), Some(&json!("bob's street")));
         assert_eq!(es_bob.pointer("/label"), Some(&json!("bob's name")));
         assert_eq!(es_bob.pointer("/weight"), Some(&json!(0.42)));
     };
@@ -69,6 +69,7 @@ pub fn rubber_zero_downtime_test(mut es: ::ElasticSearchWrapper) {
     let bob = Street {
         id: "bob".to_string(),
         street_name: "bob's street".to_string(),
+        name: "bob's street".to_string(),
         label: "bob's name".to_string(),
         administrative_regions: vec![],
         weight: 0.42,
@@ -89,6 +90,7 @@ pub fn rubber_zero_downtime_test(mut es: ::ElasticSearchWrapper) {
     let bobette = Street {
         id: "bobette".to_string(),
         street_name: "bobette's street".to_string(),
+        name: "bobette's street".to_string(),
         label: "bobette's name".to_string(),
         administrative_regions: vec![],
         weight: 0.24,
@@ -121,10 +123,7 @@ pub fn rubber_zero_downtime_test(mut es: ::ElasticSearchWrapper) {
         );
         let es_bob = es_elt.pointer("/_source").unwrap();
         assert_eq!(es_bob.pointer("/id"), Some(&json!("bobette")));
-        assert_eq!(
-            es_bob.pointer("/street_name"),
-            Some(&json!("bobette's street"))
-        );
+        assert_eq!(es_bob.pointer("/name"), Some(&json!("bobette's street")));
         assert_eq!(es_bob.pointer("/label"), Some(&json!("bobette's name")));
         assert_eq!(es_bob.pointer("/weight"), Some(&json!(0.24)));
 


### PR DESCRIPTION
Since #211 as it is worsen the geocoder-test, this PR includes #211 and #213 and add some more stuff:

* add a `name` (correctly indexed) the the addresses (so they can also enjoy theboost on the `name`
* do not take the label's size into account (as the label is a generated field). check [the commit](https://github.com/CanalTP/mimirsbrunn/commit/1075633de9f2504bcaf45f10db67f98fdaec62bb) for more information

The geocoder tester (run with [this script](https://github.com/QwantResearch/geocoder-tester/blob/master/run_qwant.sh)) seems happy with this version:

```diff
--- results on master 
+++ results on this PR
-summary for france_autre ==== 1630 failed, 9386 passed, 1 skipped, 1066 deselected in 823.38 seconds ====
-++++++++++ result france_autre: 85% (/) (/11016)
+summary for france_autre === 1568 failed, 9577 passed, 1 skipped, 1066 deselected in 1361.40 seconds ====
+++++++++++ result france_autre: 85% (/) (/11145)
 running test france_fautes
-summary for france_fautes ========== 196 failed, 756 passed, 11131 deselected in 155.50 seconds ==========
-++++++++++ result france_fautes: 79% (/) (/952)
+summary for france_fautes ========== 187 failed, 765 passed, 11260 deselected in 205.41 seconds ==========
+++++++++++ result france_fautes: 80% (/) (/952)
 running test france_admins
-summary for france_admins ============ 12 failed, 38 passed, 12033 deselected in 5.55 seconds ============
-++++++++++ result france_admins: 76% (/) (/50)
+summary for france_admins ============ 6 failed, 44 passed, 12162 deselected in 4.70 seconds =============
+++++++++++ result france_admins: 88% (/) (/50)
 running test france_poi
-summary for france_poi =========== 49 failed, 15 passed, 12019 deselected in 10.65 seconds ============
-++++++++++ result france_poi: 23% (/) (/64)
+summary for france_poi ============ 26 failed, 38 passed, 12148 deselected in 9.39 seconds ============
+++++++++++ result france_poi: 59% (/) (/64)

```