### PR TITLE
Clean warning

### DIFF
--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -193,8 +193,7 @@ impl From<mimir::Admin> for GeocodingResponse {
 fn get_admin_type(adm: &mimir::Admin) -> String {
     match adm.zone_type {
         Some(t) => format!("{:?}", t).to_snake_case(),
-        // TODO below return administrative_region when admin_type is removed
-        None => adm.admin_type.to_string(),
+        None => "administrative_region".to_string(),
     }
 }
 

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -288,22 +288,6 @@ impl Members for Stop {
     }
 }
 
-#[deprecated]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub enum AdminType {
-    City,
-    Unknown,
-}
-
-impl fmt::Display for AdminType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            AdminType::City => write!(f, "city"),
-            AdminType::Unknown => write!(f, "administrative_region"),
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Admin {
     pub id: String,
@@ -330,30 +314,17 @@ pub struct Admin {
     )]
     pub bbox: Option<geo::Bbox<f64>>,
 
-    #[serde(default = "default_admin_city")]
-    pub admin_type: AdminType, // deprecated, to be removed after the new zone_type deployment
     #[serde(default)]
     pub zone_type: Option<ZoneType>,
     #[serde(default)]
     pub parent_id: Option<String>, // id of the Admin's parent (from the cosmogony's hierarchy)
 }
 
