### PR TITLE
Fix labels normalization

### DIFF
--- a/json/addr_settings.json
+++ b/json/addr_settings.json
@@ -109,6 +109,9 @@
                                 "enabled": false
                             }
                         }
+                    },
+                    "norms": {
+                        "enabled": false
                     }
                 },
                 "full_label": {
@@ -134,6 +137,9 @@
                                 "enabled": false
                             }
                         }
+                    },
+                    "norms": {
+                        "enabled": false
                     }
                 },
                 "weight": { "type": "double" }

--- a/json/admin_settings.json
+++ b/json/admin_settings.json
@@ -109,6 +109,9 @@
                                 "enabled": false
                             }
                         }
+                    },
+                    "norms": {
+                        "enabled": false
                     }
                 },
                 "full_label": {
@@ -134,6 +137,9 @@
                                 "enabled": false
                             }
                         }
+                    },
+                    "norms": {
+                        "enabled": false
                     }
                 },
                 "weight": { "type": "double" },

--- a/json/poi_settings.json
+++ b/json/poi_settings.json
@@ -107,6 +107,9 @@
                                 "enabled": false
                             }
                         }
+                    },
+                    "norms": {
+                        "enabled": false
                     }
                 },
                 "label": {
@@ -133,6 +136,9 @@
                                 "enabled": false
                             }
                         }
+                    },
+                    "norms": {
+                        "enabled": false
                     }
                 },
                 "properties": {

--- a/json/stop_settings.json
+++ b/json/stop_settings.json
@@ -101,6 +101,9 @@
                                 "enabled": false
                             }
                         }
+                    },
+                    "norms": {
+                        "enabled": false
                     }
                 },
                 "full_label": {
@@ -126,6 +129,9 @@
                                 "enabled": false
                             }
                         }
+                    },
+                    "norms": {
+                        "enabled": false
                     }
                 },
                 "weight": {

--- a/json/street_settings.json
+++ b/json/street_settings.json
@@ -108,6 +108,9 @@
                                 "enabled": false
                             }
                         }
+                    },
+                    "norms": {
+                        "enabled": false
                     }
                 },
                 "full_label": {
@@ -133,6 +136,9 @@
                                 "enabled": false
                             }
                         }
+                    },
+                    "norms": {
+                        "enabled": false
                     }
                 },
                 "weight": { "type": "double" }


### PR DESCRIPTION
We don't want to use the size of a label since it is generated.
It has been implemented in https://github.com/CanalTP/mimirsbrunn/pull/229 but I forgot to also remove the norms for the full field (we want to boost a response when we match entire tokens.

The test case for us was that the query `Lyon` was having the results:

```
* Lyon, Coahoma County, Mississippi, United States <---- small village in
mississipi
* Lyon, Métropole de Lyon, Auvergne-Rhône-Alpes, France <---- big french
city with a lot of population
```

with this PR, we now have the french city first