### PR TITLE
Do not expose internal serveur message to the client

### DIFF
--- a/tests/canonical_import_process_test.rs
+++ b/tests/canonical_import_process_test.rs
@@ -35,6 +35,7 @@ use super::count_types;
 use super::get_poi_type_ids;
 use super::get_types;
 use super::get_value;
+use super::to_json;
 use super::BragiHandler;
 
 /// Test the whole mimirsbrunn pipeline with all the import binary
@@ -173,4 +174,7 @@ pub fn bragi_invalid_es_test(_es_wrapper: ::ElasticSearchWrapper) {
     // the autocomplete gives a 503
     let resp = bragi.raw_get("/autocomplete?q=toto").unwrap();
     assert_eq!(resp.status, Some(iron::status::Status::ServiceUnavailable));
+    let json = to_json(resp);
+    assert_eq!(json.get("short"), Some(&json!("query error")));
+    assert_eq!(json.get("long"), Some(&json!("service unavailable")));
 }


### PR DESCRIPTION
return in the json response a generic "internal server error" on
error 500 (or "service unavailable" when ES is not reachable, status code 503) not to have
error messages like:

```json
{
   "short":"query error",
   "long":"invalid query 503 Service Unavailable -
{\"error\":{\"root_cause\":[],\"type\":\"search_phase_execution_exception\",\"reason\":\"all
shards
failed\",\"phase\":\"query\",\"grouped\":true,\"failed_shards\":[]},\"status\":503}"
}
```

the error is logged to trace it.