### PR TITLE
Timeout for the ES query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
  "navitia_model 0.1.0 (git+https://github.com/CanalTP/navitia_model)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustless 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -437,7 +437,7 @@ name = "error"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -906,7 +906,7 @@ dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -949,7 +949,7 @@ dependencies = [
  "osmpbfreader 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustless 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1083,7 +1083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "rs-es"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2478,7 +2478,7 @@ dependencies = [
 "checksum rental 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "f098d5bfcbc5b929baf992ca6e09244daf4b47d1aedba3a808364faf48bd036e"
 "checksum rental-impl 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "cb24fb6b34fdd7b264154ea85c34bf9d3a9ac1355163b6e22ab8262f9f4a73f1"
 "checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
-"checksum rs-es 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "99ae20cbdcc58993d35040892fdf366dd0152ca447a21c7587506af819c85ab2"
+"checksum rs-es 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a3ef5f0d1f98cce3a194c362e1165960a5912aab864f3882d66adbc1b85d002a"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ slog-envlogger = "2.1.0"
 slog-async = "2.2.0"
 structopt = "0.2"
 csv = "1.0.0-beta.4"
-rs-es = {version = "0.10", default-features = false}
+rs-es = {version = "0.10.5", default-features = false}
 regex = "*"
 osmpbfreader = "0.11.2"
 chrono = "0.4"

--- a/libs/bragi/Cargo.toml
+++ b/libs/bragi/Cargo.toml
@@ -11,7 +11,7 @@ slog-scope = "4.0"
 rustless = "0.10"
 urlencoded = "0.4"
 valico = "1.0"
-rs-es = {version = "0.10", default-features = false}
+rs-es = {version = "0.10.5", default-features = false}
 serde = {version = "1", features = ["rc"]}
 serde_json = "1"
 serde_derive = "1"

