### PR TITLE
add labels/names fields

### DIFF
--- a/json/poi_settings.json
+++ b/json/poi_settings.json
@@ -1,6 +1,7 @@
 {
     "template": "munin_poi_*",
     "settings": {
+		"refresh_interval" : "60s",
         "analysis": {
             "filter": {
                 "prefix_filter": {
@@ -48,22 +49,76 @@
     },
     "mappings": {
         "poi": {
-            "dynamic": "false",
-            "properties": {
-                "id": { "type": "string", "index": "not_analyzed" },
-                "name": {
-                    "type": "string",
-                    "index_options": "docs",
-                    "analyzer": "word",
-                    "fields": {
-                        "prefix": {
+            "_all": {
+                "enabled": false
+            },
+            "dynamic_templates": [
+                {
+                    "i18n_names": {
+                        "match_pattern": "regex",
+                        "path_match": "^name($|s\\.\\w+)",
+                        "mapping": {
                             "type": "string",
                             "index_options": "docs",
-                            "analyzer": "prefix",
-                            "search_analyzer": "word"
+                            "analyzer": "word",
+                            "fields": {
+                                "prefix": {
+                                    "type": "string",
+                                    "index_options": "docs",
+                                    "analyzer": "prefix",
+                                    "search_analyzer": "word"
+                                }
+                            }
                         }
                     }
                 },
+                {
+                    "i18n_labels": {
+                        "match_pattern": "regex",
+                        "path_match": "^label($|s\\.\\w+)",
+                        "mapping": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "word",
+                            "copy_to": "full_label",
+                            "fields": {
+                                "prefix": {
+                                    "type": "string",
+                                    "index_options": "docs",
+                                    "analyzer": "prefix",
+                                    "search_analyzer": "word",
+                                    "norms": {
+                                        "enabled": false
+                                    }
+                                },
+                                "ngram": {
+                                    "type": "string",
+                                    "index_options": "docs",
+                                    "analyzer": "ngram_with_synonyms",
+                                    "search_analyzer": "ngram",
+                                    "norms": {
+                                        "enabled": false
+                                    }
+                                }
+                            },
+                            "norms": {
+                                "enabled": false
+                            }
+                        }
+                    }
+                },
+                {
+                    "disable_other_dynamic_fields": {
+                        "match_pattern": "regex",
+                        "path_match": "^(?!name|label|full_label).*",
+                        "mapping": {
+                            "index": "no"
+                        }
+                    }
+                }
+			],
+            "properties": {
+                "id": { "type": "string", "index": "not_analyzed" },
                 "zip_codes": {
                     "type": "string",
                     "index_options": "docs",
@@ -86,37 +141,8 @@
                 },
                 "full_label": {
                     "type": "string",
-                    "index_options": "docs",
+                    "index": "no",
                     "analyzer": "word",
-                    "fields": {
-                        "prefix": {
-                            "type": "string",
-                            "index_options": "docs",
-                            "analyzer": "prefix",
-                            "search_analyzer": "word",
-                            "norms": {
-                                "enabled": false
-                            }
-                        },
-                        "ngram": {
-                            "type": "string",
-                            "index_options": "docs",
-                            "analyzer": "ngram_with_synonyms",
-                            "search_analyzer": "ngram",
-                            "norms": {
-                                "enabled": false
-                            }
-                        }
-                    },
-                    "norms": {
-                        "enabled": false
-                    }
-                },
-                "label": {
-                    "type": "string",
-                    "index_options": "docs",
-                    "analyzer": "word",
-                    "copy_to": "full_label",
                     "fields": {
                         "prefix": {
                             "type": "string",

--- a/json/poi_settings.json
+++ b/json/poi_settings.json
@@ -1,7 +1,7 @@
 {
     "template": "munin_poi_*",
     "settings": {
-		"refresh_interval" : "60s",
+        "refresh_interval" : "60s",
         "analysis": {
             "filter": {
                 "prefix_filter": {

--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -395,9 +395,17 @@ impl FromWithLang<mimir::Addr> for GeocodingResponse {
 
 impl FromWithLang<mimir::Poi> for GeocodingResponse {
     fn from_with_lang(other: mimir::Poi, lang: Option<&str>) -> GeocodingResponse {
+        let (name, label) = if let Some(code) = lang {
+            (
+                other.names.get(code).unwrap_or(&other.name),
+                other.labels.get(code).unwrap_or(&other.label),
+            )
+        } else {
+            (other.name.as_ref(), other.label.as_ref())
+        };
+        let name = Some(name.to_owned());
+        let label = Some(label.to_owned());
         let type_ = "poi".to_string();
-        let label = Some(other.label);
-        let name = Some(other.name);
         let admins = other.administrative_regions;
         let city = get_city_name(&admins);
         let postcode = if other.zip_codes.is_empty() {

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -210,6 +210,12 @@ pub struct Poi {
     pub poi_type: PoiType,
     pub properties: Vec<Property>,
     pub address: Option<Address>,
+
+    #[serde(default)]
+    pub names: I18nProperties,
+    #[serde(default)]
+    pub labels: I18nProperties,
+
     /// Distance to the coord in query.
     /// Not serialized as is because it is returned in the `Feature` object
     #[serde(default, skip)]

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -259,6 +259,8 @@ fn parse_poi(
         poi_type: poi_type.clone(),
         properties: make_properties(osmobj.tags()),
         address: None,
+        names: mimir::I18nProperties::default(),
+        labels: mimir::I18nProperties::default(),
         distance: None,
     })
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,15 +52,19 @@ pub fn format_international_labels(
         .iter()
         .filter_map(|ref lang| {
             let local_poi_name = poi_names.get(lang).unwrap_or(default_poi_name);
-            let i18n_poi_label = match admins.iter().position(|adm| adm.is_city()) {
-                Some(idx) => {
-                    let default_admin_name = &admins[idx].name;
-                    let local_admin_name =
-                        admins[idx].names.get(lang).unwrap_or(&default_admin_name);
-                    format!("{} ({})", local_poi_name, local_admin_name)
-                }
-                _ => local_poi_name.to_string(),
-            };
+            let i18n_poi_label = admins
+                .iter()
+                .find(|adm| adm.is_city())
+                .map_or(
+                    local_poi_name.to_string(),
+                    |adm|  {
+                        let default_admin_name = &adm.name;
+                        let local_admin_name = &adm.names.get(lang).unwrap_or(&default_admin_name);
+                        format!("{} ({})", local_poi_name, local_admin_name)
+                    }
+
+                );
+
             if i18n_poi_label == default_poi_label {
                 None
             } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,7 +41,7 @@ pub fn format_label(admins: &[Arc<mimir::Admin>], name: &str) -> String {
     }
 }
 
-pub fn format_international_labels(
+pub fn format_international_poi_label(
     admins: &[Arc<mimir::Admin>],
     poi_names: &mimir::I18nProperties,
     default_poi_name: &str,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,18 +52,15 @@ pub fn format_international_labels(
         .iter()
         .filter_map(|ref lang| {
             let local_poi_name = poi_names.get(lang).unwrap_or(default_poi_name);
-            let i18n_poi_label = admins
-                .iter()
-                .find(|adm| adm.is_city())
-                .map_or(
-                    local_poi_name.to_string(),
-                    |adm|  {
+            let i18n_poi_label =
+                admins
+                    .iter()
+                    .find(|adm| adm.is_city())
+                    .map_or(local_poi_name.to_string(), |adm| {
                         let default_admin_name = &adm.name;
                         let local_admin_name = &adm.names.get(lang).unwrap_or(&default_admin_name);
                         format!("{} ({})", local_poi_name, local_admin_name)
-                    }
-
-                );
+                    });
 
             if i18n_poi_label == default_poi_label {
                 None

--- a/tests/bragi_poi_test.rs
+++ b/tests/bragi_poi_test.rs
@@ -257,8 +257,9 @@ fn poi_from_osm_with_address_addr_test(bragi: &mut BragiHandler) {
 
 // test 'labels' and 'names' fields work with i18n queries
 pub fn test_i18n_poi(mut es: crate::ElasticSearchWrapper<'_>) {
-    // we define a simple test poi with 2 langs ('it' and 'es')
-    let i18n_poi = mimir::Poi {
+    // we define a simple test italian poi (the 'Colosseo'
+    // with 2 langs for labels and names fields ('fr' and 'es')
+    let colosseo = mimir::Poi {
         id: "".to_string(),
         label: "Colosseo (Roma)".to_string(),
         name: "Colosseo".to_string(),
@@ -302,7 +303,7 @@ pub fn test_i18n_poi(mut es: crate::ElasticSearchWrapper<'_>) {
     // we index the poi above
     let result = es
         .rubber
-        .index("munin_poi", &index_settings, std::iter::once(i18n_poi));
+        .index("munin_poi", &index_settings, std::iter::once(colosseo));
 
     es.refresh();
 
@@ -320,16 +321,10 @@ pub fn test_i18n_poi(mut es: crate::ElasticSearchWrapper<'_>) {
     assert_eq!(result["name"], "Colisée");
     assert_eq!(result["label"], "Colisée (Rome)");
 
-    // We look for the Colisée in italian
-    let poi = bragi.get("/autocomplete?q=Colosseo&lang=it");
-    let result = poi.first().unwrap();
-    assert_eq!(result["name"], "Colosseo");
-    assert_eq!(result["label"], "Colosseo (Roma)");
-
-    // We look for the Colisée in russian: since it has not been
+    // We look for the Colisée in italian: since it has not been
     // indexed in russian we expect the default name and label (ie the
     // local ones: italian).
-    let poi = bragi.get("/autocomplete?q=Colisée&lang=ru");
+    let poi = bragi.get("/autocomplete?q=Colosseo&lang=it");
     let result = poi.first().unwrap();
     assert_eq!(result["name"], "Colosseo");
     assert_eq!(result["label"], "Colosseo (Roma)");

--- a/tests/bragi_poi_test.rs
+++ b/tests/bragi_poi_test.rs
@@ -260,8 +260,8 @@ pub fn test_i18n_poi(mut es: crate::ElasticSearchWrapper<'_>) {
     // we define a simple test poi with 2 langs ('it' and 'es')
     let i18n_poi = mimir::Poi {
         id: "".to_string(),
-        label: "Colisée (Rome)".to_string(),
-        name: "Colisée".to_string(),
+        label: "Colosseo (Roma)".to_string(),
+        name: "Colosseo".to_string(),
         coord: mimir::Coord(geo::Coordinate { x: 0.0, y: 0.0 }),
         administrative_regions: vec![],
         weight: 0.0,
@@ -274,8 +274,8 @@ pub fn test_i18n_poi(mut es: crate::ElasticSearchWrapper<'_>) {
         address: None,
         names: mimir::I18nProperties(vec![
             mimir::Property {
-                key: "it".to_string(),
-                value: "Colosseo".to_string(),
+                key: "fr".to_string(),
+                value: "Colisée".to_string(),
             },
             mimir::Property {
                 key: "es".to_string(),
@@ -284,8 +284,8 @@ pub fn test_i18n_poi(mut es: crate::ElasticSearchWrapper<'_>) {
         ]),
         labels: mimir::I18nProperties(vec![
             mimir::Property {
-                key: "it".to_string(),
-                value: "Colosseo (Roma)".to_string(),
+                key: "fr".to_string(),
+                value: "Colisée (Rome)".to_string(),
             },
             mimir::Property {
                 key: "es".to_string(),
@@ -309,21 +309,28 @@ pub fn test_i18n_poi(mut es: crate::ElasticSearchWrapper<'_>) {
     let mut bragi = BragiHandler::new(format!("{}/munin", es.host()));
 
     // We look for the Colisée in spanish
-    let poi = bragi.get("/autocomplete?q=Colisée&lang=es");
+    let poi = bragi.get("/autocomplete?q=Coliseo&lang=es");
     let result = poi.first().unwrap();
     assert_eq!(result["name"], "Coliseo");
     assert_eq!(result["label"], "Coliseo (Roma)");
 
+    // We look for the Colisée in french
+    let poi = bragi.get("/autocomplete?q=Colisée&lang=fr");
+    let result = poi.first().unwrap();
+    assert_eq!(result["name"], "Colisée");
+    assert_eq!(result["label"], "Colisée (Rome)");
+
     // We look for the Colisée in italian
-    let poi = bragi.get("/autocomplete?q=Colisée&lang=it");
+    let poi = bragi.get("/autocomplete?q=Colosseo&lang=it");
     let result = poi.first().unwrap();
     assert_eq!(result["name"], "Colosseo");
     assert_eq!(result["label"], "Colosseo (Roma)");
 
     // We look for the Colisée in russian: since it has not been
-    // indexed in russian we expect the default name and label.
+    // indexed in russian we expect the default name and label (ie the
+    // local ones: italian).
     let poi = bragi.get("/autocomplete?q=Colisée&lang=ru");
     let result = poi.first().unwrap();
-    assert_eq!(result["name"], "Colisée");
-    assert_eq!(result["label"], "Colisée (Rome)");
+    assert_eq!(result["name"], "Colosseo");
+    assert_eq!(result["label"], "Colosseo (Roma)");
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -390,6 +390,7 @@ fn all_tests() {
     rubber_test::rubber_empty_bulk(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_bano_test::bragi_bano_test(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_osm_test::bragi_osm_test(ElasticSearchWrapper::new(&docker_wrapper));
+    bragi_poi_test::test_i18n_poi(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_three_cities_test::bragi_three_cities_test(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_poi_test::bragi_poi_test(ElasticSearchWrapper::new(&docker_wrapper));
     bragi_stops_test::bragi_stops_test(ElasticSearchWrapper::new(&docker_wrapper));


### PR DESCRIPTION
This PR is the extension of https://github.com/CanalTP/mimirsbrunn/pull/285 for POI.
Basically it simply adds the 'names' and 'labels' fields to the POI object.
The index POI settings are changed accordingly to these changes.
A basic test comes along the PR.



