### PR TITLE
Do not index useless fields

### DIFF
--- a/json/addr_settings.json
+++ b/json/addr_settings.json
@@ -49,6 +49,7 @@
     },
     "mappings": {
         "addr": {
+            "dynamic": "false",
             "properties": {
                 "id": { "type": "string", "index": "no" },
                 "house_number": { "type": "string", "analyzer": "word"},
@@ -136,23 +137,7 @@
                         }
                     }
                 },
-                "weight": { "type": "double" },
-                "street": {
-                    "properties": {
-                        "id": { "type": "string", "index": "no" },
-                        "street_name": { "type": "string" },
-                        "administrative_regions": {
-                            "properties": {
-                                "id": { "type": "string", "index": "no" },
-                                "level": { "type": "long", "index": "no" },
-                                "zip_codes": { "type": "string", "index": "not_analyzed" },
-                                "weight": { "type": "double" }
-                            }
-                        },
-                        "weight": { "type": "double" },
-                        "zip_codes": { "type": "string", "index": "not_analyzed" }
-                    }
-                }
+                "weight": { "type": "double" }
             }
         }
     }

--- a/json/admin_settings.json
+++ b/json/admin_settings.json
@@ -49,6 +49,7 @@
     },
     "mappings": {
         "admin": {
+            "dynamic": "false",
             "properties": {
                 "id": { "type": "string", "index": "no" },
                 "level": { "type": "long", "index": "no" },

--- a/json/admin_settings.json
+++ b/json/admin_settings.json
@@ -138,7 +138,7 @@
                     }
                 },
                 "weight": { "type": "double" },
-                "bbox": { "type": "double", "index": "no"}
+                "zone_type": { "type": "string", "index": "not_analyzed"}
             }
         }
     }

--- a/json/poi_settings.json
+++ b/json/poi_settings.json
@@ -49,6 +49,7 @@
     },
     "mappings": {
         "poi": {
+            "dynamic": "false",
             "properties": {
                 "id": { "type": "string", "index": "no" },
                 "name": {
@@ -133,14 +134,6 @@
                                 "enabled": false
                             }
                         }
-                    }
-                },
-                "administrative_regions": {
-                    "properties": {
-                        "id": { "type": "string", "index": "no" },
-                        "level": { "type": "long", "index": "no" },
-                        "zip_codes": { "type": "string", "index": "not_analyzed" },
-                        "weight": { "type": "double" }
                     }
                 },
                 "properties": {

--- a/json/stop_settings.json
+++ b/json/stop_settings.json
@@ -49,6 +49,7 @@
     },
     "mappings": {
         "stop": {
+            "dynamic": "false",
             "properties": {
                 "id": {
                     "type": "string",
@@ -125,25 +126,6 @@
                             "norms": {
                                 "enabled": false
                             }
-                        }
-                    }
-                },
-                "administrative_regions": {
-                    "properties": {
-                        "id": {
-                            "type": "string",
-                            "index": "no"
-                        },
-                        "level": {
-                            "type": "long",
-                            "index": "no"
-                        },
-                        "zip_codes": {
-                            "type": "string",
-                            "index": "not_analyzed"
-                        },
-                        "weight": {
-                            "type": "double"
                         }
                     }
                 },

--- a/json/street_settings.json
+++ b/json/street_settings.json
@@ -49,6 +49,7 @@
     },
     "mappings": {
         "street": {
+            "dynamic": "false",
             "properties": {
                 "id": { "type": "string", "index": "no" },
                 "name": {
@@ -135,15 +136,7 @@
                         }
                     }
                 },
-                "weight": { "type": "double" },
-                "administrative_regions": {
-                    "properties": {
-                        "id": { "type": "string", "index": "no" },
-                        "level": { "type": "long", "index": "no" },
-                        "zip_codes": { "type": "string", "index": "not_analyzed" },
-                        "weight": { "type": "double" }
-                    }
-                }
+                "weight": { "type": "double" }
             }
         }
     }

--- a/libs/bragi/src/lib.rs
+++ b/libs/bragi/src/lib.rs
@@ -83,7 +83,11 @@ pub struct Args {
     #[structopt(short = "b", long = "bind", default_value = "127.0.0.1:4000")]
     bind: String,
     /// Elasticsearch parameters, override BRAGI_ES environment variable.
-    #[structopt(short = "c", long = "connection-string", raw(default_value = "&BRAGI_ES"))]
+    #[structopt(
+        short = "c",
+        long = "connection-string",
+        raw(default_value = "&BRAGI_ES")
+    )]
     connection_string: String,
 }
 

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -192,7 +192,9 @@ struct Args {
     input: PathBuf,
     /// Elasticsearch parameters.
     #[structopt(
-        short = "c", long = "connection-string", default_value = "http://localhost:9200/munin"
+        short = "c",
+        long = "connection-string",
+        default_value = "http://localhost:9200/munin"
     )]
     connection_string: String,
     /// Name of the dataset.

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -129,7 +129,9 @@ struct Args {
     input: String,
     /// Elasticsearch parameters.
     #[structopt(
-        short = "c", long = "connection-string", default_value = "http://localhost:9200/munin"
+        short = "c",
+        long = "connection-string",
+        default_value = "http://localhost:9200/munin"
     )]
     connection_string: String,
     /// Name of the dataset.

