### PR TITLE
add codes to admin

### DIFF
--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -185,6 +185,7 @@ impl From<mimir::Admin> for GeocodingResponse {
             postcode: postcode,
             label: label,
             bbox: other.bbox,
+            codes: other.codes,
             ..Default::default()
         }
     }

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -318,6 +318,9 @@ pub struct Admin {
     pub zone_type: Option<ZoneType>,
     #[serde(default)]
     pub parent_id: Option<String>, // id of the Admin's parent (from the cosmogony's hierarchy)
+
+    #[serde(default)]
+    pub codes: Vec<Code>,
 }
 
 impl Admin {

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -268,6 +268,7 @@ mod tests {
             insee: "outlook".to_string(),
             zone_type: zt,
             parent_id: parent_offset.map(|id| id.into()),
+            codes: vec![],
         }
     }
 

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -44,6 +44,7 @@ use failure::Error;
 use mimir::objects::Admin;
 use mimir::rubber::Rubber;
 use mimirsbrunn::osm_reader::admin;
+use mimirsbrunn::osm_reader::osm_utils;
 use mimirsbrunn::utils::normalize_admin_weight;
 use std::collections::BTreeMap;
 
@@ -89,6 +90,7 @@ impl IntoAdmin for Zone {
             coord: center,
             zone_type: self.zone_type,
             parent_id: parent_osm_id,
+            codes: osm_utils::get_osm_codes_from_tags(&self.tags),
         }
     }
 }

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -38,7 +38,7 @@ use super::OsmPbfReader;
 use cosmogony::ZoneType;
 use geo::prelude::BoundingBox;
 use itertools::Itertools;
-use osm_reader::osm_utils::make_centroid;
+use osm_reader::osm_utils::{get_osm_codes_from_tags, make_centroid};
 use std::collections::BTreeSet;
 use utils::normalize_admin_weight;
 
@@ -172,6 +172,7 @@ pub fn read_administrative_regions(
                 boundary: boundary,
                 zone_type: zone_type,
                 parent_id: None,
+                codes: get_osm_codes_from_tags(&relation.tags),
             };
             administrative_regions.push(admin);
         }

--- a/src/osm_reader/osm_utils.rs
+++ b/src/osm_reader/osm_utils.rs
@@ -66,3 +66,16 @@ pub fn make_centroid(boundary: &Option<MultiPolygon<f64>>) -> mimir::Coord {
         mimir::Coord::default()
     }
 }
+
+pub fn get_osm_codes_from_tags(tags: &osmpbfreader::Tags) -> Vec<mimir::Code> {
+    // read codes from osm tags
+    // for the moment we only use:
+    // * ISO3166 codes (mainly to get country codes)
+    // * ref:* tags (to get NUTS codes, INSEE code (even if we have a custom field for them), ...)
+    tags.iter()
+        .filter(|(k, _)| k.starts_with("ISO3166") || k.starts_with("ref:"))
+        .map(|property| mimir::Code {
+            name: property.0.to_string(),
+            value: property.1.to_string(),
+        }).collect()
+}

--- a/tests/canonical_import_process_test.rs
+++ b/tests/canonical_import_process_test.rs
@@ -143,6 +143,15 @@ fn melun_test(bragi: &BragiHandler) {
     assert_eq!(cityhall_admins[2]["label"], "France hexagonale");
     assert_eq!(cityhall_admins[2]["name"], "France hexagonale");
     assert_eq!(cityhall_admins[2]["zone_type"], "country");
+    assert_eq!(
+        cityhall_admins[2]["codes"],
+        json!([
+                    {"name": "ISO3166-1", "value": "FR"},
+                    {"name": "ISO3166-1:alpha2", "value": "FR"},
+                    {"name": "ISO3166-1:alpha3", "value": "FRA"},
+                    {"name": "ISO3166-1:numeric", "value": "250"},
+    ])
+    );
 
     // the poi should have been associated to an address
     let poi_addr = cityhall["address"].as_object().unwrap();

--- a/tests/cosmogony2mimir_test.rs
+++ b/tests/cosmogony2mimir_test.rs
@@ -30,6 +30,7 @@
 
 use cosmogony::ZoneType;
 use mimir;
+use std::collections::BTreeMap;
 use std::f64;
 
 /// load a cosmogony file in mimir.
@@ -120,6 +121,19 @@ pub fn cosmogony2mimir_test(es_wrapper: ::ElasticSearchWrapper) {
             assert_eq!(fr.insee, "");
             assert_eq!(fr.level, 2);
             assert_eq!(fr.zip_codes, Vec::<String>::new());
+            assert_eq!(
+                fr.codes
+                    .iter()
+                    .map(|c| (c.name.as_str(), c.value.as_str()))
+                    .collect::<BTreeMap<_, _>>(),
+                vec![
+                    ("ISO3166-1", "FR"),
+                    ("ISO3166-1:alpha2", "FR"),
+                    ("ISO3166-1:alpha3", "FRA"),
+                    ("ISO3166-1:numeric", "250"),
+                ].into_iter()
+                .collect()
+            );
             assert_eq!(fr.weight, 0f64);
             assert!(fr.coord.is_valid());
             assert_eq!(fr.zone_type, Some(ZoneType::Country));

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -161,6 +161,7 @@ pub fn rubber_custom_id(mut es: ::ElasticSearchWrapper) {
         boundary: Some(boundary),
         zone_type: Some(ZoneType::City),
         parent_id: None,
+        codes: vec![],
     };
 
     // we index our admin
@@ -242,6 +243,7 @@ pub fn rubber_ghost_index_cleanup(mut es: ::ElasticSearchWrapper) {
         bbox: None,
         zone_type: Some(ZoneType::City),
         parent_id: None,
+        codes: vec![],
     };
 
     // we index our admin


### PR DESCRIPTION
add codes to Admins (like it is done for stops)

We need this mainly to associate a poi to a country (to correctly format
the phone number)

Since a poi is associated to it's admin hierarchy we only need to return
the country codes from the osm tags.

To be a bit more generic than our need, we fill the `codes` with:
* ISO3166 codes
* ref:* tags (to get NUTS codes, INSEE code (even if we have a custom
field for them), ...)