### PR TITLE
remove useless log

### DIFF
--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -167,10 +167,7 @@ where
             })
             .filter(|a| {
                 !a.street.street_name.is_empty() || {
-                    info!(
-                        "Address {}:{:?}:{:?} has no street name and has been ignored.",
-                        a.id, a.coord, a.street
-                    );
+                    debug!("Address {} has no street name and has been ignored.", a.id);
                     false
                 }
             });

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -133,7 +133,7 @@ where
             })
             .filter(|a| {
                 !a.street.street_name.is_empty() || {
-                    info!("Address {} has no street name and has been ignored.", a.id);
+                    debug!("Address {} has no street name and has been ignored.", a.id);
                     false
                 }
             });


### PR DESCRIPTION
in the bano dataset there are 284917 addresses without a street name so
it flood the logs, I propose to move the log as debug (are remove the
debug dump of the address