### PR TITLE
Import i18n labels and names from cosmogony admins into ES

### DIFF
--- a/json/admin_settings.json
+++ b/json/admin_settings.json
@@ -1,6 +1,7 @@
 {
     "template": "munin_admin_*",
     "settings": {
+        "refresh_interval" : "60s",
         "analysis": {
             "filter": {
                 "prefix_filter": {
@@ -48,23 +49,77 @@
     },
     "mappings": {
         "admin": {
-            "dynamic": "false",
-            "properties": {
-                "id": { "type": "string", "index": "not_analyzed" },
-                "level": { "type": "long", "index": "no" },
-                "name": {
-                    "type": "string",
-                    "index_options": "docs",
-                    "analyzer": "word",
-                    "fields": {
-                        "prefix": {
+            "_all": {
+                "enabled": false
+            },
+            "dynamic_templates": [
+                {
+                    "i18n_names": {
+                        "match_pattern": "regex",
+                        "path_match": "^name($|s\\.\\w+)",
+                        "mapping": {
                             "type": "string",
                             "index_options": "docs",
-                            "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "analyzer": "word",
+                            "fields": {
+                                "prefix": {
+                                    "type": "string",
+                                    "index_options": "docs",
+                                    "analyzer": "prefix",
+                                    "search_analyzer": "word"
+                                }
+                            }
                         }
                     }
                 },
+                {
+                    "i18n_labels": {
+                        "match_pattern": "regex",
+                        "path_match": "^label($|s\\.\\w+)",
+                        "mapping": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "word",
+                            "copy_to": "full_label",
+                            "fields": {
+                                "prefix": {
+                                    "type": "string",
+                                    "index_options": "docs",
+                                    "analyzer": "prefix",
+                                    "search_analyzer": "word",
+                                    "norms": {
+                                        "enabled": false
+                                    }
+                                },
+                                "ngram": {
+                                    "type": "string",
+                                    "index_options": "docs",
+                                    "analyzer": "ngram_with_synonyms",
+                                    "search_analyzer": "ngram",
+                                    "norms": {
+                                        "enabled": false
+                                    }
+                                }
+                            },
+                            "norms": {
+                                "enabled": false
+                            }
+                        }
+                    }
+                },
+                {
+                    "disable_other_dynamic_fields": {
+                        "match_pattern": "regex",
+                        "path_match": "^(?!name|label|full_label).*",
+                        "mapping": {
+                            "index": "no"
+                        }
+                    }
+                }
+            ],
+            "properties": {
+                "id": { "type": "string", "index": "not_analyzed" },
+                "level": { "type": "long", "index": "no" },
                 "zip_codes": {
                     "type": "string",
                     "index_options": "docs",
@@ -85,39 +140,9 @@
                     "geohash_prefix": true,
                     "geohash_precision": "1m"
                 },
-                "label": {
-                    "type": "string",
-                    "index_options": "docs",
-                    "analyzer": "word",
-                    "copy_to": "full_label",
-                    "fields": {
-                        "prefix": {
-                            "type": "string",
-                            "index_options": "docs",
-                            "analyzer": "prefix",
-                            "search_analyzer": "word",
-                            "norms": {
-                                "enabled": false
-                            }
-                        },
-                        "ngram": {
-                            "type": "string",
-                            "index_options": "docs",
-                            "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram",
-                            "norms": {
-                                "enabled": false
-                            }
-                        }
-                    },
-                    "norms": {
-                        "enabled": false
-                    }
-                },
                 "full_label": {
                     "type": "string",
-                    "index_options": "docs",
-                    "analyzer": "word",
+                    "index": "no",
                     "fields": {
                         "prefix": {
                             "type": "string",

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -463,6 +463,12 @@ impl Rubber {
         index: TypedIndex<T>,
     ) -> Result<(), Error> {
         debug!("publishing index");
+
+        // Refresh index before publishing
+        self.es_client
+            .refresh()
+            .with_indexes(&[&index.name])
+            .send()?;
         let last_indexes = self.get_last_index(&index, dataset)?;
 
         let dataset_index = get_main_type_and_dataset_index::<T>(dataset);

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -267,6 +267,8 @@ mod tests {
             zone_type: zt,
             parent_id: parent_offset.map(|id| id.into()),
             codes: vec![],
+            names: ::mimir::I18nProperties::default(),
+            labels: ::mimir::I18nProperties::default(),
         }
     }
 

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -174,6 +174,8 @@ pub fn read_administrative_regions(
                 zone_type: zone_type,
                 parent_id: None,
                 codes: get_osm_codes_from_tags(&relation.tags),
+                names: mimir::I18nProperties::default(),
+                labels: mimir::I18nProperties::default(),
             };
             administrative_regions.push(admin);
         }

--- a/src/osm_reader/osm_utils.rs
+++ b/src/osm_reader/osm_utils.rs
@@ -80,3 +80,18 @@ pub fn get_osm_codes_from_tags(tags: &osmpbfreader::Tags) -> Vec<mimir::Code> {
         })
         .collect()
 }
+
+pub fn get_names_from_tags(tags: &osmpbfreader::Tags, langs: &[String]) -> mimir::I18nProperties {
+    const NAME_TAG_PREFIX: &str = "name:";
+
+    let properties = tags
+        .iter()
+        .filter(|(k, _)| k.starts_with(&NAME_TAG_PREFIX))
+        .map(|property| mimir::Property {
+            key: property.0[NAME_TAG_PREFIX.len()..].to_string(),
+            value: property.1.to_string(),
+        })
+        .filter(|p| langs.contains(&p.key))
+        .collect();
+    mimir::I18nProperties(properties)
+}

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -172,6 +172,8 @@ pub fn rubber_custom_id(mut es: crate::ElasticSearchWrapper<'_>) {
         zone_type: Some(ZoneType::City),
         parent_id: None,
         codes: vec![],
+        names: mimir::I18nProperties::default(),
+        labels: mimir::I18nProperties::default(),
     };
 
     // we index our admin
@@ -271,6 +273,8 @@ pub fn rubber_ghost_index_cleanup(mut es: crate::ElasticSearchWrapper<'_>) {
         zone_type: Some(ZoneType::City),
         parent_id: None,
         codes: vec![],
+        names: mimir::I18nProperties::default(),
+        labels: mimir::I18nProperties::default(),
     };
 
     // we index our admin


### PR DESCRIPTION
This is the first step towards handling requests in multiple languages :crossed_flags: 

These changes focus on importing admins with internationalized labels and names in cosmogony2mimir : 
 * Add `--lang` parameter to cosmogony2mimir
 * Add new fields `names` and `labels` into mimir `Admin` 
 * Update elasticsearch mapping for admins:
   * Index names.* and labels.* as dynamic fields
   * Copy all labels.* to `full_label` (its behavior is unchanged, and could still be used to match all queries, regardless of language)
 * Some elasticsearch optimizations:
    * disable `_all` field (unused, and default behavior in ES 5+)
    * use refresh_interval=60s (instead of 1s by default)

Index size seems reasonable (from 1.3 GB to 1.7 GB with all admins in Europe in 5 languages).

If that's ok, the next step will be to use these new fields in bragi (in both query and response) ; and apply similar changes, to handle other types of objects, as described in  #181 and #208.