### PR TITLE
Admin lookup speedup

### DIFF
--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -335,6 +335,8 @@ pub struct Admin {
     pub admin_type: AdminType, // deprecated, to be removed after the new zone_type deployment
     #[serde(default)]
     pub zone_type: Option<ZoneType>,
+    #[serde(default)]
+    pub parent_id: Option<String>, // id of the Admin's parent (from the cosmogony's hierarchy)
 }
 
 fn default_admin_city() -> AdminType {

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -104,7 +104,7 @@ impl AdminGeoFinder {
         let mut added_zone_types = BTreeSet::new();
         let mut res = vec![];
 
-        for boundary_and_admin in rtree_results.into_iter().map(|(_, a)| a) {
+        for (_, boundary_and_admin) in rtree_results {
             let boundary = &boundary_and_admin.0;
             let admin = &boundary_and_admin.1;
             if tested_hierarchy.contains(&admin.id) {

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -51,7 +51,7 @@ impl BoundaryAndAdmin {
 
 pub struct AdminGeoFinder {
     admins: RTree<BoundaryAndAdmin>,
-    parents_map: BTreeMap<String, String>,
+    admin_by_id: BTreeMap<String, Arc<Admin>>,
 }
 
 impl AdminGeoFinder {
@@ -86,10 +86,10 @@ impl AdminGeoFinder {
                 )
             })
         };
-        if let Some(parent_id) = &admin.parent_id {
-            self.parents_map.insert(admin.id.clone(), parent_id.clone());
-        }
-        self.admins.insert(rect, BoundaryAndAdmin::new(admin));
+        let bound_admin = BoundaryAndAdmin::new(admin);
+        self.admin_by_id
+            .insert((*bound_admin.1).id.clone(), bound_admin.1.clone());
+        self.admins.insert(rect, bound_admin);
     }
 
     /// Get all Admins overlapping the coordinate
@@ -101,20 +101,36 @@ impl AdminGeoFinder {
         rtree_results.sort_by_key(|(_, a)| (*a.1).zone_type);
 
         let mut tested_hierarchy = BTreeSet::<String>::new();
+        let mut added_zone_types = BTreeSet::new();
         let mut res = vec![];
 
         for boundary_and_admin in rtree_results.into_iter().map(|(_, a)| a) {
             let boundary = &boundary_and_admin.0;
             let admin = &boundary_and_admin.1;
-            if tested_hierarchy.contains(&(*admin).id)
-                || boundary
-                    .as_ref()
-                    .map_or(false, |b| (*b).contains(&geo::Point(*coord)))
+            if tested_hierarchy.contains(&(*admin).id) {
+                res.push(admin.clone());
+            } else if (*admin)
+                .zone_type
+                .as_ref()
+                .map_or(false, |zt| added_zone_types.contains(zt))
             {
-                let mut admin_parent = (*admin).parent_id.clone();
-                while let Some(id) = admin_parent {
-                    admin_parent = self.parents_map.get(&id).cloned();
+                // we don't want it, we already have this kind of ZoneType
+            } else if boundary
+                .as_ref()
+                .map_or(false, |b| (*b).contains(&geo::Point(*coord)))
+            {
+                // we found a valid admin, we save it's hierarchy not to have to test their boundaries
+                if let Some(zt) = (*admin).zone_type {
+                    added_zone_types.insert(zt.clone());
+                }
+                let mut admin_parent_id = (*admin).parent_id.clone();
+                while let Some(id) = admin_parent_id {
+                    let admin_parent = self.admin_by_id.get(&id);
+                    if let Some(zt) = admin_parent.as_ref().and_then(|a| (*a).zone_type) {
+                        added_zone_types.insert(zt.clone());
+                    }
                     tested_hierarchy.insert(id);
+                    admin_parent_id = admin_parent.and_then(|a| (*a).parent_id.clone());
                 }
 
                 res.push(admin.clone());
@@ -162,7 +178,7 @@ impl Default for AdminGeoFinder {
     fn default() -> Self {
         AdminGeoFinder {
             admins: RTree::new(),
-            parents_map: BTreeMap::new(),
+            admin_by_id: BTreeMap::new(),
         }
     }
 }
@@ -213,26 +229,37 @@ mod tests {
         ::geo::Point(::geo::Coordinate { x: x, y: y })
     }
 
-    fn make_admin(offset: f64) -> ::mimir::Admin {
+    fn make_admin(offset: f64, zt: Option<ZoneType>) -> ::mimir::Admin {
+        make_complex_admin(&format!("admin:offset:{}", offset,), offset, zt, 1., None)
+    }
+
+    fn make_complex_admin(
+        id: &str,
+        offset: f64,
+        zt: Option<ZoneType>,
+        zone_size: f64,
+        parent_offset: Option<&str>,
+    ) -> ::mimir::Admin {
         // the boundary is a big octogon
+        // the zone_size param is used to control the area of the zone
         let shape = ::geo::Polygon::new(
             ::geo::LineString(vec![
-                p(3. + offset, 0. + offset),
-                p(6. + offset, 0. + offset),
-                p(9. + offset, 3. + offset),
-                p(9. + offset, 6. + offset),
-                p(6. + offset, 9. + offset),
-                p(3. + offset, 9. + offset),
-                p(0. + offset, 6. + offset),
-                p(0. + offset, 3. + offset),
-                p(3. + offset, 0. + offset),
+                p(3. * zone_size + offset, 0. * zone_size + offset),
+                p(6. * zone_size + offset, 0. * zone_size + offset),
+                p(9. * zone_size + offset, 3. * zone_size + offset),
+                p(9. * zone_size + offset, 6. * zone_size + offset),
+                p(6. * zone_size + offset, 9. * zone_size + offset),
+                p(3. * zone_size + offset, 9. * zone_size + offset),
+                p(0. * zone_size + offset, 6. * zone_size + offset),
+                p(0. * zone_size + offset, 3. * zone_size + offset),
+                p(3. * zone_size + offset, 0. * zone_size + offset),
             ]),
             vec![],
         );
         let boundary = ::geo::MultiPolygon(vec![shape]);
 
         ::mimir::Admin {
-            id: format!("admin:offset:{}", offset),
+            id: id.into(),
             level: 8,
             name: "city".to_string(),
             label: format!("city {}", offset),
@@ -243,16 +270,16 @@ mod tests {
             boundary: Some(boundary),
             insee: "outlook".to_string(),
             admin_type: AdminType::City,
-            zone_type: Some(ZoneType::City),
-            parent_id: None,
+            zone_type: zt,
+            parent_id: parent_offset.map(|id| id.into()),
         }
     }
 
     #[test]
     fn test_two_fake_admins() {
         let mut finder = AdminGeoFinder::default();
-        finder.insert(make_admin(40.));
-        finder.insert(make_admin(43.));
+        finder.insert(make_admin(40., Some(ZoneType::City)));
+        finder.insert(make_admin(43., Some(ZoneType::State)));
 
         // outside
         for coord in [p(48., 41.), p(411., 41.), p(51., 54.), p(53., 53.)].iter() {
@@ -273,5 +300,139 @@ mod tests {
         assert_eq!(admins.len(), 2);
         assert_eq!(admins[0].id, "admin:offset:40");
         assert_eq!(admins[1].id, "admin:offset:43");
+    }
+
+    #[test]
+    fn test_two_admin_same_zone_type() {
+        // a point can be associated to only 1 admin type
+        // so a point is in 2 city, it is associated to only one
+        let mut finder = AdminGeoFinder::default();
+        finder.insert(make_admin(40., Some(ZoneType::City)));
+        finder.insert(make_admin(43., Some(ZoneType::City)));
+        let mut admins = finder.get(&p(46., 46.).0);
+        assert_eq!(admins.len(), 1);
+    }
+
+    #[test]
+    fn test_two_no_zone_type() {
+        // a point can be associated to only 1 admin type
+        // but a point can be associated to multiple admin without zone_type
+        // (for retrocompatibility of the data imported without cosmogony)
+        let mut finder = AdminGeoFinder::default();
+        finder.insert(make_admin(40., None));
+        finder.insert(make_admin(43., None));
+        let mut admins = finder.get(&p(46., 46.).0);
+        assert_eq!(admins.len(), 2);
+    }
+
+    #[test]
+    fn test_hierarchy() {
+        let mut finder = AdminGeoFinder::default();
+        finder.insert(make_complex_admin(
+            "bob_city",
+            40.,
+            Some(ZoneType::City),
+            1.,
+            Some("bob_state"),
+        ));
+        finder.insert(make_complex_admin(
+            "bob_state",
+            40.,
+            Some(ZoneType::StateDistrict),
+            2.,
+            Some("bob_country"),
+        ));
+        finder.insert(make_complex_admin(
+            "bob_country",
+            40.,
+            Some(ZoneType::Country),
+            3.,
+            None,
+        ));
+
+        let mut admins = finder.get(&p(46., 46.).0);
+        assert_eq!(admins.len(), 3);
+        assert_eq!(admins[0].id, "bob_city");
+        assert_eq!(admins[1].id, "bob_state");
+        assert_eq!(admins[2].id, "bob_country");
+    }
+
+    #[test]
+    fn test_hierarchy_orphan() {
+        let mut finder = AdminGeoFinder::default();
+        finder.insert(make_complex_admin(
+            "bob_city",
+            40.,
+            Some(ZoneType::City),
+            1.,
+            Some("bob_state"),
+        ));
+        finder.insert(make_complex_admin(
+            "bob_state",
+            40.,
+            Some(ZoneType::StateDistrict),
+            2.,
+            Some("bob_country"),
+        ));
+        finder.insert(make_complex_admin(
+            "bob_country",
+            40.,
+            Some(ZoneType::Country),
+            3.,
+            None,
+        ));
+
+        // another_state also contains the point, but the geofinder look for only 1 admin by type (it needs only 1 state)
+        // since bob_city has been tester first, it's hierarchy has been added automatically
+        // so [46., 46.] will not be associated to another_state
+        finder.insert(make_complex_admin(
+            "another_state",
+            40.,
+            Some(ZoneType::StateDistrict),
+            2.,
+            Some("bob_country"),
+        ));
+
+        let mut admins = finder.get(&p(46., 46.).0);
+        assert_eq!(admins.len(), 3);
+        assert_eq!(admins[0].id, "bob_city");
+        assert_eq!(admins[1].id, "bob_state");
+        assert_eq!(admins[2].id, "bob_country");
+    }
+
+    #[test]
+    fn test_hierarchy_and_not_typed_zone() {
+        let mut finder = AdminGeoFinder::default();
+        finder.insert(make_complex_admin(
+            "bob_city",
+            40.,
+            Some(ZoneType::City),
+            1.,
+            Some("bob_state"),
+        ));
+        finder.insert(make_complex_admin(
+            "bob_state",
+            40.,
+            Some(ZoneType::StateDistrict),
+            2.,
+            Some("bob_country"),
+        ));
+        finder.insert(make_complex_admin(
+            "bob_country",
+            40.,
+            Some(ZoneType::Country),
+            3.,
+            None,
+        ));
+
+        // not_typed zone is outside the hierarchy, but since it contains the point and it has no type it is added
+        finder.insert(make_complex_admin("no_typed_zone", 40., None, 2., None));
+
+        let mut admins = finder.get(&p(46., 46.).0);
+        assert_eq!(admins.len(), 4);
+        assert_eq!(admins[0].id, "no_typed_zone");
+        assert_eq!(admins[1].id, "bob_city");
+        assert_eq!(admins[2].id, "bob_state");
+        assert_eq!(admins[3].id, "bob_country");
     }
 }

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -178,6 +178,7 @@ pub fn read_administrative_regions(
                 boundary: boundary,
                 admin_type: admin_type,
                 zone_type: zone_type,
+                parent_id: None,
             };
             administrative_regions.push(admin);
         }

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -164,6 +164,7 @@ pub fn rubber_custom_id(mut es: ::ElasticSearchWrapper) {
         boundary: Some(boundary),
         admin_type: City,
         zone_type: Some(ZoneType::City),
+        parent_id: None,
     };
 
     // we index our admin
@@ -246,6 +247,7 @@ pub fn rubber_ghost_index_cleanup(mut es: ::ElasticSearchWrapper) {
         bbox: None,
         admin_type: City,
         zone_type: Some(ZoneType::City),
+        parent_id: None,
     };
 
     // we index our admin


### PR DESCRIPTION
# Speed up the association to an admin

Our data import process to import the addresses is very long, even on a quite small dataset like France.

The major time (80% of the run time in our case) is taken to associate an admin to an address.
To do this, mimir load all the admin in a rtree and check the admin boundaries.

Since we use [cosmogony](https://github.com/osm-without-borders/cosmogony) to import our admins, we got lots of them (compared to the basic CanalTP use case that read only the admin 8 from osm).

This PR speed up the admin association by using the cosmogony hierarchy.
Cosmogony already do lots of geographic inclusion to produce a hierachy. The idea is to store this hierarchy in ES (only storing the parent's ID will not overload the db) and skip some `contains` based on this hierarchy.

We also consider that we associate a point to only one zone of a kind (at most 1 city, 1 state, 1 country, ...). This is clearly a bias since there is nothing stopping 2 cities to overlap, but we think we don't want to associate a point to 2 city. 
What do you think of this ?


This speeds up our import process by more than 2 (17h :scream: hours for the 28M addresses of OA drops to 7h) since we now only check 1 or 2 zones (and we especially tests very few big zones that have lots a points and are long to check)

I still need to run some bench to check that your import process is not impacted by this change (I think the only overhead is that we now sort the rtree results + the creation of the admin map by id, I need to check the impact)