### PR TITLE
More stable street id

### DIFF
--- a/libs/bragi/src/api.rs
+++ b/libs/bragi/src/api.rs
@@ -63,17 +63,20 @@ lazy_static! {
         "bragi_http_requests_total",
         "Total number of HTTP requests made.",
         &["handler", "method", "status"]
-    ).unwrap();
+    )
+    .unwrap();
     static ref HTTP_REQ_HISTOGRAM: prometheus::HistogramVec = register_histogram_vec!(
         "bragi_http_request_duration_seconds",
         "The HTTP request latencies in seconds.",
         &["handler", "method"],
         prometheus::exponential_buckets(0.001, 1.5, 25).unwrap()
-    ).unwrap();
+    )
+    .unwrap();
     static ref HTTP_IN_FLIGHT: prometheus::Gauge = register_gauge!(
         "bragi_http_requests_in_flight",
         "current number of http request being served"
-    ).unwrap();
+    )
+    .unwrap();
 }
 
 /// get the timeout from the query 'timeout' parameter
@@ -89,7 +92,8 @@ fn parse_timeout(
         .map(|t| match default_timeout {
             Some(dt) => t.min(dt),
             None => t,
-        }).or(default_timeout)
+        })
+        .or(default_timeout)
 }
 
 fn add_distance(autocomp_resp: &mut model::Autocomplete, origin_coord: &Coord) {
@@ -162,12 +166,14 @@ impl ApiEndPoint {
                 let method = client.endpoint.method.to_string();
 
                 HTTP_REQ_HISTOGRAM
-                    .get_metric_with(&labels!{
+                    .get_metric_with(&labels! {
                         "handler" => client.endpoint.path.path.as_str(),
                         "method" => method.as_str(),
-                    }).map(|timer| {
+                    })
+                    .map(|timer| {
                         client.ext.insert::<Timer>(timer.start_timer());
-                    }).unwrap_or_else(|err| {
+                    })
+                    .unwrap_or_else(|err| {
                         error!("impossible to get HTTP_REQ_HISTOGRAM metrics";
                                "err" => err.to_string());
                     });
@@ -181,11 +187,12 @@ impl ApiEndPoint {
                 HTTP_IN_FLIGHT.dec();
 
                 HTTP_COUNTER
-                    .get_metric_with(&labels!{
+                    .get_metric_with(&labels! {
                         "handler" => client.endpoint.path.path.as_str(),
                         "method" => method.as_str(),
                         "status" => code.as_str(),
-                    }).map(|counter| counter.inc())
+                    })
+                    .map(|counter| counter.inc())
                     .unwrap_or_else(|err| {
                         error!("impossible to get HTTP_COUNTER metrics"; "err" => err.to_string());
                     });

--- a/libs/bragi/src/lib.rs
+++ b/libs/bragi/src/lib.rs
@@ -102,11 +102,7 @@ pub struct Args {
     nb_threads: usize,
     /// Default Max timeout in ms on ES connection.
     /// This timeout is both a network timeout and a timeout given to ES.
-    #[structopt(
-        short = "e",
-        long = "max-es-timeout",
-        env = "BRAGI_MAX_ES_TIMEOUT"
-    )]
+    #[structopt(short = "e", long = "max-es-timeout", env = "BRAGI_MAX_ES_TIMEOUT")]
     max_es_timeout: Option<u64>,
 }
 
@@ -115,7 +111,8 @@ pub fn runserver() {
     let api = api::ApiEndPoint {
         es_cnx_string: args.connection_string,
         max_es_timeout: args.max_es_timeout.map(time::Duration::from_millis),
-    }.root();
+    }
+    .root();
     let app = Application::new(api);
 
     let (logger_before, logger_after) = Logger::new(None);

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -49,7 +49,8 @@ lazy_static! {
         "The elasticsearch request latencies in seconds.",
         &["search_type"],
         prometheus::exponential_buckets(0.001, 1.5, 25).unwrap()
-    ).unwrap();
+    )
+    .unwrap();
 }
 
 /// takes a ES json blob and build a Place from it
@@ -105,8 +106,10 @@ fn build_proximity_with_boost(coord: &Coord, boost: f64) -> Query {
                 "coord",
                 rs_u::Location::LatLon(coord.lat, coord.lon),
                 rs_u::Distance::new(50f64, rs_u::DistanceUnit::Kilometer),
-            ).build_gauss(),
-        ).build()
+            )
+            .build_gauss(),
+        )
+        .build()
 }
 
 // filter to handle PT coverages
@@ -122,7 +125,8 @@ fn build_coverage_condition(pt_datasets: &[&str]) -> Query {
             Query::build_terms("coverages")
                 .with_values(pt_datasets)
                 .build(),
-        ]).build()
+        ])
+        .build()
 }
 
 fn build_query(
@@ -148,7 +152,8 @@ fn build_query(
             match_type_with_boost::<Stop>(18.),
             match_type_with_boost::<Poi>(1.5),
             match_type_with_boost::<Street>(1.),
-        ]).with_boost(30.)
+        ])
+        .with_boost(30.)
         .build();
 
     // Priorization by query string
