### PR TITLE
Use a connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,7 +1397,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.16",
+ "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.11.4",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1440,7 +1440,7 @@ dependencies = [
  "osmpbfreader 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.16",
+ "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.11.4",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2336,33 +2336,7 @@ dependencies = [
 name = "reqwest"
 version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie_store 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+replace = "reqwest 0.9.16"
 
 [[package]]
 name = "resolv-conf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
  "mimir 1.2.0",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.11.4",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_qs 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1397,8 +1397,8 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.16",
+ "rs-es 0.11.4",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1440,8 +1440,8 @@ dependencies = [
  "osmpbfreader 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.16",
+ "rs-es 0.11.4",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2304,6 +2304,37 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.9.16"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie_store 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2364,11 +2395,10 @@ dependencies = [
 [[package]]
 name = "rs-es"
 version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "geojson 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.16",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3741,7 +3771,6 @@ dependencies = [
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
 "checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
-"checksum rs-es 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "eb3392a829939d7a79983937cf50fc8769bdc9336672a09788e5b297244b6b49"
 "checksum rstar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "120bfe4837befb82c5a637a5a8c490a27d25524ac19fffec5b4e555ca6e36ee8"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
  "mimir 1.2.0",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.11.4",
+ "rs-es 0.11.4 (git+https://github.com/antoine-de/rs-es.git?branch=clonable_client)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_qs 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1398,7 +1398,7 @@ dependencies = [
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.11.4",
+ "rs-es 0.11.4 (git+https://github.com/antoine-de/rs-es.git?branch=clonable_client)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1441,7 +1441,7 @@ dependencies = [
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.11.4",
+ "rs-es 0.11.4 (git+https://github.com/antoine-de/rs-es.git?branch=clonable_client)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2304,6 +2304,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.9.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2331,12 +2332,6 @@ dependencies = [
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "reqwest"
-version = "0.9.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-replace = "reqwest 0.9.16"
 
 [[package]]
 name = "resolv-conf"
@@ -2369,10 +2364,11 @@ dependencies = [
 [[package]]
 name = "rs-es"
 version = "0.11.4"
+source = "git+https://github.com/antoine-de/rs-es.git?branch=clonable_client#ca978a4f2d5c0d40ec488325a07d24bc1310fb6a"
 dependencies = [
  "geojson 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.16",
+ "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3745,6 +3741,7 @@ dependencies = [
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
 "checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
+"checksum rs-es 0.11.4 (git+https://github.com/antoine-de/rs-es.git?branch=clonable_client)" = "<none>"
 "checksum rstar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "120bfe4837befb82c5a637a5a8c490a27d25524ac19fffec5b4e555ca6e36ee8"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ slog-envlogger = "2.1"
 slog-async = "2.3"
 structopt = "0.2"
 csv = "1"
-rs-es = {version = "^0.11.4", features = ["geo"]}
+rs-es = {path = "/home/antoine/dev/bin/rs-es", features = ["geo"]}
+#rs-es = {version = "^0.11.4", features = ["geo"]}
 regex = "1"
 osmpbfreader = "0.13"
 chrono = "0.4"
@@ -46,7 +47,8 @@ path = "libs/bragi"
 path = "libs/mimir"
 
 [dev-dependencies]
-reqwest = "0.9"
+#reqwest = "0.9"
+reqwest = { path = "/home/antoine/dev/bin/reqwest" }
 approx = "0.2.0"
 actix-web = "0.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ path = "libs/bragi"
 path = "libs/mimir"
 
 [dev-dependencies]
-#reqwest = "0.9"
-reqwest = { path = "/home/antoine/dev/bin/reqwest" }
+reqwest = "0.9"
+#reqwest = { path = "/home/antoine/dev/bin/reqwest" }
 approx = "0.2.0"
 actix-web = "0.7"
 
@@ -61,3 +61,9 @@ git-version = "0.2"
 # we just call one test method: cf. tests::all_tests()
 [[test]]
 name = "tests"
+
+#[patch.crates-io]
+#reqwest = { path = "/home/antoine/dev/bin/reqwest" }
+
+[replace]
+"reqwest:0.9.16" = { path = "/home/antoine/dev/bin/reqwest" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ slog-envlogger = "2.1"
 slog-async = "2.3"
 structopt = "0.2"
 csv = "1"
-rs-es = {path = "/home/antoine/dev/bin/rs-es", features = ["geo"]}
-#rs-es = {version = "^0.11.4", features = ["geo"]}
+rs-es = { git = "https://github.com/antoine-de/rs-es.git", branch = "clonable_client", version = "^0.11.4", features = ["geo"]}
 regex = "1"
 osmpbfreader = "0.13"
 chrono = "0.4"
@@ -48,7 +47,6 @@ path = "libs/mimir"
 
 [dev-dependencies]
 reqwest = "0.9"
-#reqwest = { path = "/home/antoine/dev/bin/reqwest" }
 approx = "0.2.0"
 actix-web = "0.7"
 
@@ -61,9 +59,3 @@ git-version = "0.2"
 # we just call one test method: cf. tests::all_tests()
 [[test]]
 name = "tests"
-
-#[patch.crates-io]
-#reqwest = { path = "/home/antoine/dev/bin/reqwest" }
-
-[replace]
-"reqwest:0.9.16" = { path = "/home/antoine/dev/bin/reqwest" }

--- a/libs/bragi/Cargo.toml
+++ b/libs/bragi/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2018"
 structopt = "0.2"
 slog = { version = "2.1", features = ["max_level_trace", "release_max_level_info"]}
 slog-scope = "4.0"
-rs-es = {version = "^0.11.4", features = ["geo"]}
+rs-es = {path = "/home/antoine/dev/bin/rs-es", features = ["geo"]}
+#rs-es = {version = "^0.11.4", features = ["geo"]}
 serde = {version = "1", features = ["rc"]}
 serde_json = "1"
 geojson = "0.15"

--- a/libs/bragi/Cargo.toml
+++ b/libs/bragi/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2018"
 structopt = "0.2"
 slog = { version = "2.1", features = ["max_level_trace", "release_max_level_info"]}
 slog-scope = "4.0"
-rs-es = {path = "/home/antoine/dev/bin/rs-es", features = ["geo"]}
-#rs-es = {version = "^0.11.4", features = ["geo"]}
+rs-es = { git = "https://github.com/antoine-de/rs-es.git", branch = "clonable_client", version = "^0.11.4", features = ["geo"]}
 serde = {version = "1", features = ["rc"]}
 serde_json = "1"
 geojson = "0.15"

--- a/libs/bragi/src/lib.rs
+++ b/libs/bragi/src/lib.rs
@@ -34,6 +34,8 @@ extern crate slog;
 extern crate slog_scope;
 #[macro_use]
 extern crate failure;
+use mimir::rubber::Rubber;
+use std::time::Duration;
 use structopt::StructOpt;
 
 mod extractors;
@@ -47,7 +49,7 @@ lazy_static::lazy_static! {
     static ref BRAGI_NB_THREADS: String = (8 * ::num_cpus::get()).to_string();
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(StructOpt, Debug, Clone)]
 pub struct Args {
     /// Address to bind.
     #[structopt(short = "b", long = "bind", default_value = "127.0.0.1:4000")]
@@ -76,15 +78,21 @@ pub struct Args {
 
 #[derive(Clone, Debug)]
 pub struct Context {
-    pub es_cnx_string: String, //TODO create a rs-es client
-    pub max_es_timeout: Option<std::time::Duration>,
+    pub rubber: Rubber,
 }
 
 impl From<&Args> for Context {
     fn from(args: &Args) -> Self {
+        let max_es_timeout = args.max_es_timeout.map(Duration::from_millis);
         Self {
-            es_cnx_string: args.connection_string.clone(),
-            max_es_timeout: args.max_es_timeout.map(std::time::Duration::from_millis),
+            rubber: Rubber::new_with_timeout(&args.connection_string, max_es_timeout.clone()),
         }
+    }
+}
+
+impl Context {
+    pub fn get_rubber(&self, timeout: Option<Duration>) -> Rubber {
+        // we clone the rs_es_client, reusing the reqwest connection pool
+        self.rubber.clone_with_timeout(timeout)
     }
 }

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -31,7 +31,7 @@ use super::model::{self, BragiError};
 use geojson::Geometry;
 use mimir;
 use mimir::objects::{Addr, Admin, Coord, MimirObject, Poi, Stop, Street};
-use mimir::rubber::{get_indexes, read_places};
+use mimir::rubber::{get_indexes, read_places, Rubber};
 use prometheus::{self, exponential_buckets, histogram_opts, register_histogram_vec, HistogramVec};
 use rs_es;
 use rs_es::error::EsError;
@@ -42,7 +42,7 @@ use rs_es::query::Query;
 use rs_es::units as rs_u;
 use serde;
 use serde_json;
-use std::{fmt, iter, time};
+use std::{fmt, iter};
 
 lazy_static::lazy_static! {
     static ref ES_REQ_HISTOGRAM: HistogramVec = register_histogram_vec!(
@@ -329,7 +329,7 @@ fn query(
     q: &str,
     pt_datasets: &[&str],
     all_data: bool,
-    client: &mut rs_es::Client,
+    rubber: &mut Rubber,
     match_type: MatchType,
     offset: u64,
     limit: u64,
@@ -339,7 +339,6 @@ fn query(
     zone_types: &[&str],
     poi_types: &[&str],
     langs: &[&str],
-    timeout: Option<time::Duration>,
 ) -> Result<Vec<mimir::Place>, EsError> {
     let query_type = match_type.to_string();
     let query = build_query(
@@ -374,8 +373,8 @@ fn query(
         )
         .ok();
 
-    let timeout = timeout.map(|t| format!("{:?}", t));
-    let mut search_query = client.search_query();
+    let timeout = rubber.timeout.map(|t| format!("{:?}", t));
+    let mut search_query = rubber.es_client.search_query();
 
     let search_query = search_query
         .with_ignore_unavailable(true)
@@ -400,9 +399,8 @@ fn query(
 pub fn features(
     pt_datasets: &[&str],
     all_data: bool,
-    cnx: &str,
     id: &str,
-    timeout: Option<time::Duration>,
+    mut rubber: Rubber,
 ) -> Result<Vec<mimir::Place>, BragiError> {
     let val = rs_es::units::JsonVal::String(id.into());
     let mut filters = vec![Query::build_ids(vec![val]).build()];
@@ -413,8 +411,6 @@ pub fn features(
     }
     let filter = Query::build_bool().with_must(filters).build();
     let query = Query::build_bool().with_filter(filter).build();
-
-    let mut client = rs_es::Client::init_with_timeout(cnx, timeout).unwrap();
 
     let indexes = get_indexes(all_data, &pt_datasets, &[]);
     let indexes = indexes
@@ -438,8 +434,8 @@ pub fn features(
         )
         .ok();
 
-    let timeout = timeout.map(|t| format!("{:?}", t));
-    let mut search_query = client.search_query();
+    let timeout = rubber.timeout.map(|t| format!("{:?}", t));
+    let mut search_query = rubber.es_client.search_query();
 
     let search_query = search_query
         .with_ignore_unavailable(true)
@@ -468,13 +464,12 @@ pub fn autocomplete(
     offset: u64,
     limit: u64,
     coord: Option<Coord>,
-    cnx: &str,
     shape: Option<Geometry>,
     types: &[&str],
     zone_types: &[&str],
     poi_types: &[&str],
     langs: &[&str],
-    timeout: Option<time::Duration>,
+    mut rubber: Rubber,
 ) -> Result<Vec<mimir::Place>, BragiError> {
     // Perform parameters validation.
     if !zone_types.is_empty() && !types.iter().any(|s| *s == "zone") {
@@ -488,15 +483,13 @@ pub fn autocomplete(
         ));
     }
 
-    let mut client = rs_es::Client::init_with_timeout(cnx, timeout).unwrap();
-
     // First we try a pretty exact match on the prefix.
     // If there are no results then we do a new fuzzy search (matching ngrams)
     let results = query(
         &q,
         &pt_datasets,
         all_data,
-        &mut client,
+        &mut rubber,
         MatchType::Prefix,
         offset,
         limit,
@@ -506,7 +499,6 @@ pub fn autocomplete(
         &zone_types,
         &poi_types,
         &langs,
-        timeout,
     )
     .map_err(model::BragiError::from)?;
     if results.is_empty() {
@@ -514,7 +506,7 @@ pub fn autocomplete(
             &q,
             &pt_datasets,
             all_data,
-            &mut client,
+            &mut rubber,
             MatchType::Fuzzy,
             offset,
             limit,
@@ -524,7 +516,6 @@ pub fn autocomplete(
             &zone_types,
             &poi_types,
             &langs,
-            timeout,
         )
         .map_err(model::BragiError::from)
     } else {

--- a/libs/bragi/src/routes/autocomplete.rs
+++ b/libs/bragi/src/routes/autocomplete.rs
@@ -129,7 +129,7 @@ pub fn call_autocomplete(
     shape: Option<Geometry>,
 ) -> Result<Json<Autocomplete>, model::BragiError> {
     let langs = params.langs();
-    let timeout = params::get_timeout(&params.timeout(), &state.max_es_timeout);
+    let rubber = state.get_rubber(params.timeout());
     let res = query::autocomplete(
         &params.q,
         &params
@@ -141,13 +141,12 @@ pub fn call_autocomplete(
         params.offset,
         params.limit,
         params.coord()?,
-        &state.es_cnx_string,
         shape,
         &params.types_as_str(),
         &params.zone_types_as_str(),
         &params.poi_types_as_str(),
         &langs,
-        timeout,
+        rubber,
     );
     res.map(|r| Autocomplete::from_with_lang(r, langs.into_iter().next()))
         .map(Json)

--- a/libs/bragi/src/routes/autocomplete.rs
+++ b/libs/bragi/src/routes/autocomplete.rs
@@ -129,7 +129,7 @@ pub fn call_autocomplete(
     shape: Option<Geometry>,
 ) -> Result<Json<Autocomplete>, model::BragiError> {
     let langs = params.langs();
-    let rubber = state.get_rubber(params.timeout());
+    let rubber = state.get_rubber_for_autocomplete(params.timeout());
     let res = query::autocomplete(
         &params.q,
         &params

--- a/libs/bragi/src/routes/features.rs
+++ b/libs/bragi/src/routes/features.rs
@@ -19,7 +19,7 @@ pub fn features(
     state: State<Context>,
     id: Path<String>,
 ) -> Result<Json<model::Autocomplete>, model::BragiError> {
-    let rubber = state.get_rubber(params.timeout.map(Duration::from_millis));
+    let rubber = state.get_rubber_for_features(params.timeout.map(Duration::from_millis));
     let features = query::features(
         &params
             .pt_dataset

--- a/libs/bragi/src/routes/features.rs
+++ b/libs/bragi/src/routes/features.rs
@@ -1,5 +1,4 @@
 use crate::extractors::BragiQuery;
-use crate::routes::params;
 use crate::{model, model::FromWithLang, query, Context};
 use actix_web::{Json, Path, State};
 use serde::{Deserialize, Serialize};
@@ -20,10 +19,7 @@ pub fn features(
     state: State<Context>,
     id: Path<String>,
 ) -> Result<Json<model::Autocomplete>, model::BragiError> {
-    let timeout = params::get_timeout(
-        &params.timeout.map(Duration::from_millis),
-        &state.max_es_timeout,
-    );
+    let rubber = state.get_rubber(params.timeout.map(Duration::from_millis));
     let features = query::features(
         &params
             .pt_dataset
@@ -31,9 +27,8 @@ pub fn features(
             .map(String::as_str)
             .collect::<Vec<_>>(),
         params.all_data,
-        &state.es_cnx_string,
         &*id,
-        timeout,
+        rubber,
     );
     features
         .map(|r| model::Autocomplete::from_with_lang(r, None))

--- a/libs/bragi/src/routes/params.rs
+++ b/libs/bragi/src/routes/params.rs
@@ -1,19 +1,5 @@
 use crate::model::BragiError;
 use mimir::objects::Coord;
-use std::time::Duration;
-
-pub fn get_timeout(
-    query_timeout: &Option<Duration>,
-    default_timeout: &Option<Duration>,
-) -> Option<Duration> {
-    query_timeout
-        .clone()
-        .map(|t| match default_timeout {
-            Some(dt) => t.min(*dt),
-            None => t,
-        })
-        .or_else(|| default_timeout.clone())
-}
 
 pub fn make_coord(lon: f64, lat: f64) -> Result<Coord, BragiError> {
     if lon < -90f64 || lon > 90f64 {

--- a/libs/bragi/src/routes/reverse.rs
+++ b/libs/bragi/src/routes/reverse.rs
@@ -2,7 +2,6 @@ use crate::extractors::BragiQuery;
 use crate::routes::params;
 use crate::{model, model::FromWithLang, Context};
 use actix_web::{Json, State};
-use mimir::rubber::Rubber;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -18,14 +17,10 @@ pub fn reverse(
     params: BragiQuery<Params>,
     state: State<Context>,
 ) -> Result<Json<model::Autocomplete>, model::BragiError> {
-    let timeout = params::get_timeout(
-        &params.timeout.map(Duration::from_millis),
-        &state.max_es_timeout,
-    );
-    let mut rubber = Rubber::new_with_timeout(&state.es_cnx_string, timeout);
+    let mut rubber = state.get_rubber(params.timeout.map(Duration::from_millis));
     let coord = params::make_coord(params.lon, params.lat)?;
     rubber
-        .get_address(&coord, timeout)
+        .get_address(&coord)
         .map_err(model::BragiError::from)
         .map(|r| model::Autocomplete::from_with_lang(r, None))
         .map(Json)

--- a/libs/bragi/src/routes/reverse.rs
+++ b/libs/bragi/src/routes/reverse.rs
@@ -17,7 +17,7 @@ pub fn reverse(
     params: BragiQuery<Params>,
     state: State<Context>,
 ) -> Result<Json<model::Autocomplete>, model::BragiError> {
-    let mut rubber = state.get_rubber(params.timeout.map(Duration::from_millis));
+    let mut rubber = state.get_rubber_for_reverse(params.timeout.map(Duration::from_millis));
     let coord = params::make_coord(params.lon, params.lat)?;
     rubber
         .get_address(&coord)

--- a/libs/bragi/src/routes/status.rs
+++ b/libs/bragi/src/routes/status.rs
@@ -12,7 +12,7 @@ pub struct Status {
 pub fn status(state: State<Context>) -> Json<Status> {
     Json(Status {
         version: env!("CARGO_PKG_VERSION").to_string(),
-        es: state.rubber.cnx_string.clone(),
+        es: state.cnx_string.clone(),
         status: "good".to_string(),
     })
 }

--- a/libs/bragi/src/routes/status.rs
+++ b/libs/bragi/src/routes/status.rs
@@ -12,7 +12,7 @@ pub struct Status {
 pub fn status(state: State<Context>) -> Json<Status> {
     Json(Status {
         version: env!("CARGO_PKG_VERSION").to_string(),
-        es: state.es_cnx_string.clone(),
+        es: state.rubber.cnx_string.clone(),
         status: "good".to_string(),
     })
 }

--- a/libs/mimir/Cargo.toml
+++ b/libs/mimir/Cargo.toml
@@ -12,8 +12,7 @@ slog-scope = "4"
 slog-envlogger = "2.1.0"
 slog-stdlog = "3.0.2"
 slog-async = "2.2.0"
-#rs-es = {version = "^0.11.4", features = ["geo"]}
-rs-es = {path = "/home/antoine/dev/bin/rs-es", features = ["geo"]}
+rs-es = { git = "https://github.com/antoine-de/rs-es.git", branch = "clonable_client", version = "^0.11.4", features = ["geo"]}
 serde = {version = "1", features = ["rc"]}
 serde_json = "1"
 chrono = "0.4"

--- a/libs/mimir/Cargo.toml
+++ b/libs/mimir/Cargo.toml
@@ -12,11 +12,13 @@ slog-scope = "4"
 slog-envlogger = "2.1.0"
 slog-stdlog = "3.0.2"
 slog-async = "2.2.0"
-rs-es = {version = "^0.11.4", features = ["geo"]}
+#rs-es = {version = "^0.11.4", features = ["geo"]}
+rs-es = {path = "/home/antoine/dev/bin/rs-es", features = ["geo"]}
 serde = {version = "1", features = ["rc"]}
 serde_json = "1"
 chrono = "0.4"
-reqwest = "0.9"
+#reqwest = "0.9"
+reqwest = { path = "/home/antoine/dev/bin/reqwest" }
 geo = "0.12"
 geo-types = "0.4"
 geojson = "0.15"

--- a/libs/mimir/Cargo.toml
+++ b/libs/mimir/Cargo.toml
@@ -17,8 +17,8 @@ rs-es = {path = "/home/antoine/dev/bin/rs-es", features = ["geo"]}
 serde = {version = "1", features = ["rc"]}
 serde_json = "1"
 chrono = "0.4"
-#reqwest = "0.9"
-reqwest = { path = "/home/antoine/dev/bin/reqwest" }
+reqwest = "0.9"
+#reqwest = { path = "/home/antoine/dev/bin/reqwest" }
 geo = "0.12"
 geo-types = "0.4"
 geojson = "0.15"

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -262,26 +262,6 @@ impl Rubber {
         }
     }
 
-    /// Clone rubber and change the timeout
-    /// Note: the timeout cannot be increased, it can only be reduced
-    /// (to protect bragi agains malicius use)
-    /// The first given timeout is thus an upper bound
-    pub fn clone_with_timeout(&self, timeout: Option<time::Duration>) -> Rubber {
-        // the timeout is the min between the timeout set at startup time and at query time
-        let timeout = timeout
-            .clone()
-            .map(|t| match self.timeout {
-                Some(dt) => t.min(dt),
-                None => t,
-            })
-            .or_else(|| self.timeout.clone());
-
-        let mut new_rubber = self.clone();
-        new_rubber.es_client.set_timeout(timeout);
-        new_rubber.http_client.timeout(timeout);
-        new_rubber
-    }
-
     pub fn get(&self, path: &str) -> Result<reqwest::Response, EsError> {
         // Note: a bit duplicate on rs_es because some ES operations are not implemented
         debug!("doing a get on {}", path);

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -297,7 +297,7 @@ pub fn compute_poi_weight(pois_vec: &mut [Poi]) {
 pub fn add_address(pois_vec: &mut [Poi], rubber: &mut rubber::Rubber) {
     for poi in pois_vec {
         poi.address = rubber
-            .get_address(&poi.coord, None)
+            .get_address(&poi.coord)
             .ok()
             .and_then(|addrs| addrs.into_iter().next())
             .map(|addr| addr.address().unwrap());

--- a/tests/bragi_bano_test.rs
+++ b/tests/bragi_bano_test.rs
@@ -34,7 +34,7 @@ use serde_json::json;
 use std::path::Path;
 
 pub fn bragi_bano_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
-    let mut bragi = BragiHandler::new(format!("{}/munin", es_wrapper.host()));
+    let mut bragi = BragiHandler::new(es_wrapper.host());
 
     // *********************************
     // We load bano files

--- a/tests/bragi_filter_types_test.rs
+++ b/tests/bragi_filter_types_test.rs
@@ -34,7 +34,7 @@ use serde_json::json;
 use std::path::Path;
 
 pub fn bragi_filter_types_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
-    let mut bragi = BragiHandler::new(format!("{}/munin", es_wrapper.host()));
+    let mut bragi = BragiHandler::new(es_wrapper.host());
     let out_dir = Path::new(env!("OUT_DIR"));
 
     // ******************************************

--- a/tests/bragi_ntfs_test.rs
+++ b/tests/bragi_ntfs_test.rs
@@ -34,7 +34,7 @@ use serde_json::json;
 use std::path::Path;
 
 pub fn bragi_ntfs_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
-    let mut bragi = BragiHandler::new(format!("{}/munin", es_wrapper.host()));
+    let mut bragi = BragiHandler::new(es_wrapper.host());
     let out_dir = Path::new(env!("OUT_DIR"));
 
     let ntfs2mimir = out_dir.join("../../../ntfs2mimir").display().to_string();

--- a/tests/bragi_osm_test.rs
+++ b/tests/bragi_osm_test.rs
@@ -36,7 +36,7 @@ use super::BragiHandler;
 use std::path::Path;
 
 pub fn bragi_osm_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
-    let mut bragi = BragiHandler::new(format!("{}/munin", es_wrapper.host()));
+    let mut bragi = BragiHandler::new(es_wrapper.host());
 
     // *********************************
     // We load the OSM dataset (including ways)

--- a/tests/bragi_poi_test.rs
+++ b/tests/bragi_poi_test.rs
@@ -40,7 +40,7 @@ use serde_json::json;
 use std::path::Path;
 
 pub fn bragi_poi_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
-    let mut bragi = BragiHandler::new(format!("{}/munin", es_wrapper.host()));
+    let mut bragi = BragiHandler::new(es_wrapper.host());
 
     // ******************************************
     // We load three-cities bano dataset and then the OSM dataset (with the POIs)

--- a/tests/bragi_stops_test.rs
+++ b/tests/bragi_stops_test.rs
@@ -33,7 +33,7 @@ use super::BragiHandler;
 use std::path::Path;
 
 pub fn bragi_stops_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
-    let mut bragi = BragiHandler::new(format!("{}/munin", es_wrapper.host()));
+    let mut bragi = BragiHandler::new(es_wrapper.host());
     let out_dir = Path::new(env!("OUT_DIR"));
 
     // ******************************************

--- a/tests/bragi_synonyms_test.rs
+++ b/tests/bragi_synonyms_test.rs
@@ -33,7 +33,7 @@ use super::BragiHandler;
 use std::path::Path;
 
 pub fn bragi_synonyms_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
-    let mut bragi = BragiHandler::new(format!("{}/munin", es_wrapper.host()));
+    let mut bragi = BragiHandler::new(es_wrapper.host());
     let out_dir = Path::new(env!("OUT_DIR"));
 
     // ******************************************

--- a/tests/bragi_three_cities_test.rs
+++ b/tests/bragi_three_cities_test.rs
@@ -36,7 +36,7 @@ use super::BragiHandler;
 use std::path::Path;
 
 pub fn bragi_three_cities_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
-    let mut bragi = BragiHandler::new(format!("{}/munin", es_wrapper.host()));
+    let mut bragi = BragiHandler::new(es_wrapper.host());
     let out_dir = Path::new(env!("OUT_DIR"));
 
     // *********************************

--- a/tests/canonical_import_process_test.rs
+++ b/tests/canonical_import_process_test.rs
@@ -43,7 +43,7 @@ use std::path::Path;
 /// then openaddress (or bano),
 /// then osm (without any admins)
 pub fn canonical_import_process_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
-    let mut bragi = BragiHandler::new(format!("{}/munin", es_wrapper.host()));
+    let mut bragi = BragiHandler::new(es_wrapper.host());
     let out_dir = Path::new(env!("OUT_DIR"));
 
     let cosmogony2mimir = out_dir

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -215,8 +215,7 @@ impl BragiHandler {
     pub fn new(url: String) -> BragiHandler {
         let make_server = move || {
             bragi::server::create_server(bragi::Context {
-                es_cnx_string: url.clone(),
-                max_es_timeout: None,
+                rubber: mimir::rubber::Rubber::new(&url),
             })
         };
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -214,9 +214,10 @@ pub struct BragiHandler {
 impl BragiHandler {
     pub fn new(url: String) -> BragiHandler {
         let make_server = move || {
-            bragi::server::create_server(bragi::Context {
-                rubber: mimir::rubber::Rubber::new(&url),
-            })
+            bragi::server::create_server(bragi::Context::from(&bragi::Args {
+                connection_string: url.clone(),
+                ..Default::default()
+            }))
         };
 
         BragiHandler {


### PR DESCRIPTION
Reuse the same connections when querying ES by storing a rubber in the Actix's `State`

since synchronous reqwest 0.9.18 does not work in a asynchronous (actix) context, we are not able to update reqwest to be able to change the timeout.

To work around this limitation, we create 1 rubber / route (/autocomplete, /features and /reverse), and use this rubber (and thus the connection pool associated) if a different timeout has not been specified in the query.

That is not very neat, but this greatly reduce the cost calling ES (from 20ms to 1ms on my computer for dumb query)


depends on https://github.com/benashford/rs-es/pull/137