### PR TITLE
Remove a verbose useless log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ services:
   - docker
 matrix:
   include:
-    - rust: nightly
+    - rust: stable
       env: RUN=RUSTFMT
       before_script: rustup component add rustfmt-preview
-      script: cargo fmt --all -- --check
+      script: cargo fmt --all -- --write-mode diff
   allow_failures:
     - rust: nightly
       env: RUN=TEST

--- a/libs/bragi/src/api.rs
+++ b/libs/bragi/src/api.rs
@@ -34,9 +34,7 @@ use iron::typemap::Key;
 use mimir::rubber::Rubber;
 use model;
 use model::v1::*;
-use params::{
-    coord_param, dataset_param, get_param_array, paginate_param, shape_param, types_param,
-};
+use params::{coord_param, dataset_param, get_param_array, paginate_param, shape_param, types_param};
 use prometheus;
 use prometheus::Encoder;
 use rustless;

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -271,12 +271,10 @@ fn query(
 
     let result: SearchResult<serde_json::Value> = client
         .search_query()
-        .with_indexes(
-            &indexes
-                .iter()
-                .map(|index| index.as_str())
-                .collect::<Vec<&str>>(),
-        )
+        .with_indexes(&indexes
+            .iter()
+            .map(|index| index.as_str())
+            .collect::<Vec<&str>>())
         .with_query(&query)
         .with_from(offset)
         .with_size(limit)
@@ -318,12 +316,10 @@ pub fn features(
     let result: SearchResult<serde_json::Value> = try!(
         client
             .search_query()
-            .with_indexes(
-                &indexes
-                    .iter()
-                    .map(|index| index.as_str())
-                    .collect::<Vec<&str>>()
-            )
+            .with_indexes(&indexes
+                .iter()
+                .map(|index| index.as_str())
+                .collect::<Vec<&str>>())
             .with_query(&query)
             .send()
     );

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -595,10 +595,7 @@ impl Coord {
         self.lat() == 0. && self.lon() == 0.
     }
     pub fn is_valid(&self) -> bool {
-        !self.is_default()
-            && -90. <= self.lat()
-            && self.lat() <= 90.
-            && -180. <= self.lon()
+        !self.is_default() && -90. <= self.lat() && self.lat() <= 90. && -180. <= self.lon()
             && self.lon() <= 180.
     }
 }
@@ -652,11 +649,9 @@ impl<'de> Deserialize<'de> for Coord {
             where
                 V: SeqAccess<'de>,
             {
-                let lon = seq
-                    .next_element()?
+                let lon = seq.next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let lat = seq
-                    .next_element()?
+                let lat = seq.next_element()?
                     .ok_or_else(|| de::Error::invalid_length(1, &self))?;
                 Ok(Coord::new(lon, lat))
             }

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -375,8 +375,7 @@ impl Rubber {
         &self,
         base_index: &str,
     ) -> Result<BTreeMap<String, Vec<String>>, Error> {
-        let res = self
-            .get(&format!("{}*/_aliases", base_index))
+        let res = self.get(&format!("{}*/_aliases", base_index))
             .with_context(|_| format!("Error occurred when getting {}*/_aliases", base_index))?;
         match res.status {
             StatusCode::Ok => {
@@ -416,8 +415,7 @@ impl Rubber {
     ) -> Result<Vec<String>, Error> {
         let base_index = get_main_type_and_dataset_index::<T>(dataset);
         // we don't want to remove the newly created index
-        Ok(self
-            .get_all_aliased_index(&base_index)?
+        Ok(self.get_all_aliased_index(&base_index)?
             .into_iter()
             .map(|(k, _)| k)
             .filter(|i| i.as_str() != new_index.name)
@@ -435,15 +433,12 @@ impl Rubber {
             .with_must(geo_distance)
             .build();
 
-        let result: SearchResult<serde_json::Value> = self
-            .es_client
+        let result: SearchResult<serde_json::Value> = self.es_client
             .search_query()
-            .with_indexes(
-                &indexes
-                    .iter()
-                    .map(|index| index.as_str())
-                    .collect::<Vec<_>>(),
-            )
+            .with_indexes(&indexes
+                .iter()
+                .map(|index| index.as_str())
+                .collect::<Vec<_>>())
             .with_query(&query)
             .with_size(1)
             .send()?;
@@ -516,8 +511,7 @@ impl Rubber {
             actions: add_operations.chain(remove_operations).collect(),
         };
         let json = serde_json::to_string(&operations)?;
-        let res = self
-            .post("_aliases", &json)
+        let res = self.post("_aliases", &json)
             .context("Error occurred when POSTing: _alias")?;
         match res.status {
             StatusCode::Ok => Ok(()),
@@ -527,8 +521,7 @@ impl Rubber {
 
     pub fn delete_index(&mut self, index: &String) -> Result<(), Error> {
         debug!("deleting index {}", &index);
-        let res = self
-            .es_client
+        let res = self.es_client
             .delete_index(&index)
             .map(|res| res.acknowledged)
             .unwrap_or(false);
@@ -591,8 +584,7 @@ impl Rubber {
         I: Iterator<Item = T>,
     {
         // TODO better error handling
-        let index = self
-            .make_index(dataset)
+        let index = self.make_index(dataset)
             .with_context(|_| format!("Error occurred when making index: {}", dataset))?;
         let nb_elements = self.bulk_index(&index, iter)?;
         self.publish_index(dataset, index)?;
@@ -618,8 +610,7 @@ impl Rubber {
         for<'de> T: MimirObject + serde::de::Deserialize<'de> + std::fmt::Debug,
     {
         let mut result: Vec<T> = vec![];
-        let mut scan: ScanResult<T> = self
-            .es_client
+        let mut scan: ScanResult<T> = self.es_client
             .search_query()
             .with_indexes(&[&index])
             .with_size(1000)

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -106,8 +106,7 @@ impl AdminGeoFinder {
 
     /// Iterates on all the admins with a not None boundary.
     pub fn admins<'a>(&'a self) -> Box<Iterator<Item = Admin> + 'a> {
-        let iter = self
-            .admins
+        let iter = self.admins
             .get(&Rect::from_float(
                 std::f32::NEG_INFINITY,
                 std::f32::INFINITY,
@@ -125,8 +124,7 @@ impl AdminGeoFinder {
 
     /// Iterates on all the `Rc<Admin>` in the structure as returned by `get`.
     pub fn admins_without_boundary<'a>(&'a self) -> Box<Iterator<Item = Arc<Admin>> + 'a> {
-        let iter = self
-            .admins
+        let iter = self.admins
             .get(&Rect::from_float(
                 std::f32::NEG_INFINITY,
                 std::f32::INFINITY,

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -158,8 +158,7 @@ where
     for f in files {
         info!("importing {:?}...", &f);
         let mut rdr = csv::ReaderBuilder::new().has_headers(false).from_path(&f)?;
-        let iter = rdr
-            .deserialize()
+        let iter = rdr.deserialize()
             .filter_map(|r| {
                 r.map_err(|e| info!("impossible to read line, error: {}", e))
                     .ok()

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -133,10 +133,7 @@ where
             })
             .filter(|a| {
                 !a.street.street_name.is_empty() || {
-                    info!(
-                        "Address {}:{:?}:{:?} has no street name and has been ignored.",
-                        a.id, a.coord, a.street
-                    );
+                    info!("Address {} has no street name and has been ignored.", a.id);
                     false
                 }
             });

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -124,8 +124,7 @@ where
     for f in files {
         info!("importing {:?}...", &f);
         let mut rdr = csv::ReaderBuilder::new().has_headers(true).from_path(&f)?;
-        let iter = rdr
-            .deserialize()
+        let iter = rdr.deserialize()
             .filter_map(|r| {
                 r.map_err(|e| info!("impossible to read line, error: {}", e))
                     .ok()

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -109,9 +109,7 @@ impl GtfsStop {
             Err(StopConversionErr::NotStopArea)
         } else if self.visible == Some(0) {
             Err(StopConversionErr::InvisibleStop)
-        } else if self.stop_lat <= MIN_LAT
-            || self.stop_lat >= MAX_LAT
-            || self.stop_lon <= MIN_LON
+        } else if self.stop_lat <= MIN_LAT || self.stop_lat >= MAX_LAT || self.stop_lon <= MIN_LON
             || self.stop_lon >= MAX_LON
         {
             //Here we return an error message
@@ -160,8 +158,7 @@ fn run(args: Args) -> Result<(), failure::Error> {
 
     let mut rdr = csv::Reader::from_path(&args.input)?;
     let mut nb_stop_points = HashMap::new();
-    let mut stops: Vec<mimir::Stop> = rdr
-        .deserialize()
+    let mut stops: Vec<mimir::Stop> = rdr.deserialize()
         .filter_map(|rc| rc.map_err(|e| warn!("skip csv line: {}", e)).ok())
         .filter_map(|stop: GtfsStop| {
             stop.incr_stop_point(&mut nb_stop_points);
@@ -184,8 +181,7 @@ fn test_load_stops() {
     let mut rdr = csv::Reader::from_path("./tests/fixtures/stops.txt".to_string()).unwrap();
 
     let mut nb_stop_points = HashMap::new();
-    let stops: Vec<mimir::Stop> = rdr
-        .deserialize()
+    let stops: Vec<mimir::Stop> = rdr.deserialize()
         .filter_map(Result::ok)
         .filter_map(|stop: GtfsStop| {
             stop.incr_stop_point(&mut nb_stop_points);

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -209,8 +209,7 @@ pub fn format_zip_codes(zip_codes: &[String]) -> String {
 }
 
 pub fn read_zip_codes(tags: &osmpbfreader::Tags) -> Vec<String> {
-    let zip_code = tags
-        .get("addr:postcode")
+    let zip_code = tags.get("addr:postcode")
         .or_else(|| tags.get("postal_code"))
         .map_or("", |val| &val[..]);
     zip_code

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -451,7 +451,7 @@ mod tests {
             c.get_poi_id(&tags(&[
                 ("bob", "bobette"),
                 ("titi", "tata"),
-                ("foo", "bar")
+                ("foo", "bar"),
             ],))
         );
         assert_eq!(
@@ -459,7 +459,7 @@ mod tests {
             c.get_poi_id(&tags(&[
                 ("bob", "bobitta"),
                 ("titi", "toto"),
-                ("foo", "bar")
+                ("foo", "bar"),
             ],))
         );
         assert_eq!(
@@ -467,7 +467,7 @@ mod tests {
             c.get_poi_id(&tags(&[
                 ("bob", "bobette"),
                 ("titi", "toto"),
-                ("foo", "bar")
+                ("foo", "bar"),
             ],))
         );
         assert_eq!(
@@ -475,7 +475,7 @@ mod tests {
             c.get_poi_id(&tags(&[
                 ("bob", "bobitta"),
                 ("titi", "tata"),
-                ("foo", "bar")
+                ("foo", "bar"),
             ],))
         );
     }

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -63,16 +63,14 @@ pub fn streets(
                 way.tags.get("highway").map_or(false, |v| !v.is_empty())
                     && way.tags.get("name").map_or(false, |v| !v.is_empty())
             }
-            osmpbfreader::OsmObj::Relation(ref rel) => rel
-                .tags
+            osmpbfreader::OsmObj::Relation(ref rel) => rel.tags
                 .get("type")
                 .map_or(false, |v| v == "associatedStreet"),
             _ => false,
         }
     }
     info!("reading pbf...");
-    let objs_map = pbf
-        .get_objs_and_deps(is_valid_obj)
+    let objs_map = pbf.get_objs_and_deps(is_valid_obj)
         .context("Error occurred when reading pbf")?;
     info!("reading pbf done.");
     let mut street_rel: StreetWithRelationSet = BTreeSet::new();

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -126,8 +126,7 @@ fn attach_stops_to_admins<'a, It: Iterator<Item = &'a mut mimir::Stop>>(
 fn merge_collection<T: Ord>(target: &mut Vec<T>, source: Vec<T>) {
     use std::collections::BTreeSet;
     let tmp = replace(target, vec![]);
-    *target = tmp
-        .into_iter()
+    *target = tmp.into_iter()
         .chain(source)
         .collect::<BTreeSet<_>>()
         .into_iter()

--- a/tests/bragi_poi_test.rs
+++ b/tests/bragi_poi_test.rs
@@ -88,8 +88,7 @@ fn poi_admin_address_test(bragi: &BragiHandler) {
 
     // the first element returned should be the poi 'Le-Mée-sur-Seine Courtilleraies'
     let poi = geocodings.first().unwrap();
-    let properties = poi
-        .get("properties")
+    let properties = poi.get("properties")
         .and_then(|json| json.as_array())
         .unwrap();
     let keys = [

--- a/tests/bragi_stops_test.rs
+++ b/tests/bragi_stops_test.rs
@@ -116,8 +116,7 @@ fn stop_attached_to_admin_test(bragi: &BragiHandler) {
     // this stop area is in the boundary of the admin 'Vaux-le-Pénil',
     // it should have been associated to it
     assert_eq!(get_value(stop, "city"), "Vaux-le-Pénil");
-    let admins = stop
-        .get("administrative_regions")
+    let admins = stop.get("administrative_regions")
         .and_then(|a| a.as_array());
     assert_eq!(admins.map(|a| a.len()).unwrap_or(0), 1);
 }
@@ -134,8 +133,7 @@ fn stop_no_admin_test(bragi: &BragiHandler) {
     assert_eq!(get_value(stop, "name"), "Far west station");
     assert_eq!(get_value(stop, "id"), "stop_area:SA:station_no_city");
     assert_eq!(get_value(stop, "city"), "");
-    let admins = stop
-        .get("administrative_regions")
+    let admins = stop.get("administrative_regions")
         .and_then(|a| a.as_array());
     assert_eq!(admins.map(|a| a.len()).unwrap_or(0), 0);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -127,8 +127,7 @@ impl<'a> ElasticSearchWrapper<'a> {
     /// simple search on an index
     /// assert that the result is OK and transform it to a json Value
     pub fn search(&self, word: &str) -> serde_json::Value {
-        let res = self
-            .rubber
+        let res = self.rubber
             .get(&format!("munin/_search?q={}", word))
             .unwrap();
         assert!(res.status == hyper::Ok);
@@ -136,8 +135,7 @@ impl<'a> ElasticSearchWrapper<'a> {
     }
 
     pub fn search_on_global_stop_index(&self, word: &str) -> serde_json::Value {
-        let res = self
-            .rubber
+        let res = self.rubber
             .get(&format!("munin_global_stops/_search?q={}", word))
             .unwrap();
         assert!(res.status == hyper::Ok);
@@ -203,8 +201,7 @@ impl<'a> ElasticSearchWrapper<'a> {
                             v.into_iter()
                                 .filter_map(|json| {
                                     into_object(json).and_then(|obj| {
-                                        let doc_type = obj
-                                            .get("_type")
+                                        let doc_type = obj.get("_type")
                                             .and_then(|doc_type| doc_type.as_str())
                                             .map(|doc_type| doc_type.into());
 


### PR DESCRIPTION
A recent PR https://github.com/CanalTP/mimirsbrunn/pull/226 added a too verbose log in case of an ignored address.

This PR just remove the useless part of this log.
The change in the log has no impact on the existing tests, so no test comes along this small fix.