@@ -185,7 +190,8 @@ fn build_query(
                 .with_must_not(Query::build_exists("house_number").build())
                 .build(),
             Query::build_match("house_number", q.to_string()).build(),
-        ]).build();
+        ])
+        .build();
 
     use rs_es::query::CombinationMinimumShouldMatch;
     use rs_es::query::MinimumShouldMatch;
@@ -212,7 +218,8 @@ fn build_query(
                 CombinationMinimumShouldMatch::new(1i64, 75f64),
                 CombinationMinimumShouldMatch::new(6i64, 60f64),
                 CombinationMinimumShouldMatch::new(9i64, 40f64),
-            ])).build(),
+            ]))
+            .build(),
     };
 
     let mut filters = vec![house_number_condition, matching_condition];
@@ -265,7 +272,8 @@ fn query(
         .map(|h| h.start_timer())
         .map_err(
             |err| error!("impossible to get ES_REQ_HISTOGRAM metrics"; "err" => err.to_string()),
-        ).ok();
+        )
+        .ok();
 
     let timeout = timeout.map(|t| format!("{:?}", t));
     let mut search_query = client.search_query();
@@ -327,7 +335,8 @@ pub fn features(
         .map(|h| h.start_timer())
         .map_err(
             |err| error!("impossible to get ES_REQ_HISTOGRAM metrics"; "err" => err.to_string()),
-        ).ok();
+        )
+        .ok();
 
     let timeout = timeout.map(|t| format!("{:?}", t));
     let mut search_query = client.search_query();
@@ -388,7 +397,8 @@ pub fn autocomplete(
         make_shape(&shape),
         &types,
         timeout,
-    ).map_err(model::BragiError::from)?;
+    )
+    .map_err(model::BragiError::from)?;
     if results.is_empty() {
         query(
             &q,
@@ -402,7 +412,8 @@ pub fn autocomplete(
             make_shape(&shape),
             &types,
             timeout,
-        ).map_err(model::BragiError::from)
+        )
+        .map_err(model::BragiError::from)
     } else {
         Ok(results)
     }

--- a/libs/docker_wrapper/src/lib.rs
+++ b/libs/docker_wrapper/src/lib.rs
@@ -53,24 +53,21 @@ impl DockerWrapper {
 
     fn setup(&mut self) -> Result<(), Box<Error>> {
         info!("Launching ES docker");
-        let status = try!(
-            Command::new("docker")
-                .args(&["run", "-d", "--name=mimirsbrunn_tests", "elasticsearch:2"])
-                .status()
-        );
+        let status = try!(Command::new("docker")
+            .args(&["run", "-d", "--name=mimirsbrunn_tests", "elasticsearch:2"])
+            .status());
         if !status.success() {
             return Err(format!("`docker run` failed {}", &status).into());
         }
 
         // we need to get the ip of the container if the container has been run on another machine
-        let container_ip_cmd = try!(
-            Command::new("docker")
-                .args(&[
-                    "inspect",
-                    "--format={{.NetworkSettings.IPAddress}}",
-                    "mimirsbrunn_tests",
-                ]).output()
-        );
+        let container_ip_cmd = try!(Command::new("docker")
+            .args(&[
+                "inspect",
+                "--format={{.NetworkSettings.IPAddress}}",
+                "mimirsbrunn_tests",
+            ])
+            .output());
 
         let container_ip = std::str::from_utf8(container_ip_cmd.stdout.as_slice())?.trim();
 

--- a/libs/mimir/src/lib.rs
+++ b/libs/mimir/src/lib.rs
@@ -73,10 +73,10 @@ pub fn logger_init() -> (slog_scope::GlobalLoggerGuard, ()) {
         let mut drain = slog_json::Json::new(std::io::stderr())
             .add_default_keys()
             .add_key_value(o!(
-                    "module" => slog::FnValue(|rinfo : &slog::Record| {
-                        rinfo.module()
-                    })
-        ));
+                        "module" => slog::FnValue(|rinfo : &slog::Record| {
+                            rinfo.module()
+                        })
+            ));
         if s == "pretty" {
             drain = drain.set_pretty(true);
         }

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -75,7 +75,8 @@ lazy_static! {
         "bragi_elasticsearch_reverse_duration_seconds",
         "The elasticsearch reverse request latencies in seconds.",
         prometheus::exponential_buckets(0.001, 1.5, 25).unwrap()
-    ).unwrap();
+    )
+    .unwrap();
 }
 
 // Rubber is an wrapper around elasticsearch API
