### PR TITLE
Don't check if index exist before doing a query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
  "navitia_model 0.1.0 (git+https://github.com/CanalTP/navitia_model)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustless 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -904,7 +904,7 @@ dependencies = [
  "geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -947,7 +947,7 @@ dependencies = [
  "osmpbfreader 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustless 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "rs-es"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2476,7 +2476,7 @@ dependencies = [
 "checksum rental 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "f098d5bfcbc5b929baf992ca6e09244daf4b47d1aedba3a808364faf48bd036e"
 "checksum rental-impl 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "cb24fb6b34fdd7b264154ea85c34bf9d3a9ac1355163b6e22ab8262f9f4a73f1"
 "checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
-"checksum rs-es 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df7598a759ee12e4e46a86ca83dfafc0d0cde9ea2bfd8e02fc4cf78d728230bf"
+"checksum rs-es 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "99ae20cbdcc58993d35040892fdf366dd0152ca447a21c7587506af819c85ab2"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -237,7 +237,7 @@ fn query(
     q: &str,
     pt_datasets: &[&str],
     all_data: bool,
-    mut client: &mut rs_es::Client,
+    client: &mut rs_es::Client,
     match_type: MatchType,
     offset: u64,
     limit: u64,
@@ -248,7 +248,7 @@ fn query(
     let query_type = match_type.to_string();
     let query = build_query(q, match_type, coord, shape, pt_datasets, all_data);
 
-    let indexes = try!(get_indexes(all_data, &pt_datasets, types, &mut client));
+    let indexes = get_indexes(all_data, &pt_datasets, types);
 
     debug!("ES indexes: {:?}", indexes);
 
@@ -266,6 +266,7 @@ fn query(
 
     let result: SearchResult<serde_json::Value> = client
         .search_query()
+        .with_ignore_unavailable(true)
         .with_indexes(
             &indexes
                 .iter()
@@ -301,7 +302,7 @@ pub fn features(
     let mut client = rs_es::Client::new(cnx).unwrap();
     client.set_read_timeout(timeout);
 
-    let indexes = try!(get_indexes(all_data, &pt_datasets, &[], &mut client));
+    let indexes = get_indexes(all_data, &pt_datasets, &[]);
 
     debug!("ES indexes: {:?}", indexes);
 
@@ -314,6 +315,7 @@ pub fn features(
     let result: SearchResult<serde_json::Value> = try!(
         client
             .search_query()
+            .with_ignore_unavailable(true)
             .with_indexes(
                 &indexes
                     .iter()

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -178,12 +178,7 @@ pub fn build_proximity_with_boost(coord: &Coord, boost: f64) -> Query {
         ).build()
 }
 
-
-pub fn get_indexes(
-    all_data: bool,
-    pt_datasets: &[&str],
-    types: &[&str],
-) -> Vec<String> {
+pub fn get_indexes(all_data: bool, pt_datasets: &[&str], types: &[&str]) -> Vec<String> {
     if all_data {
         return vec!["munin".to_string()];
     }
@@ -195,7 +190,7 @@ pub fn get_indexes(
         0 => (),
         1 => {
             for pt_dataset in pt_datasets.iter() {
-                    pt_dataset_indexes.push(format!("munin_stop_{}", pt_dataset));
+                pt_dataset_indexes.push(format!("munin_stop_{}", pt_dataset));
             }
         }
         _ => pt_dataset_indexes.push("munin_global_stops".to_string()),
@@ -621,16 +616,10 @@ pub fn test_invalid_url_no_port() {
 #[test]
 fn test_make_indexes_impl() {
     // all_data
-    assert_eq!(
-        get_indexes(true, &[], &[]),
-        vec!["munin"]
-    );
+    assert_eq!(get_indexes(true, &[], &[]), vec!["munin"]);
 
     // no dataset and no types
-    assert_eq!(
-        get_indexes(false, &[], &[]),
-        vec!["munin_geo_data"]
-    );
+    assert_eq!(get_indexes(false, &[], &[]), vec!["munin_geo_data"]);
 
     // dataset fr + no types
     assert_eq!(
@@ -686,11 +675,7 @@ fn test_make_indexes_impl() {
     // dataset fr types poi, city, street, house without public_transport:stop_area
     //  => munin_stop_fr is not included
     assert_eq!(
-        get_indexes(
-            false,
-            &["fr"],
-            &["poi", "city", "street", "house"],
-        ),
+        get_indexes(false, &["fr"], &["poi", "city", "street", "house"],),
         vec!["munin_poi", "munin_admin", "munin_street", "munin_addr"]
     );
 }

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -178,69 +178,37 @@ pub fn build_proximity_with_boost(coord: &Coord, boost: f64) -> Query {
         ).build()
 }
 
-pub fn is_existing_index(client: &mut rs_es::Client, index: &str) -> Result<bool, EsError> {
-    if index.is_empty() {
-        return Ok(false);
-    }
-    match client.open_index(&index) {
-        //This error indicates that the search index is absent in ElasticSearch.
-        Err(EsError::EsError(_)) => Ok(false),
-        Err(e) => Err(e),
-        Ok(_) => Ok(true),
-    }
-}
 
 pub fn get_indexes(
     all_data: bool,
     pt_datasets: &[&str],
     types: &[&str],
-    client: &mut rs_es::Client,
-) -> Result<Vec<String>, EsError> {
-    make_indexes_impl(all_data, pt_datasets, types, |index| {
-        is_existing_index(client, index)
-    })
-}
-
-pub fn make_indexes_impl<F: FnMut(&str) -> Result<bool, EsError>>(
-    all_data: bool,
-    pt_datasets: &[&str],
-    types: &[&str],
-    mut is_existing_index: F,
-) -> Result<Vec<String>, EsError> {
+) -> Vec<String> {
     if all_data {
-        return Ok(vec!["munin".to_string()]);
+        return vec!["munin".to_string()];
     }
 
     let mut result: Vec<String> = vec![];
-    let mut push = |result: &mut Vec<_>, i: &str| -> Result<(), EsError> {
-        if try!(is_existing_index(i)) {
-            result.push(i.into());
-        }
-        Ok(())
-    };
 
     let mut pt_dataset_indexes: Vec<String> = vec![];
     match pt_datasets.len() {
         0 => (),
         1 => {
             for pt_dataset in pt_datasets.iter() {
-                try!(push(
-                    &mut pt_dataset_indexes,
-                    format!("munin_stop_{}", pt_dataset).as_str(),
-                ))
+                    pt_dataset_indexes.push(format!("munin_stop_{}", pt_dataset));
             }
         }
-        _ => try!(push(&mut pt_dataset_indexes, "munin_global_stops")),
+        _ => pt_dataset_indexes.push("munin_global_stops".to_string()),
     };
 
     match types.len() {
         0 => {
-            try!(push(&mut result, &"munin_geo_data".to_string()));
+            result.push("munin_geo_data".to_string());
             result.append(&mut pt_dataset_indexes);
         }
         _ => {
             for type_ in types.iter().filter(|t| **t != "public_transport:stop_area") {
-                try!(push(&mut result, &get_indexes_by_type(type_)));
+                result.push(get_indexes_by_type(type_));
             }
             if types.contains(&"public_transport:stop_area") {
                 result.append(&mut pt_dataset_indexes);
@@ -248,7 +216,7 @@ pub fn make_indexes_impl<F: FnMut(&str) -> Result<bool, EsError>>(
         }
     }
 
-    Ok(result)
+    result
 }
 
 impl Rubber {
@@ -434,7 +402,7 @@ impl Rubber {
 
     pub fn get_address(&mut self, coord: &Coord) -> Result<Vec<Place>, EsError> {
         let types = vec!["house".into(), "street".into()];
-        let indexes = get_indexes(false, &[], &types, &mut self.es_client)?;
+        let indexes = get_indexes(false, &[], &types);
         let distance = rs_u::Distance::new(1000., rs_u::DistanceUnit::Meter);
         let geo_distance =
             Query::build_geo_distance("coord", (coord.lat(), coord.lon()), distance).build();
@@ -446,6 +414,7 @@ impl Rubber {
         let result: SearchResult<serde_json::Value> = self
             .es_client
             .search_query()
+            .with_ignore_unavailable(true)
             .with_indexes(
                 &indexes
                     .iter()
@@ -490,12 +459,6 @@ impl Rubber {
                 .with_context(|_| format!("Error occurred when deleting index: {}", i))?;
         }
         Ok(())
-    }
-
-    pub fn is_existing_index(&self, name: &String) -> Result<bool, String> {
-        self.get(&name)
-            .map_err(|e| e.to_string())
-            .map(|res| res.status == StatusCode::Ok)
     }
 
     /// add a list of new indexes to the alias
@@ -657,31 +620,28 @@ pub fn test_invalid_url_no_port() {
 
 #[test]
 fn test_make_indexes_impl() {
-    fn ok_index(_index: &str) -> Result<bool, EsError> {
-        Ok(true)
-    }
     // all_data
     assert_eq!(
-        make_indexes_impl(true, &[], &[], ok_index).unwrap(),
+        get_indexes(true, &[], &[]),
         vec!["munin"]
     );
 
     // no dataset and no types
     assert_eq!(
-        make_indexes_impl(false, &[], &[], ok_index).unwrap(),
+        get_indexes(false, &[], &[]),
         vec!["munin_geo_data"]
     );
 
     // dataset fr + no types
     assert_eq!(
-        make_indexes_impl(false, &["fr"], &[], ok_index).unwrap(),
+        get_indexes(false, &["fr"], &[]),
         vec!["munin_geo_data", "munin_stop_fr"]
     );
 
     // no dataset + types poi, city, street, house and public_transport:stop_area
     // => munin_stop is not included
     assert_eq!(
-        make_indexes_impl(
+        get_indexes(
             false,
             &[],
             &[
@@ -691,20 +651,19 @@ fn test_make_indexes_impl() {
                 "house",
                 "public_transport:stop_area",
             ],
-            ok_index,
-        ).unwrap(),
+        ),
         vec!["munin_poi", "munin_admin", "munin_street", "munin_addr"]
     );
 
     // no dataset fr + type public_transport:stop_area only
     assert_eq!(
-        make_indexes_impl(false, &[], &["public_transport:stop_area"], ok_index).unwrap(),
+        get_indexes(false, &[], &["public_transport:stop_area"]),
         Vec::<String>::new()
     );
 
     // dataset fr + types poi, city, street, house and public_transport:stop_area
     assert_eq!(
-        make_indexes_impl(
+        get_indexes(
             false,
             &["fr"],
             &[
@@ -714,8 +673,7 @@ fn test_make_indexes_impl() {
                 "house",
                 "public_transport:stop_area",
             ],
-            ok_index,
-        ).unwrap(),
+        ),
         vec![
             "munin_poi",
             "munin_admin",
@@ -728,37 +686,11 @@ fn test_make_indexes_impl() {
     // dataset fr types poi, city, street, house without public_transport:stop_area
     //  => munin_stop_fr is not included
     assert_eq!(
-        make_indexes_impl(
+        get_indexes(
             false,
             &["fr"],
             &["poi", "city", "street", "house"],
-            ok_index,
-        ).unwrap(),
+        ),
         vec!["munin_poi", "munin_admin", "munin_street", "munin_addr"]
     );
-
-    // dataset fr types poi, city, street, house without public_transport:stop_area
-    // and the function is_existing_index with a result "false" as non of the index
-    // is present in elasticsearch
-    assert_eq!(
-        make_indexes_impl(
-            false,
-            &["fr"],
-            &["poi", "city", "street", "house"],
-            |_index| Ok::<_, EsError>(false),
-        ).unwrap(),
-        Vec::<String>::new()
-    );
-
-    // dataset fr types poi, city, street, house without public_transport:stop_area
-    // and the function is_existing_index with an error in the result (Elasticsearch is absent..)
-    match make_indexes_impl(
-        false,
-        &["fr"],
-        &["poi", "city", "street", "house"],
-        |_index| Err::<bool, _>(EsError::EsError("Elasticsearch".into())),
-    ) {
-        Err(EsError::EsError(e)) => assert_eq!(e, "Elasticsearch"),
-        _ => assert!(false),
-    }
 }

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -184,31 +184,20 @@ pub fn get_indexes(all_data: bool, pt_datasets: &[&str], types: &[&str]) -> Vec<
     }
 
     let mut result: Vec<String> = vec![];
+    if types.is_empty() {
+        result.push("munin_geo_data".to_string());
+    } else {
+        for type_ in types.iter().filter(|t| **t != "public_transport:stop_area") {
+            result.push(get_indexes_by_type(type_));
+        }
+    }
 
-    let mut pt_dataset_indexes: Vec<String> = vec![];
-    match pt_datasets.len() {
-        0 => (),
-        1 => {
-            for pt_dataset in pt_datasets.iter() {
-                pt_dataset_indexes.push(format!("munin_stop_{}", pt_dataset));
-            }
-        }
-        _ => pt_dataset_indexes.push("munin_global_stops".to_string()),
-    };
-
-    match types.len() {
-        0 => {
-            result.push("munin_geo_data".to_string());
-            result.append(&mut pt_dataset_indexes);
-        }
-        _ => {
-            for type_ in types.iter().filter(|t| **t != "public_transport:stop_area") {
-                result.push(get_indexes_by_type(type_));
-            }
-            if types.contains(&"public_transport:stop_area") {
-                result.append(&mut pt_dataset_indexes);
-            }
-        }
+    if types.is_empty() || types.contains(&"public_transport:stop_area") {
+        match pt_datasets {
+            [] => (),
+            [dataset] => result.push(format!("munin_stop_{}", dataset)),
+            _ => result.push("munin_global_stops".to_string()),
+        };
     }
 
     result


### PR DESCRIPTION
We use `ignore_unavailable` to ignore index that don't exist to not have
to check if the index exist before.

https://www.elastic.co/guide/en/elasticsearch/reference/2.4/multi-index.html

waiting for https://github.com/benashford/rs-es/pull/121 fork in the second commit of this PR, don't read that.