### PR TITLE
output country_codes

### DIFF
--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -220,6 +220,8 @@ pub struct GeocodingResponse {
         default
     )]
     pub bbox: Option<geo_types::Rect<f64>>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub country_codes: Vec<String>,
 }
 
 trait ToGeom {
@@ -309,6 +311,7 @@ impl FromWithLang<mimir::Admin> for GeocodingResponse {
             label,
             bbox: other.bbox,
             codes: other.codes,
+            country_codes: other.country_codes,
             ..Default::default()
         }
     }
@@ -357,6 +360,7 @@ impl FromWithLang<mimir::Street> for GeocodingResponse {
             street: name,
             city: city,
             administrative_regions: associated_admins,
+            country_codes: other.country_codes,
             ..Default::default()
         }
     }
@@ -394,6 +398,7 @@ impl FromWithLang<mimir::Addr> for GeocodingResponse {
             street: street_name,
             city: city,
             administrative_regions: associated_admins,
+            country_codes: other.country_codes,
             ..Default::default()
         }
     }
@@ -446,6 +451,7 @@ impl FromWithLang<mimir::Poi> for GeocodingResponse {
                 }
                 _ => None,
             },
+            country_codes: other.country_codes,
             ..Default::default()
         }
     }
@@ -487,6 +493,7 @@ impl FromWithLang<mimir::Stop> for GeocodingResponse {
             codes: other.codes,
             properties: other.properties,
             feed_publishers: other.feed_publishers,
+            country_codes: other.country_codes,
             ..Default::default()
         }
     }

--- a/tests/bragi_bano_test.rs
+++ b/tests/bragi_bano_test.rs
@@ -86,6 +86,7 @@ fn simple_bano_autocomplete_test(bragi: &mut BragiHandler) {
                             "administrative_regions": [],
                             "city": null,
                             "citycode": null,
+                            "country_codes": ["fr"],
                             "housenumber": "15",
                             "id": "addr:2.376379;48.846495:15",
                             "label": "15 Rue Hector Malot (Paris)",
@@ -164,6 +165,7 @@ fn simple_bano_shape_filter_test(bragi: &mut BragiHandler) {
                   "postcode": "75012",
                   "city": null,
                   "citycode": null,
+                  "country_codes": ["fr"],
                   "administrative_regions": []
                 }
               }


### PR DESCRIPTION
following #304 output country_codes in the api

we do not implement the search on this field via bragi for the moment, but it would be easy to do so if the need arise