### PR TITLE
Only use french retrocompatible id for cities

### DIFF
--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -127,7 +127,9 @@ impl AdminGeoFinder {
                     if let Some(zt) = admin_parent.as_ref().and_then(|a| a.zone_type) {
                         added_zone_types.insert(zt.clone());
                     }
-                    tested_hierarchy.insert(id);
+                    if !tested_hierarchy.insert(id) {
+                        break; // stop the exploration of the hierarchy since we have already added this one
+                    }
                     admin_parent_id = admin_parent.and_then(|a| a.parent_id.clone());
                 }
 


### PR DESCRIPTION
Some city_district have the same insee than their city: we were loosing
some admins during the import and had an infinite loop when recreating the
hierarchy of addresses.
Now we only construct admin's id with insee for cities, and we always
create the id with `zones_osm_id` to make sure we have coherent id between
admin and their parents

This PR also include a check when constructing the admin hierarchies to prevent infinite loop: if we add an admin that had already been added we stop the loop.