### PR TITLE
Always fetch all admins

### DIFF
--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -552,8 +552,7 @@ fn custom_multi_polygon_serialize<S>(
 where
     S: Serializer,
 {
-    use geojson::{GeoJson, Geometry, Value};
-    use serde::Serialize;
+    use geojson::{GeoJson, Value};
 
     match *multi_polygon_option {
         Some(ref multi_polygon) => {
@@ -569,9 +568,7 @@ fn custom_multi_polygon_deserialize<'de, D>(
 where
     D: serde::de::Deserializer<'de>,
 {
-    use geojson;
     use geojson::conversion::TryInto;
-    use serde::Deserialize;
 
     Option::<geojson::GeoJson>::deserialize(d).map(|option| {
         option.and_then(|geojson| match geojson {
@@ -598,8 +595,6 @@ pub fn serialize_rect<'a, S>(
 where
     S: serde::Serializer,
 {
-    use serde::Serialize;
-
     match bbox {
         Some(b) => {
             // bbox serialized as an array
@@ -616,8 +611,6 @@ fn deserialize_rect<'de, D>(d: D) -> Result<Option<geo_types::Rect<f64>>, D::Err
 where
     D: serde::Deserializer<'de>,
 {
-    use serde::Deserialize;
-
     Option::<Vec<f64>>::deserialize(d).map(|option| {
         option.map(|b| geo_types::Rect {
             min: geo_types::Coordinate { x: b[0], y: b[1] },

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -613,13 +613,6 @@ impl Rubber {
         Ok(nb_elements)
     }
 
-    pub fn get_admins_from_dataset(
-        &mut self,
-        dataset: &str,
-    ) -> Result<Vec<Admin>, rs_es::error::EsError> {
-        self.get_all_objects_from_index(&get_main_type_and_dataset_index::<Admin>(dataset))
-    }
-
     pub fn get_all_admins(&mut self) -> Result<Vec<Admin>, rs_es::error::EsError> {
         self.get_all_objects_from_index(&get_main_type_index::<Admin>())
     }

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -194,15 +194,13 @@ where
     let mut rubber = Rubber::new(cnx_string);
     rubber.initialize_templates()?;
 
-    let admins = rubber
-        .get_admins_from_dataset(dataset)
-        .unwrap_or_else(|err| {
-            info!(
-                "Administratives regions not found in es db for dataset {}. (error: {})",
-                dataset, err
-            );
-            vec![]
-        });
+    let admins = rubber.get_all_admins().unwrap_or_else(|err| {
+        info!(
+            "Administratives regions not found in es db for dataset {}. (error: {})",
+            dataset, err
+        );
+        vec![]
+    });
     let admins_geofinder = admins.iter().cloned().collect();
     let admins_by_insee = admins
         .into_iter()

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -195,7 +195,7 @@ where
     rubber.initialize_templates()?;
 
     let admins = rubber.get_all_admins().unwrap_or_else(|err| {
-        info!(
+        warn!(
             "Administratives regions not found in es db for dataset {}. (error: {})",
             dataset, err
         );

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -155,7 +155,7 @@ where
     let mut rubber = Rubber::new(cnx_string);
 
     let admins = rubber.get_all_admins().unwrap_or_else(|err| {
-        info!(
+        warn!(
             "Administratives regions not found in es db for dataset {}. (error: {})",
             dataset, err
         );

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -154,15 +154,13 @@ where
 {
     let mut rubber = Rubber::new(cnx_string);
 
-    let admins = rubber
-        .get_admins_from_dataset(dataset)
-        .unwrap_or_else(|err| {
-            info!(
-                "Administratives regions not found in es db for dataset {}. (error: {})",
-                dataset, err
-            );
-            vec![]
-        });
+    let admins = rubber.get_all_admins().unwrap_or_else(|err| {
+        info!(
+            "Administratives regions not found in es db for dataset {}. (error: {})",
+            dataset, err
+        );
+        vec![]
+    });
     let admins_geofinder = admins.into_iter().collect();
 
     import_addresses(

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -109,7 +109,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
     let admins = if args.import_admin {
         read_administrative_regions(&mut osm_reader, levels, city_level)
     } else {
-        rubber.get_admins_from_dataset(&args.dataset)?
+        rubber.get_all_admins()?
     };
     let admins_geofinder = admins.into_iter().collect::<AdminGeoFinder>();
     {

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -104,7 +104,7 @@ fn attach_stops_to_admins<'a, It: Iterator<Item = &'a mut mimir::Stop>>(
     rubber: &mut Rubber,
 ) {
     let admins = rubber.get_all_admins().unwrap_or_else(|_| {
-        info!("Administratives regions not found in elasticsearch db");
+        warn!("Administratives regions not found in elasticsearch db");
         vec![]
     });
 


### PR DESCRIPTION
fetching the admins only from the current dataset was not agodd idea, we need to fetch the admins from all the datasets.

this way we'll be able to import osm data either on a france dataset and on a nl dataset, and use the admins from cosmogony

it would be better to lazily fetch the admins, but it would be more difficult to implement, so I went to the easiest solution (and it's quite the same as before for either Qwant setup and Kisio's)