-fn default_admin_city() -> AdminType {
-    AdminType::Unknown //this way an Admin with no ZoneType won't be a city
-}
-
 impl Admin {
     pub fn is_city(&self) -> bool {
         match self.zone_type {
             Some(ZoneType::City) => true,
-            Some(_) => false,
-            None => {
-                // maintain the retrocompatibility for the moment, but this should be removed
-                match self.admin_type {
-                    AdminType::City => true,
-                    _ => false,
-                }
-            }
+            _ => false,
         }
     }
 }

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -455,9 +455,6 @@ impl MimirObject for Admin {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Street {
     pub id: String,
-    #[deprecated]
-    #[serde(default)]
-    pub street_name: String, // deprecated field only there for retrocompatibility, to remove once migration is complete
     #[serde(default)]
     pub name: String,
     pub administrative_regions: Vec<Arc<Admin>>,

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -221,7 +221,6 @@ mod tests {
     use super::*;
     use cosmogony::ZoneType;
     use geo::prelude::BoundingBox;
-    use mimir::AdminType;
 
     fn p(x: f64, y: f64) -> ::geo::Point<f64> {
         ::geo::Point(::geo::Coordinate { x: x, y: y })
@@ -267,7 +266,6 @@ mod tests {
             bbox: boundary.bbox(),
             boundary: Some(boundary),
             insee: "outlook".to_string(),
-            admin_type: AdminType::City,
             zone_type: zt,
             parent_id: parent_offset.map(|id| id.into()),
         }

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -85,7 +85,7 @@ impl Bano {
         admins_from_insee: &AdminFromInsee,
         admins_geofinder: &AdminGeoFinder,
     ) -> mimir::Addr {
-        let street_name = format!("{} ({})", self.street, self.city);
+        let street_label = format!("{} ({})", self.street, self.city);
         let addr_name = format!("{} {}", self.nb, self.street);
         let addr_label = format!("{} ({})", addr_name, self.city);
         let street_id = format!("street:{}", self.fantoir().to_string());
@@ -109,9 +109,8 @@ impl Bano {
 
         let street = mimir::Street {
             id: street_id,
-            street_name: self.street.clone(),
             name: self.street,
-            label: street_name.to_string(),
+            label: street_label.to_string(),
             administrative_regions: admins,
             weight: weight,
             zip_codes: vec![self.zip.clone()],

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -39,9 +39,9 @@ extern crate serde_json;
 extern crate structopt;
 extern crate osmpbfreader;
 
-use cosmogony::{Cosmogony, Zone, ZoneIndex, ZoneType};
+use cosmogony::{Cosmogony, Zone, ZoneIndex};
 use failure::Error;
-use mimir::objects::{Admin, AdminType};
+use mimir::objects::Admin;
 use mimir::rubber::Rubber;
 use mimirsbrunn::osm_reader::admin;
 use mimirsbrunn::utils::normalize_admin_weight;
@@ -68,11 +68,6 @@ impl IntoAdmin for Zone {
         let zip_codes = admin::read_zip_codes(&self.tags);
         let label = self.label;
         let weight = get_weight(&self.tags, &self.center_tags);
-        let admin_type = if self.zone_type == Some(ZoneType::City) {
-            AdminType::City
-        } else {
-            AdminType::Unknown
-        };
         let center = self.center.map_or(mimir::Coord::default(), |c| {
             mimir::Coord::new(c.lng(), c.lat())
         });
@@ -92,7 +87,6 @@ impl IntoAdmin for Zone {
             bbox: self.bbox,
             boundary: self.boundary,
             coord: center,
-            admin_type: admin_type,
             zone_type: self.zone_type,
             parent_id: parent_osm_id,
         }

--- a/src/bin/ntfs2mimir.rs
+++ b/src/bin/ntfs2mimir.rs
@@ -188,7 +188,7 @@ fn test_bad_connection_string() {
     };
     let causes = run(args)
         .unwrap_err()
-        .causes()
+        .iter_chain()
         .into_iter()
         .map(|cause| format!("{}", cause))
         .collect::<Vec<String>>();
@@ -212,7 +212,7 @@ fn test_bad_file() {
     };
     let causes = run(args)
         .unwrap_err()
-        .causes()
+        .iter_chain()
         .into_iter()
         .map(|cause| format!("{}", cause))
         .collect::<Vec<String>>();

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -71,7 +71,7 @@ pub struct OpenAddresse {
 
 impl OpenAddresse {
     pub fn into_addr(self, admins_geofinder: &AdminGeoFinder) -> mimir::Addr {
-        let street_name = format!("{} ({})", self.street, self.city);
+        let street_label = format!("{} ({})", self.street, self.city);
         let addr_name = format!("{} {}", self.number, self.street);
         let addr_label = format!("{} ({})", addr_name, self.city);
         let street_id = format!("street:{}", self.id); // TODO check if thats ok
@@ -84,9 +84,8 @@ impl OpenAddresse {
 
         let street = mimir::Street {
             id: street_id,
-            street_name: self.street.clone(),
             name: self.street,
-            label: street_name.to_string(),
+            label: street_label.to_string(),
             administrative_regions: admins,
             weight: weight,
             zip_codes: vec![self.postcode.clone()],

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -143,11 +143,6 @@ pub fn read_administrative_regions(
             let zip_codes = read_zip_codes(&relation.tags);
             let boundary = build_boundary(relation, &objects);
             let zone_type = get_zone_type(level, city_level);
-            let admin_type = if zone_type == Some(ZoneType::City) {
-                mimir::AdminType::City
-            } else {
-                mimir::AdminType::Unknown
-            };
 
             let weight = relation
                 .tags
@@ -175,7 +170,6 @@ pub fn read_administrative_regions(
                 coord: coord_center.unwrap_or_else(|| make_centroid(&boundary)),
                 bbox: boundary.as_ref().and_then(|b| b.bbox()),
                 boundary: boundary,
-                admin_type: admin_type,
                 zone_type: zone_type,
                 parent_id: None,
             };

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -100,7 +100,6 @@ pub fn streets(
                 let admin = get_street_admin(admins_geofinder, objs_map, way);
                 ret ret(street_list.push(mimir::Street {
                     id: way.id.0.to_string(),
-                    street_name: way_name.to_string(),
                     name: way_name.to_string(),
                     label: format_label(&admin, way_name),
                     weight: 0.,
@@ -161,7 +160,6 @@ pub fn streets(
             let admins = get_street_admin(admins_geofinder, objs_map, way);
             ret ret(street_list.push(mimir::Street {
                 id: way.id.0.to_string(),
-                street_name: way_name.to_string(),
                 name: way_name.to_string(),
                 label: format_label(&admins, way_name),
                 weight: 0.,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -74,7 +74,7 @@ where
 {
     let _guard = mimir::logger_init();
     if let Err(err) = run(O::from_args()) {
-        for cause in err.causes() {
+        for cause in err.iter_chain() {
             error!("{}", cause);
         }
         Err(err)

--- a/tests/cosmogony2mimir_test.rs
+++ b/tests/cosmogony2mimir_test.rs
@@ -79,7 +79,6 @@ pub fn cosmogony2mimir_test(es_wrapper: ::ElasticSearchWrapper) {
                 epsilon = f64::EPSILON
             );
             assert!(livry_sur_seine.coord.is_valid());
-            assert_eq!(livry_sur_seine.admin_type, mimir::AdminType::City);
             assert_eq!(livry_sur_seine.zone_type, Some(ZoneType::City));
         }
         _ => panic!("should be an admin"),

--- a/tests/osm2mimir_test.rs
+++ b/tests/osm2mimir_test.rs
@@ -79,7 +79,7 @@ pub fn osm2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
     if let mimir::Place::Admin(ref creteil) = admin_regions[0] {
         assert_eq!(creteil.name, "Créteil");
         assert_eq!(creteil.level, 7);
-        assert_eq!(creteil.admin_type, mimir::AdminType::Unknown);
+        assert!(creteil.zone_type.is_none());
     } else {
         panic!("creteil should be an admin");
     }

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -68,7 +68,6 @@ pub fn rubber_zero_downtime_test(mut es: ::ElasticSearchWrapper) {
 
     let bob = Street {
         id: "bob".to_string(),
-        street_name: "bob's street".to_string(),
         name: "bob's street".to_string(),
         label: "bob's name".to_string(),
         administrative_regions: vec![],
@@ -89,7 +88,6 @@ pub fn rubber_zero_downtime_test(mut es: ::ElasticSearchWrapper) {
 
     let bobette = Street {
         id: "bobette".to_string(),
-        street_name: "bobette's street".to_string(),
         name: "bobette's street".to_string(),
         label: "bobette's name".to_string(),
         administrative_regions: vec![],

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -33,7 +33,6 @@ use geo;
 use geo::prelude::BoundingBox;
 use hyper;
 use mimir::rubber::{self, Rubber};
-use mimir::AdminType::City;
 use mimir::{Admin, Coord, MimirObject, Street};
 use serde_json::value::Value;
 use std;
@@ -162,7 +161,6 @@ pub fn rubber_custom_id(mut es: ::ElasticSearchWrapper) {
         coord: Coord::new(2.68326290f64, 48.5110722f64),
         bbox: boundary.bbox(),
         boundary: Some(boundary),
-        admin_type: City,
         zone_type: Some(ZoneType::City),
         parent_id: None,
     };
@@ -244,7 +242,6 @@ pub fn rubber_ghost_index_cleanup(mut es: ::ElasticSearchWrapper) {
         coord: Coord::new(2.68326290f64, 48.5110722f64),
         boundary: None,
         bbox: None,
-        admin_type: City,
         zone_type: Some(ZoneType::City),
         parent_id: None,
     };


### PR DESCRIPTION
now that there has been a mimir release, we can drop the retro compatibility on the old stuff and get rid of the warnings:
* remove `AdminType` (deprecated in favor on the more fine grained ZoneType)
* remove `street_name` (renamed `name` for coherence and better ES boost on the `name` field search
* remove a `failure` warning

There is on last warning in the project that will be corrected in another PR (since there can be more discussion on it, I prefer to split it).