### PR TITLE
Use streaming capabilities of cosmogony to reduce memory usage

### DIFF
--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -141,12 +141,13 @@ fn index_cosmogony(args: Args) -> Result<(), Error> {
     info!("building maps");
 
     let mut max_weight = 0.0;
-    let cosmogony_id_to_osm_id: BTreeMap<_, _> = read_zones(&args.input)?
-        .map(|z| {
-            max_weight = f64::max(max_weight, get_weight(&z.tags, &z.center_tags));
-            (z.id.clone(), z.osm_id.clone())
-        })
-        .collect();
+    let mut cosmogony_id_to_osm_id = BTreeMap::new();
+    for z in read_zones(&args.input)? {
+        max_weight = f64::max(max_weight, get_weight(&z.tags, &z.center_tags));
+        cosmogony_id_to_osm_id.insert(z.id.clone(), z.osm_id.clone());
+    }
+    let max_weight = max_weight;
+    let cosmogony_id_to_osm_id = cosmogony_id_to_osm_id;
 
     info!("importing cosmogony into Mimir");
     let admins = read_zones(&args.input)?.map(|z| {

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -140,7 +140,7 @@ fn read_zones(input: &str) -> Result<impl Iterator<Item = Zone>, Error> {
 fn index_cosmogony(args: Args) -> Result<(), Error> {
     info!("building maps");
 
-    let mut max_weight = 0.0;
+    let mut max_weight = 1.0;
     let mut cosmogony_id_to_osm_id = BTreeMap::new();
     for z in read_zones(&args.input)? {
         max_weight = f64::max(max_weight, get_weight(&z.tags, &z.center_tags));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,8 +63,13 @@ pub fn get_zip_codes_from_admins(admins: &[Arc<mimir::Admin>]) -> Vec<String> {
 pub fn normalize_admin_weight(admins: &mut [mimir::Admin]) {
     let max = admins.iter().fold(1f64, |m, a| f64::max(m, a.weight));
     for ref mut a in admins {
-        a.weight = a.weight / max;
+        a.weight = normalize_weight(a.weight, max);
     }
+}
+
+/// normalize the weight for it to be in [0, 1]
+pub fn normalize_weight(weight: f64, max_weight: f64) -> f64 {
+    return weight / max_weight;
 }
 
 pub fn wrapped_launch_run<O, F>(run: F) -> Result<(), Error>


### PR DESCRIPTION
We read the file two times now, it doesn't seem to have any impacts on performance:

Before:
   duration: 4.25 min
   memory: 10 go

After:
   duration: 4.17 min
   memory: 250 mo

I'am not a fan of the `ZoneWeight` struct, I would like to create the map and the max_weight in one shot, but without having that struct, and I don't know how to do that without reading one more time :D 
