### PR TITLE
Add a default ES timeout

### DIFF
--- a/libs/bragi/src/lib.rs
+++ b/libs/bragi/src/lib.rs
@@ -59,6 +59,7 @@ extern crate num_cpus;
 use iron::prelude::Chain;
 use iron::{Iron, Protocol};
 use rustless::Application;
+use std::time;
 use structopt::StructOpt;
 
 extern crate logger;
@@ -99,12 +100,20 @@ pub struct Args {
         env = "BRAGI_NB_THREADS"
     )]
     nb_threads: usize,
+    /// Default timeout in ms on ES connection. It's the network timeout, not a timeout given to ES.
+    #[structopt(
+        short = "e",
+        long = "default-es-timeout",
+        env = "BRAGI_DEFAULT_ES_TIMEOUT"
+    )]
+    default_es_timeout: Option<u64>,
 }
 
 pub fn runserver() {
     let args = Args::from_args();
     let api = api::ApiEndPoint {
         es_cnx_string: args.connection_string,
+        default_es_timeout: args.default_es_timeout.map(time::Duration::from_millis),
     }.root();
     let app = Application::new(api);
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -242,7 +242,10 @@ pub struct BragiHandler {
 
 impl BragiHandler {
     pub fn new(url: String) -> BragiHandler {
-        let api = bragi::api::ApiEndPoint { es_cnx_string: url }.root();
+        let api = bragi::api::ApiEndPoint {
+            es_cnx_string: url,
+            default_es_timeout: None,
+        }.root();
         BragiHandler {
             app: rustless::Application::new(api),
         }


### PR DESCRIPTION
add a cli param `default-es-timeout` (env var `BRAGI_DEFAULT_ES_TIMEOUT`) to set the default timeout to ES connections (in ms)

If present we'll take the existing query `timeout` parameter, else the default one.

for information the current error when hitting the timeout is:

```
HTTP/1.1 503 Service Unavailable
Access-Control-Allow-Origin: *
Content-Type: application/json
{
    "long": "invalid query Resource temporarily unavailable (os error
11)",
    "short": "query error"
}

```

A bit cryptic, but I think that'll do for the moment.

I don't see an easy way to test this.