### PR TITLE
add cli params to control the number of shard/replicas

### DIFF
--- a/json/addr_settings.json
+++ b/json/addr_settings.json
@@ -1,7 +1,6 @@
 {
     "template": "munin_addr_*",
     "settings": {
-        "number_of_shards": "5",
         "analysis": {
             "filter": {
                 "prefix_filter": {

--- a/json/admin_settings.json
+++ b/json/admin_settings.json
@@ -1,7 +1,6 @@
 {
     "template": "munin_admin_*",
     "settings": {
-        "number_of_shards": "1",
         "analysis": {
             "filter": {
                 "prefix_filter": {

--- a/json/poi_settings.json
+++ b/json/poi_settings.json
@@ -1,7 +1,6 @@
 {
     "template": "munin_poi_*",
     "settings": {
-        "number_of_shards": "1",
         "analysis": {
             "filter": {
                 "prefix_filter": {

--- a/json/settings.json
+++ b/json/settings.json
@@ -7,6 +7,8 @@
                     "synonyms": []
                 }
             }
-        }
+        },
+        "number_of_shards": "to_be_replaced",
+        "number_of_replicas": "to_be_replaced"
     }
 }

--- a/json/stop_settings.json
+++ b/json/stop_settings.json
@@ -1,7 +1,6 @@
 {
     "template": "munin_*stop*",
     "settings": {
-        "number_of_shards": "1",
         "analysis": {
             "filter": {
                 "prefix_filter": {

--- a/json/street_settings.json
+++ b/json/street_settings.json
@@ -1,7 +1,6 @@
 {
     "template": "munin_street_*",
     "settings": {
-        "number_of_shards": "2",
         "analysis": {
             "filter": {
                 "prefix_filter": {

--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -1,6 +1,6 @@
 use csv;
 use failure::ResultExt;
-use mimir::rubber::Rubber;
+use mimir::rubber::{IndexSettings, Rubber};
 use mimir::Addr;
 use par_map::ParMap;
 use serde::de::DeserializeOwned;
@@ -12,6 +12,7 @@ pub fn import_addresses<T, F>(
     rubber: &mut Rubber,
     has_headers: bool,
     nb_threads: usize,
+    index_settings: IndexSettings,
     dataset: &str,
     files: impl IntoIterator<Item = PathBuf>,
     into_addr: F,
@@ -21,7 +22,7 @@ where
     T: DeserializeOwned + Send + 'static,
 {
     let addr_index = rubber
-        .make_index(dataset)
+        .make_index(dataset, &index_settings)
         .with_context(|_| format!("Error occurred when making index {}", dataset))?;
     info!("Add data in elasticsearch db.");
 

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -40,7 +40,7 @@ extern crate mimirsbrunn;
 extern crate structopt;
 
 use failure::ResultExt;
-use mimir::rubber::Rubber;
+use mimir::rubber::{IndexSettings, Rubber};
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use mimirsbrunn::osm_reader::admin::read_administrative_regions;
 use mimirsbrunn::osm_reader::make_osm_reader;
@@ -81,6 +81,24 @@ struct Args {
     /// POI configuration.
     #[structopt(short = "j", long = "poi-config", parse(from_os_str))]
     poi_config: Option<PathBuf>,
+    /// Number of shards for the admin es index
+    #[structopt(long = "nb-admin-shards", default_value = "1")]
+    nb_admin_shards: usize,
+    /// Number of replicas for the es index
+    #[structopt(long = "nb-admin-replicas", default_value = "1")]
+    nb_admin_replicas: usize,
+    /// Number of shards for the street es index
+    #[structopt(long = "nb-street-shards", default_value = "2")]
+    nb_street_shards: usize,
+    /// Number of replicas for the street es index
+    #[structopt(long = "nb-street-replicas", default_value = "1")]
+    nb_street_replicas: usize,
+    /// Number of shards for the es index
+    #[structopt(long = "nb-poi-shards", default_value = "1")]
+    nb_poi_shards: usize,
+    /// Number of replicas for the es index
+    #[structopt(long = "nb-poi-replicas", default_value = "1")]
+    nb_poi_replicas: usize,
 }
 
 fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
@@ -107,9 +125,13 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         compute_street_weight(&mut streets);
 
         if args.import_way {
+            let street_index_settings = IndexSettings {
+                nb_shards: args.nb_street_shards,
+                nb_replicas: args.nb_street_replicas,
+            };
             info!("importing streets into Mimir");
             let nb_streets = rubber
-                .index(&args.dataset, streets.into_iter())
+                .index(&args.dataset, &street_index_settings, streets.into_iter())
                 .with_context(|_| {
                     format!(
                         "Error occurred when requesting street number in {}",
@@ -120,9 +142,16 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         }
     }
     if args.import_admin {
+        let admin_index_settings = IndexSettings {
+            nb_shards: args.nb_admin_shards,
+            nb_replicas: args.nb_admin_replicas,
+        };
         let nb_admins = rubber
-            .index(&args.dataset, admins_geofinder.admins())
-            .with_context(|_| {
+            .index(
+                &args.dataset,
+                &admin_index_settings,
+                admins_geofinder.admins(),
+            ).with_context(|_| {
                 format!(
                     "Error occurred when requesting admin number in {}",
                     args.dataset
@@ -150,9 +179,13 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         info!("Adding addresss in poi");
         add_address(&mut pois, &mut rubber);
 
+        let poi_index_settings = IndexSettings {
+            nb_shards: args.nb_poi_shards,
+            nb_replicas: args.nb_poi_replicas,
+        };
         info!("Importing pois into Mimir");
         let nb_pois = rubber
-            .index(&args.dataset, pois.into_iter())
+            .index(&args.dataset, &poi_index_settings, pois.into_iter())
             .context("Importing pois into Mimir")?;
 
         info!("Nb of indexed pois: {}", nb_pois);

--- a/tests/cosmogony2mimir_test.rs
+++ b/tests/cosmogony2mimir_test.rs
@@ -94,8 +94,8 @@ pub fn cosmogony2mimir_test(es_wrapper: ::ElasticSearchWrapper) {
     let sem = &res[0];
     match sem {
         &mimir::Place::Admin(ref sem) => {
-            assert_eq!(sem.id, "admin:osm:relation:424253843");
             assert_eq!(sem.name, "Fausse Seine-et-Marne");
+            assert_eq!(sem.id, "admin:osm:relation:424253843");
             assert_eq!(sem.label, "Fausse Seine-et-Marne, France hexagonale");
             assert_eq!(sem.insee, "77");
             assert_eq!(sem.zip_codes, Vec::<String>::new());


### PR DESCRIPTION
fix https://github.com/CanalTP/mimirsbrunn/issues/267

add 2 cli parameters on each data importer:
* `--nb-shards`
* `--nb-replicas`

for `osm2mimir` it is a bit more complex since it can import several
types, so we can add several cli param, one for each type:
`--nb-poi-shards` `--nb-admin-shards` `--nb-street-shards` and the same
for the replicas.