@@ -189,8 +190,10 @@ pub fn build_proximity_with_boost(coord: &Coord, boost: f64) -> Query {
                 "coord",
                 rs_u::Location::LatLon(coord.lat(), coord.lon()),
                 rs_u::Distance::new(50f64, rs_u::DistanceUnit::Kilometer),
-            ).build_gauss(),
-        ).build()
+            )
+            .build_gauss(),
+        )
+        .build()
 }
 
 pub fn get_indexes(all_data: bool, pt_datasets: &[&str], types: &[&str]) -> Vec<String> {
@@ -278,13 +281,12 @@ impl Rubber {
         // storing the mapping in json is more convenient
         let settings = include_str!("../../../json/settings.json");
 
-        let mut settings_json_value = try!(
-            serde_json::from_str::<serde_json::Value>(&settings).map_err(|err| format_err!(
+        let mut settings_json_value = try!(serde_json::from_str::<serde_json::Value>(&settings)
+            .map_err(|err| format_err!(
                 "Error occurred when creating index: {} err: {}",
                 name,
                 err
-            ))
-        );
+            )));
 
         let synonyms: Vec<_> = SYNONYMS
             .iter()
@@ -309,7 +311,8 @@ impl Rubber {
                     name,
                     e.to_string()
                 )
-            }).and_then(|res| {
+            })
+            .and_then(|res| {
                 if res.status == StatusCode::Ok {
                     Ok(())
                 } else {
@@ -324,7 +327,8 @@ impl Rubber {
             .map_err(|e| {
                 info!("Error while creating template {}", name);
                 format_err!("Error: {} while creating template {}", e.to_string(), name)
-            }).and_then(|res| {
+            })
+            .and_then(|res| {
                 if res.status == StatusCode::Ok {
                     Ok(())
                 } else {
@@ -378,8 +382,10 @@ impl Rubber {
                                 a.pointer("/aliases")
                                     .and_then(|a| a.as_object())
                                     .map(|aliases| (i.clone(), aliases.keys().cloned().collect()))
-                            }).collect()
-                    }).unwrap_or_else(|| {
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_else(|| {
                         info!("no aliases for {}", base_index);
                         BTreeMap::new()
                     }))
@@ -552,7 +558,8 @@ impl Rubber {
                     v.es_id()
                         .into_iter()
                         .fold(Action::index(v), |action, id| action.with_id(id))
-                }).collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
         });
         for chunk in chunks.filter(|c| !c.is_empty()) {
             nb += chunk.len();

--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -42,7 +42,8 @@ where
                             .ok()
                     })
                 })
-        }).with_nb_threads(nb_threads)
+        })
+        .with_nb_threads(nb_threads)
         .par_map(into_addr)
         .filter(|a| {
             !a.street.name.is_empty() || {

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -148,7 +148,8 @@ impl AdminGeoFinder {
                 std::f32::INFINITY,
                 std::f32::NEG_INFINITY,
                 std::f32::INFINITY,
-            )).into_iter()
+            ))
+            .into_iter()
             .map(|(_, a)| {
                 let mut admin = (*a.1).clone();
                 admin.boundary = a.0.clone();
@@ -166,7 +167,8 @@ impl AdminGeoFinder {
                 std::f32::INFINITY,
                 std::f32::NEG_INFINITY,
                 std::f32::INFINITY,
-            )).into_iter()
+            ))
+            .into_iter()
             .map(|(_, a)| a.1.clone());
         Box::new(iter)
     }

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -159,7 +159,8 @@ where
         .map(|mut a| {
             a.boundary = None; // to save some space we remove the admin boundary
             (a.insee.clone(), Arc::new(a))
-        }).collect();
+        })
+        .collect();
 
     let index_settings = IndexSettings {
         nb_shards: nb_shards,

--- a/src/bin/ntfs2mimir.rs
+++ b/src/bin/ntfs2mimir.rs
@@ -49,12 +49,7 @@ use std::path::PathBuf;
 #[derive(Debug, StructOpt)]
 struct Args {
     /// NTFS directory.
-    #[structopt(
-        short = "i",
-        long = "input",
-        parse(from_os_str),
-        default_value = "."
-    )]
+    #[structopt(short = "i", long = "input", parse(from_os_str), default_value = ".")]
     input: PathBuf,
     /// Name of the dataset.
     #[structopt(short = "d", long = "dataset", default_value = "fr")]
@@ -88,20 +83,23 @@ fn to_mimir(
         .map(|cm_idx| mimir::CommercialMode {
             id: format!("commercial_mode:{}", navitia.commercial_modes[cm_idx].id),
             name: navitia.commercial_modes[cm_idx].name.clone(),
-        }).collect();
+        })
+        .collect();
     let physical_modes = navitia
         .get_corresponding_from_idx(idx)
         .into_iter()
         .map(|pm_idx| mimir::PhysicalMode {
             id: format!("physical_mode:{}", navitia.physical_modes[pm_idx].id),
             name: navitia.physical_modes[pm_idx].name.clone(),
-        }).collect();
+        })
+        .collect();
     let comments = navitia
         .comments
         .iter_from(&stop_area.comment_links)
         .map(|comment| mimir::Comment {
             name: comment.name.clone(),
-        }).collect();
+        })
+        .collect();
     let feed_publishers = navitia
         .get_corresponding_from_idx(idx)
         .into_iter()