--- a/src/bin/mimir_init.rs
+++ b/src/bin/mimir_init.rs
@@ -43,7 +43,11 @@ use mimir::rubber::Rubber;
 #[derive(StructOpt, Debug)]
 struct Args {
     /// Elasticsearch parameters.
-    #[structopt(short = "c", long = "connection-string", default_value = "http://localhost:9200/")]
+    #[structopt(
+        short = "c",
+        long = "connection-string",
+        default_value = "http://localhost:9200/"
+    )]
     connection_string: String,
 }
 

--- a/src/bin/ntfs2mimir.rs
+++ b/src/bin/ntfs2mimir.rs
@@ -48,14 +48,21 @@ use std::path::PathBuf;
 #[derive(Debug, StructOpt)]
 struct Args {
     /// NTFS directory.
-    #[structopt(short = "i", long = "input", parse(from_os_str), default_value = ".")]
+    #[structopt(
+        short = "i",
+        long = "input",
+        parse(from_os_str),
+        default_value = "."
+    )]
     input: PathBuf,
     /// Name of the dataset.
     #[structopt(short = "d", long = "dataset", default_value = "fr")]
     dataset: String,
     /// Elasticsearch parameters.
     #[structopt(
-        short = "c", long = "connection-string", default_value = "http://localhost:9200/munin"
+        short = "c",
+        long = "connection-string",
+        default_value = "http://localhost:9200/munin"
     )]
     connection_string: String,
     /// Deprecated option.

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -155,7 +155,9 @@ struct Args {
     input: PathBuf,
     /// Elasticsearch parameters.
     #[structopt(
-        short = "c", long = "connection-string", default_value = "http://localhost:9200/munin"
+        short = "c",
+        long = "connection-string",
+        default_value = "http://localhost:9200/munin"
     )]
     connection_string: String,
     /// Name of the dataset.

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -61,7 +61,9 @@ struct Args {
     city_level: u32,
     /// Elasticsearch parameters.
     #[structopt(
-        short = "c", long = "connection-string", default_value = "http://localhost:9200/munin"
+        short = "c",
+        long = "connection-string",
+        default_value = "http://localhost:9200/munin"
     )]
     connection_string: String,
     /// Import ways.

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -63,7 +63,9 @@ struct Args {
     dataset: String,
     /// Elasticsearch parameters.
     #[structopt(
-        short = "c", long = "connection-string", default_value = "http://localhost:9200/munin"
+        short = "c",
+        long = "connection-string",
+        default_value = "http://localhost:9200/munin"
     )]
     connection_string: String,
     /// Deprecated option.

--- a/tests/osm2mimir_test.rs
+++ b/tests/osm2mimir_test.rs
@@ -73,21 +73,16 @@ pub fn osm2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
 
     // Test that Créteil (admin_level 7) is not treated as a city (level 8)
     let admin_regions: Vec<_> = es_wrapper
-        .search_and_filter("admin_type:Unknown", |_| true)
-        .filter_map(|admin| match admin {
-            mimir::Place::Admin(admin) => {
-                if admin.name == "Créteil" {
-                    Some(admin)
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        })
+        .search_and_filter("label:Créteil", |_| true)
         .collect();
     assert!(admin_regions.len() >= 1);
-    assert_eq!(admin_regions[0].level, 7);
-    assert_eq!(admin_regions[0].admin_type, mimir::AdminType::Unknown);
+    if let mimir::Place::Admin(ref creteil) = admin_regions[0] {
+        assert_eq!(creteil.name, "Créteil");
+        assert_eq!(creteil.level, 7);
+        assert_eq!(creteil.admin_type, mimir::AdminType::Unknown);
+    } else {
+        panic!("creteil should be an admin");
+    }
 
     // Test: search for "Rue des Près"
     let res: Vec<_> = es_wrapper


### PR DESCRIPTION
by default elasticsearch index all unknown field (not in the mapping).

this means that it will take some time and some space to index some useless field. Like for example the big admins name (thrice in the poi index :wink: )

https://www.elastic.co/guide/en/elasticsearch/guide/current/dynamic-mapping.html

adding `"dynamic": "false"` to the mapping tells ES not to index the unknown field (but they are still stored).

Note: do not merge this PR yet, I opened it for review, and I'm waiting for the data import process to give figures about the impact on the index time/space