### PR TITLE
Improvements in i18n query

### DIFF
--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -163,10 +163,15 @@ fn build_query<'a>(
     let format_labels_field = |lang| format!("labels.{}", lang);
     let format_labels_prefix_field = |lang| format!("labels.{}.prefix", lang);
 
+    const I18N_FIELD_BOOST: f64 = 1.2;
     let build_multi_match =
         |default_field: &str, lang_field_formatter: &Fn(&'a &'a str) -> String| {
+            let boosted_i18n_fields = langs
+                .iter()
+                .map(lang_field_formatter)
+                .map(|f| format!("{}^{:.2}", f, I18N_FIELD_BOOST));
             let fields: Vec<String> = iter::once(default_field.into())
-                .chain(langs.iter().map(lang_field_formatter))
+                .chain(boosted_i18n_fields)
                 .collect();
             Query::build_multi_match(fields, q)
         };

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -34,6 +34,7 @@ use mimir::rubber::{collect, get_indexes};
 use prometheus;
 use rs_es;
 use rs_es::error::EsError;
+use rs_es::operations::search::Source;
 use rs_es::query::compound::BoostMode;
 use rs_es::query::Query;
 use rs_es::units as rs_u;
@@ -320,7 +321,10 @@ fn query(
         .with_indexes(&indexes)
         .with_query(&query)
         .with_from(offset)
-        .with_size(limit);
+        .with_size(limit)
+        // No need to fetch "boundary" as it's not used in the geocoding response
+        // and is very large in some documents (countries...)
+        .with_source(Source::exclude(&["boundary"]));
 
     if let Some(timeout) = &timeout {
         search_query.with_timeout(timeout.as_str());


### PR DESCRIPTION
* Define an arbitrary boost on  `names.*` and `labels.*` fields.  
(Improve rankings of admins with translated names, compared to other objects with matching name)

**Without boost** (planet)
```
                region                 | category | failed | total | ratio |    duration    
---------------------------------------|----------|--------|-------|-------|----------------
 test_admin_capital_cities_i18n_en.csv |  admins  |  320   |  486  |  34%  | 0:00:06.720000 
         test_admin_cities.csv         |  admins  |  491   |  940  |  48%  | 0:00:12.700000 
     test_admin_cities_i18n_en.csv     |  admins  |  513   |  940  |  45%  | 0:00:12.700000 
     test_admin_cities_i18n_fr.csv     |  admins  |  527   |  940  |  44%  | 0:00:08.740000 
                   _                   |  fuzzy   |  342   |  993  |  66%  | 0:00:35.130000 
                   _                   |  admins  |  2432  | 4168  |  42%  | 0:00:56.530000 
                   _                   |   poi    |  4510  | 9521  |  53%  | 0:04:02.050000 
                   _                   |  autre   |  1828  | 11508 |  84%  | 0:02:18.600000 
```

**With boost** (planet)
```
                region                 | category | failed | total | ratio |    duration    
---------------------------------------|----------|--------|-------|-------|----------------
 test_admin_capital_cities_i18n_en.csv |  admins  |  294   |  486  |  40%  | 0:00:15.950000 
         test_admin_cities.csv         |  admins  |  490   |  940  |  48%  | 0:00:27.360000 
     test_admin_cities_i18n_en.csv     |  admins  |  486   |  940  |  48%  | 0:00:34.360000 
     test_admin_cities_i18n_fr.csv     |  admins  |  488   |  940  |  48%  | 0:00:27.920000 
                   _                   |  fuzzy   |  342   |  993  |  66%  | 0:00:34.030000 
                   _                   |  admins  |  2346  | 4168  |  44%  | 0:02:21.950000 
                   _                   |   poi    |  4589  | 9521  |  52%  | 0:04:39.320000 
                   _                   |  autre   |  1829  | 11508 |  84%  | 0:02:28.180000 
```


* Optimization: exclude `boundary` from the elasticsearch response (saves up to several MBs on response with large zones)