--- a/libs/bragi/src/api.rs
+++ b/libs/bragi/src/api.rs
@@ -86,10 +86,11 @@ fn parse_timeout(
         .find("timeout")
         .and_then(|v| v.as_u64())
         .map(time::Duration::from_millis)
-        .and_then(|t| match default_timeout {
-            Some(dt) => Some(t.min(dt)),
-            None => Some(t),
-        }).or(default_timeout)
+        .map(|t| match default_timeout {
+            Some(dt) => t.min(dt),
+            None => t,
+        })
+        .or(default_timeout)
 }
 
 fn add_distance(autocomp_resp: &mut model::Autocomplete, origin_coord: &Coord) {

--- a/libs/bragi/src/api.rs
+++ b/libs/bragi/src/api.rs
@@ -89,8 +89,7 @@ fn parse_timeout(
         .map(|t| match default_timeout {
             Some(dt) => t.min(dt),
             None => t,
-        })
-        .or(default_timeout)
+        }).or(default_timeout)
 }
 
 fn add_distance(autocomp_resp: &mut model::Autocomplete, origin_coord: &Coord) {

--- a/libs/bragi/src/api.rs
+++ b/libs/bragi/src/api.rs
@@ -118,7 +118,7 @@ where
 
 pub struct ApiEndPoint {
     pub es_cnx_string: String,
-    pub default_es_max_timeout: Option<time::Duration>,
+    pub max_es_timeout: Option<time::Duration>,
 }
 
 impl ApiEndPoint {
@@ -249,7 +249,7 @@ impl ApiEndPoint {
                     timeout_param(params);
                 });
                 let cnx = self.es_cnx_string.clone();
-                let default_timeout = self.default_es_max_timeout.clone();
+                let default_timeout = self.max_es_timeout.clone();
                 endpoint.handle(move |client, params| {
                     let coord = ::mimir::Coord::new(
                         params.find("lon").and_then(|p| p.as_f64()).unwrap(),
@@ -280,7 +280,7 @@ impl ApiEndPoint {
                 });
 
                 let cnx = self.es_cnx_string.clone();
-                let default_timeout = self.default_es_max_timeout.clone();
+                let default_timeout = self.max_es_timeout.clone();
                 endpoint.handle(move |client, params| {
                     let id = params.find("id").unwrap().as_str().unwrap();
                     let pt_datasets = get_param_array(params, "pt_dataset");
@@ -309,7 +309,7 @@ impl ApiEndPoint {
                 });
 
                 let cnx = self.es_cnx_string.clone();
-                let default_timeout = self.default_es_max_timeout.clone();
+                let default_timeout = self.max_es_timeout.clone();
                 endpoint.handle(move |client, params| {
                     let q = params
                         .find("q")
@@ -370,7 +370,7 @@ impl ApiEndPoint {
                     timeout_param(params);
                 });
                 let cnx = self.es_cnx_string.clone();
-                let default_timeout = self.default_es_max_timeout.clone();
+                let default_timeout = self.max_es_timeout.clone();
                 endpoint.handle(move |client, params| {
                     let q = params
                         .find("q")

--- a/libs/bragi/src/lib.rs
+++ b/libs/bragi/src/lib.rs
@@ -100,20 +100,21 @@ pub struct Args {
         env = "BRAGI_NB_THREADS"
     )]
     nb_threads: usize,
-    /// Default timeout in ms on ES connection. It's the network timeout, not a timeout given to ES.
+    /// Default Max timeout in ms on ES connection.
+    /// This timeout is both a network timeout and a timeout given to ES.
     #[structopt(
         short = "e",
-        long = "default-es-timeout",
-        env = "BRAGI_DEFAULT_ES_TIMEOUT"
+        long = "default-es-max-timeout",
+        env = "BRAGI_DEFAULT_ES_MAX_TIMEOUT"
     )]
-    default_es_timeout: Option<u64>,
+    default_es_max_timeout: Option<u64>,
 }
 
 pub fn runserver() {
     let args = Args::from_args();
     let api = api::ApiEndPoint {
         es_cnx_string: args.connection_string,
-        default_es_timeout: args.default_es_timeout.map(time::Duration::from_millis),
+        default_es_max_timeout: args.default_es_max_timeout.map(time::Duration::from_millis),
     }.root();
     let app = Application::new(api);
 

--- a/libs/bragi/src/lib.rs
+++ b/libs/bragi/src/lib.rs
@@ -104,17 +104,17 @@ pub struct Args {
     /// This timeout is both a network timeout and a timeout given to ES.
     #[structopt(
         short = "e",
-        long = "default-es-max-timeout",
-        env = "BRAGI_DEFAULT_ES_MAX_TIMEOUT"
+        long = "max-es-timeout",
+        env = "BRAGI_MAX_ES_TIMEOUT"
     )]
-    default_es_max_timeout: Option<u64>,
+    max_es_timeout: Option<u64>,
 }
 
 pub fn runserver() {
     let args = Args::from_args();
     let api = api::ApiEndPoint {
         es_cnx_string: args.connection_string,
-        default_es_max_timeout: args.default_es_max_timeout.map(time::Duration::from_millis),
+        max_es_timeout: args.max_es_timeout.map(time::Duration::from_millis),
     }.root();
     let app = Application::new(api);
 

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -267,21 +267,19 @@ fn query(
             |err| error!("impossible to get ES_REQ_HISTOGRAM metrics"; "err" => err.to_string()),
         ).ok();
 
-    let timeout = timeout
-        .map(|t| t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9)
-        .map(|t| format!("{}s", t.to_string()));
+    let timeout = timeout.map(|t| format!("{:?}", t));
     let mut search_query = client.search_query();
+
     let search_query = search_query
         .with_ignore_unavailable(true)
         .with_indexes(&indexes)
         .with_query(&query)
         .with_from(offset)
         .with_size(limit);
-    let search_query = if let Some(timeout) = &timeout {
-        search_query.with_timeout(timeout.as_str())
-    } else {
-        search_query
-    };
+
+    if let Some(timeout) = &timeout {
+        search_query.with_timeout(timeout.as_str());
+    }
     let result = search_query.send()?;
 
     timer.map(|t| t.observe_duration());
@@ -331,9 +329,7 @@ pub fn features(
             |err| error!("impossible to get ES_REQ_HISTOGRAM metrics"; "err" => err.to_string()),
         ).ok();
 
-    let timeout = timeout
-        .map(|t| t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9)
-        .map(|t| format!("{}s", t.to_string()));
+    let timeout = timeout.map(|t| format!("{:?}", t));
     let mut search_query = client.search_query();
 
     let search_query = search_query
@@ -341,11 +337,10 @@ pub fn features(
         .with_indexes(&indexes)
         .with_query(&query);
 
-    let search_query = if let Some(timeout) = &timeout {
-        search_query.with_timeout(timeout.as_str())
-    } else {
-        search_query
-    };
+    if let Some(timeout) = &timeout {
+        search_query.with_timeout(timeout.as_str());
+    }
+
     let result = search_query.send()?;
 
     timer.map(|t| t.observe_duration());

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -34,7 +34,6 @@ use mimir::rubber::{collect, get_indexes};
 use prometheus;
 use rs_es;
 use rs_es::error::EsError;
-use rs_es::operations::search::SearchResult;
 use rs_es::query::Query;
 use rs_es::units as rs_u;
 use serde;
@@ -250,7 +249,10 @@ fn query(
     let query = build_query(q, match_type, coord, shape, pt_datasets, all_data);
 
     let indexes = get_indexes(all_data, &pt_datasets, types);
-
+    let indexes = indexes
+        .iter()
+        .map(|index| index.as_str())
+        .collect::<Vec<&str>>();
     debug!("ES indexes: {:?}", indexes);
 
     if indexes.is_empty() {
@@ -265,37 +267,21 @@ fn query(
             |err| error!("impossible to get ES_REQ_HISTOGRAM metrics"; "err" => err.to_string()),
         ).ok();
 
-    let result: SearchResult<serde_json::Value> = match timeout {
-        Some(t) => {
-            let duration = t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9;
-
-            client
-                .search_query()
-                .with_timeout(&format!("{}s", duration.to_string()))
-                .with_ignore_unavailable(true)
-                .with_indexes(
-                    &indexes
-                        .iter()
-                        .map(|index| index.as_str())
-                        .collect::<Vec<&str>>(),
-                ).with_query(&query)
-                .with_from(offset)
-                .with_size(limit)
-                .send()?
-        }
-        _ => client
-            .search_query()
-            .with_ignore_unavailable(true)
-            .with_indexes(
-                &indexes
-                    .iter()
-                    .map(|index| index.as_str())
-                    .collect::<Vec<&str>>(),
-            ).with_query(&query)
-            .with_from(offset)
-            .with_size(limit)
-            .send()?,
+    let timeout =
+        timeout.map(|t| format!("{:?}", t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9));
+    let mut search_query = client.search_query();
+    let search_query = search_query
+        .with_ignore_unavailable(true)
+        .with_indexes(&indexes)
+        .with_query(&query)
+        .with_from(offset)
+        .with_size(limit);
+    let search_query = if let Some(timeout) = &timeout {
+        search_query.with_timeout(timeout.as_str())
+    } else {
+        search_query
     };
+    let result = search_query.send()?;
 
     timer.map(|t| t.observe_duration());
 
@@ -324,6 +310,10 @@ pub fn features(
     client.set_write_timeout(timeout);
 
     let indexes = get_indexes(all_data, &pt_datasets, &[]);
+    let indexes = indexes
+        .iter()
+        .map(|index| index.as_str())
+        .collect::<Vec<&str>>();
 
     debug!("ES indexes: {:?}", indexes);
 
@@ -339,36 +329,22 @@ pub fn features(
         .map_err(
             |err| error!("impossible to get ES_REQ_HISTOGRAM metrics"; "err" => err.to_string()),
         ).ok();
-    let result: SearchResult<serde_json::Value> = match timeout {
-        Some(t) => {
-            let duration = t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9;
-            try!(
-                client
-                    .search_query()
-                    .with_timeout(&format!("{}s", duration.to_string()))
-                    .with_ignore_unavailable(true)
-                    .with_indexes(
-                        &indexes
-                            .iter()
-                            .map(|index| index.as_str())
-                            .collect::<Vec<&str>>()
-                    ).with_query(&query)
-                    .send()
-            )
-        }
-        _ => try!(
-            client
-                .search_query()
-                .with_ignore_unavailable(true)
-                .with_indexes(
-                    &indexes
-                        .iter()
-                        .map(|index| index.as_str())
-                        .collect::<Vec<&str>>()
-                ).with_query(&query)
-                .send()
-        ),
+
+    let timeout =
+        timeout.map(|t| format!("{:?}", t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9));
+    let mut search_query = client.search_query();
+
+    let search_query = search_query
+        .with_ignore_unavailable(true)
+        .with_indexes(&indexes)
+        .with_query(&query);
+
+    let search_query = if let Some(timeout) = &timeout {
+        search_query.with_timeout(timeout.as_str())
+    } else {
+        search_query
     };
+    let result = search_query.send()?;
 
     timer.map(|t| t.observe_duration());
 

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -267,8 +267,9 @@ fn query(
             |err| error!("impossible to get ES_REQ_HISTOGRAM metrics"; "err" => err.to_string()),
         ).ok();
 
-    let timeout =
-        timeout.map(|t| format!("{:?}", t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9));
+    let timeout = timeout
+        .map(|t| t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9)
+        .map(|t| format!("{}s", t.to_string()));
     let mut search_query = client.search_query();
     let search_query = search_query
         .with_ignore_unavailable(true)
@@ -330,8 +331,9 @@ pub fn features(
             |err| error!("impossible to get ES_REQ_HISTOGRAM metrics"; "err" => err.to_string()),
         ).ok();
 
-    let timeout =
-        timeout.map(|t| format!("{:?}", t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9));
+    let timeout = timeout
+        .map(|t| t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9)
+        .map(|t| format!("{}s", t.to_string()));
     let mut search_query = client.search_query();
 
     let search_query = search_query

--- a/libs/mimir/Cargo.toml
+++ b/libs/mimir/Cargo.toml
@@ -11,7 +11,7 @@ slog-scope = "4.0"
 slog-envlogger = "2.1.0"
 slog-stdlog = "3.0.2"
 slog-async = "2.2.0"
-rs-es = {version = "0.10", default-features = false}
+rs-es = {version = "0.10.5", default-features = false}
 serde = {version = "1", features = ["rc"]}
 serde_derive = "1"
 serde_json = "1"

--- a/libs/mimir/src/lib.rs
+++ b/libs/mimir/src/lib.rs
@@ -102,7 +102,7 @@ where
         builder
     };
     let drain = slog_async::Async::new(builder.build())
-        .chan_size(2560)
+        .chan_size(256)
         .build();
 
     let log = slog::Logger::root(drain.fuse(), slog_o!());

--- a/libs/mimir/src/lib.rs
+++ b/libs/mimir/src/lib.rs
@@ -102,7 +102,7 @@ where
         builder
     };
     let drain = slog_async::Async::new(builder.build())
-        .chan_size(256)
+        .chan_size(2560)
         .build();
 
     let log = slog::Logger::root(drain.fuse(), slog_o!());

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -432,20 +432,18 @@ impl Rubber {
 
         let timer = ES_REQ_HISTOGRAM.start_timer();
 
-        let timeout = timeout
-            .map(|t| t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9)
-            .map(|t| format!("{}s", t.to_string()));
+        let timeout = timeout.map(|t| format!("{:?}", t));
         let mut search_query = self.es_client.search_query();
+
         let search_query = search_query
             .with_ignore_unavailable(true)
             .with_indexes(&indexes)
             .with_query(&query)
             .with_size(1);
-        let search_query = if let Some(timeout) = &timeout {
-            search_query.with_timeout(timeout.as_str())
-        } else {
-            search_query
-        };
+
+        if let Some(timeout) = &timeout {
+            search_query.with_timeout(timeout.as_str());
+        }
         let result = search_query.send()?;
 
         timer.observe_duration();

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -432,8 +432,9 @@ impl Rubber {
 
         let timer = ES_REQ_HISTOGRAM.start_timer();
 
-        let timeout =
-            timeout.map(|t| format!("{:?}", t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9));
+        let timeout = timeout
+            .map(|t| t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9)
+            .map(|t| format!("{}s", t.to_string()));
         let mut search_query = self.es_client.search_query();
         let search_query = search_query
             .with_ignore_unavailable(true)

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -417,6 +417,11 @@ impl Rubber {
     ) -> Result<Vec<Place>, EsError> {
         let types = vec!["house".into(), "street".into()];
         let indexes = get_indexes(false, &[], &types);
+        let indexes = indexes
+            .iter()
+            .map(|index| index.as_str())
+            .collect::<Vec<&str>>();
+
         let distance = rs_u::Distance::new(1000., rs_u::DistanceUnit::Meter);
         let geo_distance =
             Query::build_geo_distance("coord", (coord.lat(), coord.lon()), distance).build();
@@ -427,36 +432,21 @@ impl Rubber {
 
         let timer = ES_REQ_HISTOGRAM.start_timer();
 
-        let result: SearchResult<serde_json::Value> = match timeout {
-            Some(t) => {
-                let duration = t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9;
-
-                self.es_client
-                    .search_query()
-                    .with_timeout(&format!("{}s", duration.to_string()))
-                    .with_ignore_unavailable(true)
-                    .with_indexes(
-                        &indexes
-                            .iter()
-                            .map(|index| index.as_str())
-                            .collect::<Vec<_>>(),
-                    ).with_query(&query)
-                    .with_size(1)
-                    .send()?
-            }
-            _ => self
-                .es_client
-                .search_query()
-                .with_ignore_unavailable(true)
-                .with_indexes(
-                    &indexes
-                        .iter()
-                        .map(|index| index.as_str())
-                        .collect::<Vec<_>>(),
-                ).with_query(&query)
-                .with_size(1)
-                .send()?,
+        let timeout =
+            timeout.map(|t| format!("{:?}", t.as_secs() as f64 + t.subsec_nanos() as f64 * 1e-9));
+        let mut search_query = self.es_client.search_query();
+        let search_query = search_query
+            .with_ignore_unavailable(true)
+            .with_indexes(&indexes)
+            .with_query(&query)
+            .with_size(1);
+        let search_query = if let Some(timeout) = &timeout {
+            search_query.with_timeout(timeout.as_str())
+        } else {
+            search_query
         };
+        let result = search_query.send()?;
+
         timer.observe_duration();
         collect(result)
     }

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -290,7 +290,7 @@ pub fn compute_poi_weight(pois_vec: &mut [Poi]) {
 pub fn add_address(pois_vec: &mut [Poi], rubber: &mut rubber::Rubber) {
     for poi in pois_vec {
         poi.address = rubber
-            .get_address(&poi.coord)
+            .get_address(&poi.coord, None)
             .ok()
             .and_then(|addrs| addrs.into_iter().next())
             .map(|addr| addr.address().unwrap());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -244,7 +244,7 @@ impl BragiHandler {
     pub fn new(url: String) -> BragiHandler {
         let api = bragi::api::ApiEndPoint {
             es_cnx_string: url,
-            default_es_max_timeout: None,
+            max_es_timeout: None,
         }.root();
         BragiHandler {
             app: rustless::Application::new(api),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -244,7 +244,7 @@ impl BragiHandler {
     pub fn new(url: String) -> BragiHandler {
         let api = bragi::api::ApiEndPoint {
             es_cnx_string: url,
-            default_es_timeout: None,
+            default_es_max_timeout: None,
         }.root();
         BragiHandler {
             app: rustless::Application::new(api),


### PR DESCRIPTION
A timeout parameter has been recently added (https://github.com/CanalTP/mimirsbrunn/commit/4b2d149bcc2958736791ab1073fed7f0e25b5f7b) but it handles only the network and not the time limit allowed to the ES query.

This PR proposes to use the same timeout both for the network and for the query.

This parameter can be defined at two places:
- as a command line argument launching bragi: `default_es_max_timeout=...`
- or directly into the user query: `timeout=...`

In this PR we changed the previous behavior: instead to overwrite the default timeout with the query one, we keep the minimum. In other words the default timeout becomes the max.