### PR TITLE
reverse: Fix proximity score to always return the closest address

### DIFF
--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -191,7 +191,7 @@ pub fn build_proximity_with_boost(coord: &Coord, boost: f64) -> Query {
                 rs_u::Location::LatLon(coord.lat(), coord.lon()),
                 rs_u::Distance::new(50f64, rs_u::DistanceUnit::Kilometer),
             )
-            .build_gauss(),
+            .build_exp(),
         )
         .build()
 }

--- a/tests/bano2mimir_test.rs
+++ b/tests/bano2mimir_test.rs
@@ -107,10 +107,10 @@ pub fn bano2mimir_sample_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         vec!["munin", "munin_addr", "munin_addr_fr", "munin_geo_data"]
     );
 
-    // we should have imported 32 elements
+    // we should have imported 34 elements
     // (we shouldn't have the badly formated line)
     let total = get_nb_elements(&es_wrapper);
-    assert_eq!(total, 32);
+    assert_eq!(total, 34);
 
     // We look for 'Fake-City' which should have been filtered since the street name is empty
     let res: Vec<_> = es_wrapper

--- a/tests/bragi_bano_test.rs
+++ b/tests/bragi_bano_test.rs
@@ -187,4 +187,10 @@ fn reverse_bano_test(bragi: &BragiHandler) {
         get_values(&res, "label"),
         vec!["20 Rue Hector Malot (Paris)"]
     );
+
+    let res = bragi.get("/reverse?lon=1.3787628&lat=43.6681995");
+    assert_eq!(
+        get_values(&res, "label"),
+        vec!["2 Rue des Pins (Beauzelle)"]
+    );
 }

--- a/tests/fixtures/sample-bano.csv
+++ b/tests/fixtures/sample-bano.csv
@@ -30,5 +30,7 @@
 751124517P-8Z,8Z,Rue Hector Malot,75012,Paris,O+O,48.845692,2.375752
 751124517P-9,9,Rue Hector Malot,75012,Paris,OSM,48.845801,2.375630
 420424517P-20,20,Rue Hector Malot,42042,Trifouilli-les-Oies,OSM,50.0,2.0
+310560092F-10,10,Place de la Mairie,31700,Beauzelle,OSM,43.668175,1.378886
+310560124R-2,2,Rue des Pins,31700,Beauzelle,OSM,43.668184,1.378798
 777777777Z-77,77,,77042,Fake-City,OSM,50.0,2.0
 ,,,,,,,,,badly_formated_line,


### PR DESCRIPTION
As a Qwant Maps user pointed out (https://github.com/QwantResearch/qwantmaps/issues/28), the `/reverse` endpoint may return a wrong address is some cases. This is due to the gaussian decay function that returns **the exact same score** for multiple addresses that are only a few meters apart.

This PR suggests to replace the current function with an [exponential decay function](https://www.elastic.co/guide/en/elasticsearch/guide/2.x/decay-functions.html#img-decay-functions).

Note that this change is only about the `build_proximity_with_boost` function that is defined in `rubber.rs` and used by the reverse geocoder.  
A [similar function exists](https://github.com/CanalTP/mimirsbrunn/blob/master/libs/bragi/src/query.rs#L103) in the autocomplete query and keeps unchanged.