@@ -116,7 +114,8 @@ fn to_mimir(
                 .website
                 .clone()
                 .unwrap_or_else(|| "".into()),
-        }).collect();
+        })
+        .collect();
 
     mimir::Stop {
         id: format!("stop_area:{}", stop_area.id),
@@ -137,14 +136,16 @@ fn to_mimir(
             .map(|&(ref t, ref v)| mimir::Code {
                 name: t.clone(),
                 value: v.clone(),
-            }).collect(),
+            })
+            .collect(),
         properties: stop_area
             .object_properties
             .iter()
             .map(|&(ref k, ref v)| mimir::Property {
                 key: k.clone(),
                 value: v.clone(),
-            }).collect(),
+            })
+            .collect(),
         feed_publishers: feed_publishers,
     }
 }
@@ -170,7 +171,8 @@ fn run(args: Args) -> Result<(), navitia_model::Error> {
                 .get_corresponding_from_idx::<_, navitia::StopPoint>(idx)
                 .len();
             (id, nb_stop_points as u32)
-        }).collect();
+        })
+        .collect();
     let mut stops: Vec<mimir::Stop> = navitia
         .stop_areas
         .iter()
@@ -188,7 +190,8 @@ fn run(args: Args) -> Result<(), navitia_model::Error> {
         &args.connection_string,
         &args.dataset,
         index_settings,
-    ).with_context(|_| {
+    )
+    .with_context(|_| {
         format!(
             "Error occurred when importing stops into {} on {}",
             args.dataset, args.connection_string

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -151,7 +151,8 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
                 &args.dataset,
                 &admin_index_settings,
                 admins_geofinder.admins(),
-            ).with_context(|_| {
+            )
+            .with_context(|_| {
                 format!(
                     "Error occurred when requesting admin number in {}",
                     args.dataset

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -175,7 +175,8 @@ fn run(args: Args) -> Result<(), failure::Error> {
         .filter_map(|stop: GtfsStop| {
             stop.incr_stop_point(&mut nb_stop_points);
             stop.try_into_with_warn()
-        }).collect();
+        })
+        .collect();
     set_weights(stops.iter_mut(), &nb_stop_points);
 
     let index_settings = IndexSettings {
@@ -188,7 +189,8 @@ fn run(args: Args) -> Result<(), failure::Error> {
         &args.connection_string,
         &args.dataset,
         index_settings,
-    ).context("Error while importing stops")?;
+    )
+    .context("Error while importing stops")?;
     Ok(())
 }
 
@@ -208,7 +210,8 @@ fn test_load_stops() {
         .filter_map(|stop: GtfsStop| {
             stop.incr_stop_point(&mut nb_stop_points);
             stop.try_into_with_warn()
-        }).collect();
+        })
+        .collect();
     let ids: Vec<_> = stops.iter().map(|s| s.id.clone()).sorted();
     assert_eq!(
         ids,

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -157,7 +157,8 @@ pub fn read_administrative_regions(
                         .get("population")?
                         .parse()
                         .ok()
-                }).unwrap_or(0.);
+                })
+                .unwrap_or(0.);
 
             let admin = mimir::Admin {
                 id: admin_id,

--- a/src/osm_reader/osm_utils.rs
+++ b/src/osm_reader/osm_utils.rs
@@ -77,5 +77,6 @@ pub fn get_osm_codes_from_tags(tags: &osmpbfreader::Tags) -> Vec<mimir::Code> {
         .map(|property| mimir::Code {
             name: property.0.to_string(),
             value: property.1.to_string(),
-        }).collect()
+        })
+        .collect()
 }

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -87,7 +87,8 @@ impl PoiConfig {
                 rule.osm_tags_filters
                     .iter()
                     .all(|f| tags.get(&f.key).map_or(false, |v| v == &f.value))
-            }).and_then(|rule| {
+            })
+            .and_then(|rule| {
                 self.poi_types
                     .iter()
                     .find(|poi_type| poi_type.id == rule.poi_type_id)
@@ -197,7 +198,8 @@ fn make_properties(tags: &osmpbfreader::Tags) -> Vec<mimir::Property> {
         .map(|property| mimir::Property {
             key: property.0.to_string(),
             value: property.1.to_string(),
-        }).collect()
+        })
+        .collect()
 }
 
 fn parse_poi(
@@ -361,7 +363,8 @@ mod tests {
             ],
             "rules": []
         }"#,
-        ).unwrap_err();
+        )
+        .unwrap_err();
         from_str(
             r#"{
             "poi_types": [{"id": "bob", "name": "Bob"}],
@@ -372,7 +375,8 @@ mod tests {
                 }
             ]
         }"#,
