### PR TITLE
fix useless method

### DIFF
--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -308,7 +308,7 @@ pub fn features(
     if indexes.is_empty() {
         // if there is no indexes, rs_es search with index "_all"
         // but we want to return an error in this case.
-        return Err(BragiError::IndexNotFound);
+        return Err(BragiError::ObjectNotFound);
     }
 
     let result: SearchResult<serde_json::Value> = try!(

--- a/tests/bragi_filter_types_test.rs
+++ b/tests/bragi_filter_types_test.rs
@@ -93,6 +93,7 @@ pub fn bragi_filter_types_test(es_wrapper: ::ElasticSearchWrapper) {
     street_by_id_test(&bragi);
     stop_by_id_test(&bragi);
     stop_area_that_does_not_exists(&bragi);
+    stop_area_invalid_index(&bragi);
 }
 
 fn no_type_no_dataset_test(bragi: &BragiHandler) {
@@ -225,7 +226,9 @@ fn stop_area_that_does_not_exists(bragi: &BragiHandler) {
 }
 
 fn stop_area_invalid_index(bragi: &BragiHandler) {
-    // if the index does not exists, we get a 404 with "impossible to find object"
+    // if the index does not exists, we get a 404 with "Unable to find object" too
+    // it's not trivial to get a better error than a not found object (like a 'not found dataset' error)
+    // because the data might just not have been imported yet
     let response = bragi
         .raw_get("/features/stop_area:SA:second_station::AA?pt_dataset=invalid_dataset")
         .unwrap();
@@ -233,5 +236,5 @@ fn stop_area_invalid_index(bragi: &BragiHandler) {
     assert_eq!(response.status, Some(NotFound));
 
     let result_body = iron_test::response::extract_body_to_string(response);
-    assert!(result_body.contains("Impossible to find object"));
+    assert!(result_body.contains("Unable to find object"));
 }


### PR DESCRIPTION
A test method was never called (my bad :confused: ).

The thing is that the test was not passing either, because if we look for a non-existing index, we won't have a specific error as the test state, but a generic one (no object found). (I think this was implemented like this because an index might be missing if no data of that type has been imported yet).

This is done this way because the rubber `get_indexes` method always returns a non-empty list of elements (there is always at least "munin_geo_data" returned)

I think the get_indexes must also be refactored, but it will be for another PR.
I'd vote for:
* https://github.com/CanalTP/mimirsbrunn/blob/master/libs/mimir/src/rubber.rs#L233 => I don't see why it should be the case, we should add all pt_dataset
* if a pt_dataset does not exist, return an `IndexNotFound` error.
* I don't know when you want to search on `munin_global_stops`

As this refactor concerns more Kisio's use case, I'll let you do it.
