### PR TITLE
correct timeout handling

### DIFF
--- a/libs/bragi/src/routes/autocomplete.rs
+++ b/libs/bragi/src/routes/autocomplete.rs
@@ -49,7 +49,8 @@ pub struct Params {
     limit: u64,
     #[serde(default)]
     offset: u64,
-    timeout: Option<Duration>,
+    /// timeout in milliseconds
+    timeout: Option<u64>,
     lat: Option<f64>,
     lon: Option<f64>,
     #[serde(default, rename = "type")]
@@ -72,6 +73,9 @@ impl Params {
     }
     fn langs(&self) -> Vec<&str> {
         self.lang.iter().map(|l| l.as_str()).collect()
+    }
+    fn timeout(&self) -> Option<Duration> {
+        self.timeout.map(Duration::from_millis)
     }
 }
 
@@ -117,7 +121,7 @@ pub fn call_autocomplete(
     shape: Option<Vec<(f64, f64)>>,
 ) -> Result<Json<Autocomplete>, model::BragiError> {
     let langs = params.langs();
-    let timeout = params::get_timeout(&params.timeout, &state.max_es_timeout);
+    let timeout = params::get_timeout(&params.timeout(), &state.max_es_timeout);
     let res = query::autocomplete(
         &params.q,
         &params

--- a/libs/bragi/src/routes/features.rs
+++ b/libs/bragi/src/routes/features.rs
@@ -10,7 +10,8 @@ pub struct Params {
     pt_dataset: Vec<String>,
     #[serde(rename = "_all_data", default)]
     all_data: bool,
-    timeout: Option<Duration>,
+    /// timeout in milliseconds
+    timeout: Option<u64>,
 }
 
 pub fn features(
@@ -18,7 +19,10 @@ pub fn features(
     state: State<Context>,
     id: Path<String>,
 ) -> Result<Json<model::Autocomplete>, model::BragiError> {
-    let timeout = params::get_timeout(&params.timeout, &state.max_es_timeout);
+    let timeout = params::get_timeout(
+        &params.timeout.map(Duration::from_millis),
+        &state.max_es_timeout,
+    );
     let features = query::features(
         &params
             .pt_dataset

--- a/libs/bragi/src/routes/params.rs
+++ b/libs/bragi/src/routes/params.rs
@@ -6,7 +6,13 @@ pub fn get_timeout(
     query_timeout: &Option<Duration>,
     default_timeout: &Option<Duration>,
 ) -> Option<Duration> {
-    query_timeout.clone().or_else(|| default_timeout.clone())
+    query_timeout
+        .clone()
+        .map(|t| match default_timeout {
+            Some(dt) => t.min(*dt),
+            None => t,
+        })
+        .or_else(|| default_timeout.clone())
 }
 
 pub fn make_coord(lon: f64, lat: f64) -> Result<Coord, BragiError> {

--- a/libs/bragi/src/routes/reverse.rs
+++ b/libs/bragi/src/routes/reverse.rs
@@ -9,14 +9,18 @@ use std::time::Duration;
 pub struct Params {
     lat: f64,
     lon: f64,
-    timeout: Option<Duration>,
+    /// timeout in milliseconds
+    timeout: Option<u64>,
 }
 
 pub fn reverse(
     params: BragiQuery<Params>,
     state: State<Context>,
 ) -> Result<Json<model::Autocomplete>, model::BragiError> {
-    let timeout = params::get_timeout(&params.timeout, &state.max_es_timeout);
+    let timeout = params::get_timeout(
+        &params.timeout.map(Duration::from_millis),
+        &state.max_es_timeout,
+    );
     let mut rubber = Rubber::new(&state.es_cnx_string);
     rubber.set_read_timeout(timeout);
     rubber.set_write_timeout(timeout);

--- a/tests/canonical_import_process_test.rs
+++ b/tests/canonical_import_process_test.rs
@@ -81,6 +81,7 @@ pub fn canonical_import_process_test(es_wrapper: crate::ElasticSearchWrapper<'_>
     invalid_type_test(&mut bragi);
     invalid_route_test(&mut bragi);
     invalid_coord_test(&mut bragi);
+    valid_timeout_test(&mut bragi);
 }
 
 fn melun_test(bragi: &mut BragiHandler) {
@@ -355,4 +356,9 @@ fn invalid_coord_test(bragi: &mut BragiHandler) {
             })
         )
     );
+}
+
+// we just check that the timeout is correctly parser
+fn valid_timeout_test(bragi: &mut BragiHandler) {
+    let _ = bragi.get("/autocomplete?q=france&timeout=12340");
 }


### PR DESCRIPTION
the timeout handling has been broken by
https://github.com/CanalTP/mimirsbrunn/pull/286

this fixes it by parsing the timeout as an integer as before (and not a
duration)

Note: without this, the navitia integration is broken and maybe others too. poke @amatissart 