-        ).unwrap_err();
+        )
+        .unwrap_err();
     }
     #[test]
     fn check_with_colon() {

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -85,6 +85,7 @@ pub fn streets(
 
     for rel in objs_map.iter().filter_map(|(_, obj)| obj.relation()) {
         let way_name = rel.tags.get("name");
+
         for ref_obj in &rel.refs {
             use mdo::option::*;
             let objs_map = &objs_map;
@@ -99,7 +100,7 @@ pub fn streets(
                 way_name =<< way_name.or_else(|| way.tags.get("name"));
                 let admin = get_street_admin(admins_geofinder, objs_map, way);
                 ret ret(street_list.push(mimir::Street {
-                    id: way.id.0.to_string(),
+                    id: format!("street:osm:rel:{}", rel.id.0.to_string()),
                     name: way_name.to_string(),
                     label: format_label(&admin, way_name),
                     weight: 0.,
@@ -147,19 +148,21 @@ pub fn streets(
         };
     }
 
-    // Create a street for each way with osmid present in in objs_map
+    // Create a street for each way with osmid present in objs_map
     for way_ids in name_admin_map.values() {
         use mdo::option::*;
         let objs_map = &objs_map;
         let street_list = &mut street_list;
         let admins_geofinder = &admins_geofinder;
+
         mdo! {
-            obj =<< objs_map.get(&way_ids[0]);
+            min_id =<< way_ids.iter().min();
+            obj =<< objs_map.get(&min_id);
             way =<< obj.way();
             way_name =<< way.tags.get("name");
             let admins = get_street_admin(admins_geofinder, objs_map, way);
             ret ret(street_list.push(mimir::Street {
-                id: way.id.0.to_string(),
+                id: format!("street:osm:way:{}", way.id.0.to_string()),
                 name: way_name.to_string(),
                 label: format_label(&admins, way_name),
                 weight: 0.,

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -193,7 +193,8 @@ fn get_street_admin(
         .map(|node| geo::Coordinate {
             x: node.lon(),
             y: node.lat(),
-        }).next()
+        })
+        .next()
         .map_or(vec![], |c| admins_geofinder.get(&c))
 }
 

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -85,7 +85,6 @@ pub fn streets(
 
     for rel in objs_map.iter().filter_map(|(_, obj)| obj.relation()) {
         let way_name = rel.tags.get("name");
-
         for ref_obj in &rel.refs {
             use mdo::option::*;
             let objs_map = &objs_map;
@@ -154,7 +153,6 @@ pub fn streets(
         let objs_map = &objs_map;
         let street_list = &mut street_list;
         let admins_geofinder = &admins_geofinder;
-
         mdo! {
             min_id =<< way_ids.iter().min();
             obj =<< objs_map.get(&min_id);

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -99,7 +99,7 @@ pub fn streets(
                 way_name =<< way_name.or_else(|| way.tags.get("name"));
                 let admin = get_street_admin(admins_geofinder, objs_map, way);
                 ret ret(street_list.push(mimir::Street {
-                    id: format!("street:osm:rel:{}", rel.id.0.to_string()),
+                    id: format!("street:osm:relation:{}", rel.id.0.to_string()),
                     name: way_name.to_string(),
                     label: format_label(&admin, way_name),
                     weight: 0.,

--- a/tests/bano2mimir_test.rs
+++ b/tests/bano2mimir_test.rs
@@ -75,7 +75,8 @@ pub fn bano2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
         s =<< s.get("aliases");
         s =<< s.as_object();
         ret ret(s.keys().cloned().collect())
-    }.unwrap_or_else(Vec::new);
+    }
+    .unwrap_or_else(Vec::new);
     // for the moment 'munin' is hard coded, but hopefully that will change
     assert_eq!(
         aliases,
@@ -112,7 +113,8 @@ pub fn bano2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
         s =<< s.get("aliases");
         s =<< s.as_object();
         ret ret(s.keys().cloned().collect())
-    }.unwrap_or_else(Vec::new);
+    }
+    .unwrap_or_else(Vec::new);
     assert_eq!(
         aliases,
         vec!["munin", "munin_addr", "munin_addr_fr", "munin_geo_data"]

--- a/tests/bragi_filter_types_test.rs
+++ b/tests/bragi_filter_types_test.rs
@@ -186,14 +186,14 @@ fn admin_by_id_test(bragi: &BragiHandler) {
 }
 
 fn street_by_id_test(bragi: &BragiHandler) {
-    let all_20 = bragi.get("/features/161162362");
+    let all_20 = bragi.get("/features/street:osm:way:161162362");
     assert_eq!(all_20.len(), 1);
     let types = get_types(&all_20);
 
     let count = count_types(&types, "street");
     assert_eq!(count, 1);
 
-    assert_eq!(get_values(&all_20, "id"), vec!["161162362"]);
+    assert_eq!(get_values(&all_20, "id"), vec!["street:osm:way:161162362"]);
 }
 
 fn addr_by_id_test(bragi: &BragiHandler) {

--- a/tests/bragi_osm_test.rs
+++ b/tests/bragi_osm_test.rs
@@ -71,11 +71,9 @@ fn zip_code_test(bragi: &BragiHandler) {
     for postcodes in get_values(&all_20, "postcode") {
         assert!(postcodes.split(';').any(|p| p == "77000"));
     }
-    assert!(
-        get_values(&all_20, "postcode")
-            .iter()
-            .any(|r| *r == "77000;77003;77008;CP77001")
-    );
+    assert!(get_values(&all_20, "postcode")
+        .iter()
+        .any(|r| *r == "77000;77003;77008;CP77001"));
 
     let types = get_types(&all_20);
     let count = count_types(&types, "street");
@@ -111,11 +109,9 @@ fn zip_code_street_test(bragi: &BragiHandler) {
 fn zip_code_admin_test(bragi: &BragiHandler) {
     let all_20 = bragi.get("/autocomplete?q=77000 Vaux-le-Pénil");
     assert_eq!(all_20.len(), 4);
-    assert!(
-        get_values(&all_20, "postcode")
-            .iter()
-            .all(|r| *r == "77000",)
-    );
+    assert!(get_values(&all_20, "postcode")
+        .iter()
+        .all(|r| *r == "77000",));
     let types = get_types(&all_20);
     let count = count_types(&types, "street");
     assert_eq!(count, 3);

--- a/tests/bragi_stops_test.rs
+++ b/tests/bragi_stops_test.rs
@@ -263,7 +263,8 @@ fn features_stop_filtered_by_dataset_transcoverage_test(bragi: &BragiHandler) {
     let response = bragi
         .raw_get(
             "/features/stop_area:SA:known_by_all_dataset?pt_dataset[]=bobette&pt_dataset[]=bobito",
-        ).unwrap();
+        )
+        .unwrap();
     assert_eq!(response.status.unwrap(), iron::status::Status::NotFound);
 
     //one matching dataset, we hit the global one

--- a/tests/bragi_synonyms_test.rs
+++ b/tests/bragi_synonyms_test.rs
@@ -85,17 +85,13 @@ pub fn bragi_synonyms_test(es_wrapper: ::ElasticSearchWrapper) {
 fn synonyms_test(bragi: &BragiHandler) {
     // Test that we find Hôtel de Ville
     let response = bragi.get("/autocomplete?q=hotel de ville");
-    assert!(
-        get_values(&response, "label")
-            .iter()
-            .all(|r| r.contains("Hôtel de Ville"))
-    );
+    assert!(get_values(&response, "label")
+        .iter()
+        .all(|r| r.contains("Hôtel de Ville")));
 
     // Test we find the same result as above as mairie is synonym of hotel de ville
     let response = bragi.get("/autocomplete?q=mairie");
-    assert!(
-        get_values(&response, "label")
-            .iter()
-            .all(|r| r.contains("Hôtel de Ville"))
-    );
+    assert!(get_values(&response, "label")
+        .iter()
+        .all(|r| r.contains("Hôtel de Ville")));
 }

--- a/tests/bragi_three_cities_test.rs
+++ b/tests/bragi_three_cities_test.rs
@@ -80,11 +80,9 @@ fn three_cities_housenumber_zip_code_test(bragi: &BragiHandler) {
     // the house number with this number in this city
     let all_20 = bragi.get("/autocomplete?q=3 rue 77255");
     assert_eq!(all_20.len(), 1);
-    assert!(
-        get_values(&all_20, "postcode")
-            .iter()
-            .all(|r| *r == "77255",)
-    );
+    assert!(get_values(&all_20, "postcode")
+        .iter()
+        .all(|r| *r == "77255",));
     let types = get_types(&all_20);
     let count = count_types(&types, "street");
     assert_eq!(count, 0);
@@ -107,11 +105,9 @@ fn three_cities_zip_code_test(bragi: &BragiHandler) {
     // and some street of it (and all on this admin)
     let res = bragi.get("/autocomplete?q=77000");
     assert_eq!(res.len(), 10);
-    assert!(
-        get_values(&res, "postcode")
-            .iter()
-            .all(|r| r.contains("77000"),)
-    );
+    assert!(get_values(&res, "postcode")
+        .iter()
+        .all(|r| r.contains("77000"),));
     let types = get_types(&res);
     // since we did not ask for an house number, we should get none
     assert_eq!(count_types(&types, "house"), 0);
@@ -120,11 +116,9 @@ fn three_cities_zip_code_test(bragi: &BragiHandler) {
 fn three_cities_zip_code_address_test(bragi: &BragiHandler) {
     let all_20 = bragi.get("/autocomplete?q=77288 2 Rue de la Reine Blanche");
     assert_eq!(all_20.len(), 1);
-    assert!(
-        get_values(&all_20, "postcode")
-            .iter()
-            .all(|r| *r == "77288",)
-    );
+    assert!(get_values(&all_20, "postcode")
+        .iter()
+        .all(|r| *r == "77288",));
     let types = get_types(&all_20);
     let count = count_types(&types, "street");
     assert_eq!(count, 0);

--- a/tests/canonical_import_process_test.rs
+++ b/tests/canonical_import_process_test.rs
@@ -147,11 +147,11 @@ fn melun_test(bragi: &BragiHandler) {
     assert_eq!(
         cityhall_admins[2]["codes"],
         json!([
-                    {"name": "ISO3166-1", "value": "FR"},
-                    {"name": "ISO3166-1:alpha2", "value": "FR"},
-                    {"name": "ISO3166-1:alpha3", "value": "FRA"},
-                    {"name": "ISO3166-1:numeric", "value": "250"},
-    ])
+                        {"name": "ISO3166-1", "value": "FR"},
+                        {"name": "ISO3166-1:alpha2", "value": "FR"},
+                        {"name": "ISO3166-1:alpha3", "value": "FRA"},
+                        {"name": "ISO3166-1:numeric", "value": "250"},
+        ])
     );
 
     // the poi should have been associated to an address

--- a/tests/cosmogony2mimir_test.rs
+++ b/tests/cosmogony2mimir_test.rs
@@ -131,7 +131,8 @@ pub fn cosmogony2mimir_test(es_wrapper: ::ElasticSearchWrapper) {
                     ("ISO3166-1:alpha2", "FR"),
                     ("ISO3166-1:alpha3", "FRA"),
                     ("ISO3166-1:numeric", "250"),
-                ].into_iter()
+                ]
+                .into_iter()
                 .collect()
             );
             assert_eq!(fr.weight, 0f64);
@@ -146,7 +147,8 @@ pub fn cosmogony2mimir_test(es_wrapper: ::ElasticSearchWrapper) {
         .search_and_filter(
             "label:Melun (77000-CP77001), Fausse Seine-et-Marne, France hexagonale",
             |_| true,
-        ).collect();
+        )
+        .collect();
     assert!(res.len() >= 1);
 
     let fausse_seine_max_weight = &res[0];

--- a/tests/openaddresses2mimir_test.rs
+++ b/tests/openaddresses2mimir_test.rs
@@ -71,7 +71,8 @@ pub fn oa2mimir_simple_test(es_wrapper: ::ElasticSearchWrapper) {
         s =<< s.get("aliases");
         s =<< s.as_object();
         ret ret(s.keys().cloned().collect())
-    }.unwrap_or_else(Vec::new);
+    }
+    .unwrap_or_else(Vec::new);
     // for the moment 'munin' is hard coded, but hopefully that will change
     assert_eq!(
         aliases,
@@ -108,7 +109,8 @@ pub fn oa2mimir_simple_test(es_wrapper: ::ElasticSearchWrapper) {
         s =<< s.get("aliases");
         s =<< s.as_object();
         ret ret(s.keys().cloned().collect())
-    }.unwrap_or_else(Vec::new);
+    }
+    .unwrap_or_else(Vec::new);
     assert_eq!(
         aliases,
         vec!["munin", "munin_addr", "munin_addr_fr", "munin_geo_data"]

--- a/tests/osm2mimir_test.rs
+++ b/tests/osm2mimir_test.rs
@@ -103,11 +103,13 @@ pub fn osm2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
 
     // Test: Search for "Rue du Four à Chaux" in "Livry-sur-Seine"
     let place_filter = |place: &mimir::Place| {
-        place.is_street() && place.label() == "Rue du Four à Chaux (Livry-sur-Seine)" && place
-            .admins()
-            .first()
-            .map(|admin| admin.label() == "Livry-sur-Seine (77000)")
-            .unwrap_or(false)
+        place.is_street()
+            && place.label() == "Rue du Four à Chaux (Livry-sur-Seine)"
+            && place
+                .admins()
+                .first()
+                .map(|admin| admin.label() == "Livry-sur-Seine (77000)")
+                .unwrap_or(false)
     };
     // As we merge all ways with same name and of the same admin(level=city_level)
     // Here we have only one way
@@ -129,11 +131,13 @@ pub fn osm2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
 
     // Test: Streets having the same label in different cities
     let place_filter = |place: &mimir::Place| {
-        place.is_street() && place.label() == "Rue du Port (Melun)" && place
-            .admins()
-            .first()
-            .map(|admin| admin.label() == "Melun (77000-CP77001)")
-            .unwrap_or(false)
+        place.is_street()
+            && place.label() == "Rue du Port (Melun)"
+            && place
+                .admins()
+                .first()
+                .map(|admin| admin.label() == "Melun (77000-CP77001)")
+                .unwrap_or(false)
     };
     let nb = es_wrapper
         .search_and_filter("label:Rue du Port (Melun)", place_filter)
@@ -147,13 +151,11 @@ pub fn osm2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
         .collect();
     assert!(res.len() != 0);
     assert_eq!(res[0].label(), "Rue Marcel Houdet (Melun)");
-    assert!(
-        res[0]
-            .admins()
-            .iter()
-            .filter(|a| a.is_city())
-            .any(|a| a.name == "Melun")
-    );
+    assert!(res[0]
+        .admins()
+        .iter()
+        .filter(|a| a.is_city())
+        .any(|a| a.name == "Melun"));
 
     // Test: search Pois by label
     let res: Vec<_> = es_wrapper
@@ -162,17 +164,15 @@ pub fn osm2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
     assert!(res.len() != 0);
 
     let poi_type_post_office = "poi_type:amenity:post_office";
-    assert!(res.iter().any(|r| {
-        r.poi()
-            .map_or(false, |poi| poi.poi_type.id == poi_type_post_office)
-    }));
+    assert!(res.iter().any(|r| r
+        .poi()
+        .map_or(false, |poi| poi.poi_type.id == poi_type_post_office)));
 
     let res: Vec<_> = es_wrapper
         .search_and_filter("label:Melun Rp", |_| true)
         .collect();
     assert!(res.len() != 0);
-    assert!(res.iter().any(|r| {
-        r.poi()
-            .map_or(false, |poi| poi.poi_type.id == poi_type_post_office)
-    }));
+    assert!(res.iter().any(|r| r
+        .poi()
+        .map_or(false, |poi| poi.poi_type.id == poi_type_post_office)));
 }

--- a/tests/osm2mimir_test.rs
+++ b/tests/osm2mimir_test.rs
@@ -111,13 +111,21 @@ pub fn osm2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
     };
     // As we merge all ways with same name and of the same admin(level=city_level)
     // Here we have only one way
-    let four_a_chaux_street: Vec<mimir::Place> = es_wrapper.search_and_filter("label:Rue du Four à Chaux (Livry-sur-Seine)", place_filter).collect();
+    let four_a_chaux_street: Vec<mimir::Place> = es_wrapper
+        .search_and_filter("label:Rue du Four à Chaux (Livry-sur-Seine)", place_filter)
+        .collect();
 
     let nb = four_a_chaux_street.len();
     assert_eq!(nb, 1);
 
     // Test the id is the min(=40812939) of all the ways composing the street
-    assert!(four_a_chaux_street[0].address().map_or(false, |a| if let mimir::Address::Street(s) = a {s.id == "street:osm:way:40812939"} else {false}));
+    assert!(four_a_chaux_street[0].address().map_or(false, |a| {
+        if let mimir::Address::Street(s) = a {
+            s.id == "street:osm:way:40812939"
+        } else {
+            false
+        }
+    }));
 
     // Test: Streets having the same label in different cities
     let place_filter = |place: &mimir::Place| {

--- a/tests/osm2mimir_test.rs
+++ b/tests/osm2mimir_test.rs
@@ -111,10 +111,13 @@ pub fn osm2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
     };
     // As we merge all ways with same name and of the same admin(level=city_level)
     // Here we have only one way
-    let nb = es_wrapper
-        .search_and_filter("label:Rue du Four à Chaux (Livry-sur-Seine)", place_filter)
-        .count();
+    let four_a_chaux_street: Vec<mimir::Place> = es_wrapper.search_and_filter("label:Rue du Four à Chaux (Livry-sur-Seine)", place_filter).collect();
+
+    let nb = four_a_chaux_street.len();
     assert_eq!(nb, 1);
+
+    // Test the id is the min(=40812939) of all the ways composing the street
+    assert!(four_a_chaux_street[0].address().map_or(false, |a| if let mimir::Address::Street(s) = a {s.id == "street:osm:way:40812939"} else {false}));
 
     // Test: Streets having the same label in different cities
     let place_filter = |place: &mimir::Place| {

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -247,7 +247,8 @@ pub fn rubber_ghost_index_cleanup(mut es: ::ElasticSearchWrapper) {
             "{host}/{idx}",
             host = es.host(),
             idx = old_idx_name
-        )).send()
+        ))
+        .send()
         .unwrap();
 
     assert_eq!(res.status, hyper::Ok);

--- a/tests/stops2mimir_test.rs
+++ b/tests/stops2mimir_test.rs
@@ -94,10 +94,8 @@ pub fn stops2mimir_sample_test(es_wrapper: ::ElasticSearchWrapper) {
                     "stop_area:SA:known_by_all_dataset" => {
                         assert_eq!(stop.coverages, vec!["dataset1", "dataset2"]);
                         // we don't control which label is taken
-                        assert!(
-                            vec!["All known stop", "All known stop, but different name"]
-                                .contains(&stop.label.as_ref())
-                        );
+                        assert!(vec!["All known stop", "All known stop, but different name"]
+                            .contains(&stop.label.as_ref()));
                     }
                     "stop_area:SA:second_station:dataset2" => {
                         assert_eq!(stop.coverages, vec!["dataset2"])

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -216,13 +216,15 @@ impl<'a> ElasticSearchWrapper<'a> {
                                             })
                                         })
                                     })
-                                }).filter(predicate),
+                                })
+                                .filter(predicate),
                         )
                             as Box<Iterator<Item = mimir::Place>>)
                     }
                     _ => None,
                 }
-            }).unwrap_or(Box::new(None.into_iter()) as Box<Iterator<Item = mimir::Place>>)
+            })
+            .unwrap_or(Box::new(None.into_iter()) as Box<Iterator<Item = mimir::Place>>)
     }
 }
 
@@ -245,7 +247,8 @@ impl BragiHandler {
         let api = bragi::api::ApiEndPoint {
             es_cnx_string: url,
             max_es_timeout: None,
-        }.root();
+        }
+        .root();
         BragiHandler {
             app: rustless::Application::new(api),
         }
@@ -309,7 +312,8 @@ pub fn get_results(r: iron::Response, pointer: Option<String>) -> Vec<Map<String
             } else {
                 f.as_object().unwrap().clone()
             }
-        }).collect()
+        })
+        .collect()
 }
 
 pub fn get_values<'a>(r: &'a [Map<String, Value>], val: &'a str) -> Vec<&'a str> {


### PR DESCRIPTION
We want streets id as stable as possible.
The solution this PR proposes is the following:
- for streets divided by several ways we take the id of the corresponding relation (tagged "type=associatedStreet") with the prefix "street:osm:rel:<id>"
- for all other streets we select the min id of the corresponding ways with the prefix "street:osm:way:<id>"

