### PR TITLE
Add GitLab-CI pipeline configuration to run geocoder tester

### DIFF
--- a/ci/gitlab/.gitlab-ci.yml
+++ b/ci/gitlab/.gitlab-ci.yml
@@ -1,0 +1,42 @@
+image: docker
+
+services:
+  - docker:dind
+
+variables:
+  DOCKER_DRIVER: overlay2
+  SHARED_PATH: /builds/$CI_PROJECT_PATH/shared
+
+geocoder-tester-cosmogony:
+  before_script:
+    - export OSM_DIR=$SHARED_PATH/data/osm ADDR_DIR=$SHARED_PATH/data/addresses
+    - apk add --no-cache python3 py3-pip git bash
+    - ./ci/gitlab/init.sh
+    - ./ci/gitlab/download_data.sh
+  script:
+    - cd docker_mimir
+    - inv -f import_settings_with_cosmogony.yml load-in-docker-and-test --files docker-compose.build.yml
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - docker_mimir/results
+  tags:
+    - france_cosmogony
+
+geocoder-tester-osm-admins:
+  before_script:
+    - export OSM_DIR=$SHARED_PATH/data/osm ADDR_DIR=$SHARED_PATH/data/addresses
+    - apk add --no-cache python3 py3-pip git bash
+    - ./ci/gitlab/init.sh
+    - ./ci/gitlab/download_data.sh
+  script:
+    - cd docker_mimir
+    - inv -f import_settings_without_cosmogony.yml load-in-docker-and-test --files docker-compose.build.yml
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - docker_mimir/results
+  tags:
+    - france_osm_admins
+
+

--- a/ci/gitlab/docker-compose.build.yml
+++ b/ci/gitlab/docker-compose.build.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  bragi:
+    build:
+      context: $CI_PROJECT_DIR
+      dockerfile: docker/Dockerfile_bragi
+  mimir:
+    build:
+      context: $CI_PROJECT_DIR
+      dockerfile: docker/Dockerfile_import

--- a/ci/gitlab/download_data.sh
+++ b/ci/gitlab/download_data.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+set -e
+set -x
+
+# Download addresses
+mkdir -p $ADDR_DIR
+wget http://bano.openstreetmap.fr/data/full.csv.gz -P $ADDR_DIR
+gunzip $ADDR_DIR/full.csv.gz
+
+# Download osm dataset
+mkdir -p $OSM_DIR
+wget https://download.geofabrik.de/europe/france-latest.osm.pbf -P $OSM_DIR

--- a/ci/gitlab/import_settings_with_cosmogony.yml
+++ b/ci/gitlab/import_settings_with_cosmogony.yml
@@ -1,0 +1,13 @@
+es: http://es:9200
+
+osm_file: /data/osm/france-latest.osm.pbf
+
+admin:
+  cosmogony:
+    output_dir: /data/cosmogony
+
+poi:
+  osm:
+
+addresses:
+  bano_file: /data/addresses/full.csv

--- a/ci/gitlab/import_settings_without_cosmogony.yml
+++ b/ci/gitlab/import_settings_without_cosmogony.yml
@@ -1,0 +1,14 @@
+es: http://es:9200
+
+osm_file: /data/osm/france-latest.osm.pbf
+
+admin:
+  osm:
+    levels:
+      - 8
+
+poi:
+  osm:
+
+addresses:
+  bano_file: /data/addresses/full.csv

--- a/ci/gitlab/init.sh
+++ b/ci/gitlab/init.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+set -e
+set -x
+
+pip3 install docker-compose pipenv
+git clone -b master https://github.com/QwantResearch/docker_mimir.git
+mv ci/gitlab/*.yml docker_mimir/
+cd docker_mimir && pipenv install --system --deploy


### PR DESCRIPTION
Following #233, here are configuration files to trigger geocoding tests in a gitlab-ci pipeline.
Using [docker_mimir](https://github.com/QwantResearch/docker_mimir), a docker composition will build images, import datasets into mimirsbrunn, run geocoder-tester and create artifacts with detailed results.

**Requirements:**
 * GitLab CI must be enabled on a mirror of this repository, and configured to use 
`ci/gitlab/.gitlab-ci.yml` as the config path.
 * Register a runner with "docker-privileged" mode (necessary to use "docker inside docker": build docker images on the current branch, and run docker-compose). 
See https://docs.gitlab.com/ce/ci/docker/using_docker_build.html#use-docker-in-docker-executor
(This page also describes other approaches that could be used to make the runner execute docker commands.)
 * Set a [tag](https://docs.gitlab.com/ee/ci/yaml/#tags) on the runner to select the job(s) that will run on it. There are currently 2 jobs defined in the gitlab-ci configuration (France, with or without cosmogony), triggered with tags `france_cosmogony` and `france_osm_admins` respectively)