### PR TITLE
Feature: Handling private indices

### DIFF
--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -57,7 +57,7 @@ where
     info!("importing addresses: {} addresses added.", nb);
 
     rubber
-        .publish_index(dataset, addr_index)
+        .publish_index(dataset, addr_index, false) // false, by default addresses are not private
         .context("Error while publishing the index")?;
     Ok(())
 }

--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -1,7 +1,7 @@
 use crate::Error;
 use csv;
 use failure::ResultExt;
-use mimir::rubber::{IndexSettings, Rubber};
+use mimir::rubber::{IndexSettings, IndexVisibility, Rubber};
 use mimir::Addr;
 use par_map::ParMap;
 use serde::de::DeserializeOwned;
@@ -57,7 +57,7 @@ where
     info!("importing addresses: {} addresses added.", nb);
 
     rubber
-        .publish_index(dataset, addr_index, false) // false, by default addresses are not private
+        .publish_index(dataset, addr_index, IndexVisibility::Public)
         .context("Error while publishing the index")?;
     Ok(())
 }

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -133,7 +133,7 @@ fn send_to_es(
 ) -> Result<(), Error> {
     let mut rubber = Rubber::new(cnx_string);
     rubber.initialize_templates()?;
-    let nb_admins = rubber.index(dataset, &index_settings, admins)?;
+    let nb_admins = rubber.index(dataset, false, &index_settings, admins)?;
     info!("{} admins added.", nb_admins);
     Ok(())
 }

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -133,7 +133,7 @@ fn send_to_es(
 ) -> Result<(), Error> {
     let mut rubber = Rubber::new(cnx_string);
     rubber.initialize_templates()?;
-    let nb_admins = rubber.index(dataset, false, &index_settings, admins)?;
+    let nb_admins = rubber.public_index(dataset, &index_settings, admins)?;
     info!("{} admins added.", nb_admins);
     Ok(())
 }

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -126,7 +126,12 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
             };
             info!("importing streets into Mimir");
             let nb_streets = rubber
-                .index(&args.dataset, &street_index_settings, streets.into_iter())
+                .index(
+                    &args.dataset,
+                    false,
+                    &street_index_settings,
+                    streets.into_iter(),
+                )
                 .with_context(|_| {
                     format!(
                         "Error occurred when requesting street number in {}",
@@ -144,6 +149,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         let nb_admins = rubber
             .index(
                 &args.dataset,
+                false,
                 &admin_index_settings,
                 admins_geofinder.admins(),
             )
@@ -181,7 +187,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         };
         info!("Importing pois into Mimir");
         let nb_pois = rubber
-            .index(&args.dataset, &poi_index_settings, pois.into_iter())
+            .index(&args.dataset, false, &poi_index_settings, pois.into_iter())
             .context("Importing pois into Mimir")?;
 
         info!("Nb of indexed pois: {}", nb_pois);

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -126,12 +126,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
             };
             info!("importing streets into Mimir");
             let nb_streets = rubber
-                .index(
-                    &args.dataset,
-                    false,
-                    &street_index_settings,
-                    streets.into_iter(),
-                )
+                .public_index(&args.dataset, &street_index_settings, streets.into_iter())
                 .with_context(|_| {
                     format!(
                         "Error occurred when requesting street number in {}",
@@ -147,9 +142,8 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
             nb_replicas: args.nb_admin_replicas,
         };
         let nb_admins = rubber
-            .index(
+            .public_index(
                 &args.dataset,
-                false,
                 &admin_index_settings,
                 admins_geofinder.admins(),
             )
@@ -187,7 +181,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         };
         info!("Importing pois into Mimir");
         let nb_pois = rubber
-            .index(&args.dataset, false, &poi_index_settings, pois.into_iter())
+            .public_index(&args.dataset, &poi_index_settings, pois.into_iter())
             .context("Importing pois into Mimir")?;
 
         info!("Nb of indexed pois: {}", nb_pois);

--- a/src/bin/poi2mimir.rs
+++ b/src/bin/poi2mimir.rs
@@ -151,6 +151,7 @@ fn index_poi(
     cnx_string: &str,
     dataset: &str,
     file: &PathBuf,
+    private: bool,
     nb_shards: usize,
     nb_replicas: usize,
 ) -> Result<(), mimirsbrunn::Error>
@@ -169,7 +170,7 @@ where
     import_pois(&mut rubber, &index, file)?;
 
     rubber
-        .publish_index(dataset, index)
+        .publish_index(dataset, index, private)
         .map_err(|err| format_err!("Failed to publish index {}.", err))
 }
 
@@ -191,6 +192,10 @@ struct Args {
     /// A dataset is a label, that can be used for filtering the data.
     #[structopt(short = "d", long = "dataset", default_value = "fr")]
     dataset: String,
+
+    /// Indicate if the POI dataset is private
+    #[structopt(short = "p", long = "private")]
+    private: bool,
 
     /// Number of threads to use
     #[structopt(
@@ -214,6 +219,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         &args.connection_string,
         &args.dataset,
         &args.input,
+        args.private,
         args.nb_shards,
         args.nb_replicas,
     )

--- a/src/bin/poi2mimir.rs
+++ b/src/bin/poi2mimir.rs
@@ -36,7 +36,7 @@ extern crate slog_scope;
 use failure::format_err;
 use lazy_static::lazy_static;
 use mimir::objects::{Coord, I18nProperties, Poi, PoiType, Property};
-use mimir::rubber::{IndexSettings, Rubber, TypedIndex};
+use mimir::rubber::{IndexSettings, IndexVisibility, Rubber, TypedIndex};
 use mimirsbrunn::{labels, utils};
 use navitia_poi_model::{Model as NavitiaModel, Poi as NavitiaPoi, PoiType as NavitiaPoiType};
 use std::collections::HashMap;
@@ -151,7 +151,7 @@ fn index_poi(
     cnx_string: &str,
     dataset: &str,
     file: &PathBuf,
-    private: bool,
+    visibility: IndexVisibility,
     nb_shards: usize,
     nb_replicas: usize,
 ) -> Result<(), mimirsbrunn::Error>
@@ -170,7 +170,7 @@ where
     import_pois(&mut rubber, &index, file)?;
 
     rubber
-        .publish_index(dataset, index, private)
+        .publish_index(dataset, index, visibility)
         .map_err(|err| format_err!("Failed to publish index {}.", err))
 }
 
@@ -215,11 +215,17 @@ struct Args {
 }
 
 fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
+    let visibility = if args.private {
+        IndexVisibility::Private
+    } else {
+        IndexVisibility::Public
+    };
+
     index_poi(
         &args.connection_string,
         &args.dataset,
         &args.input,
-        args.private,
+        visibility,
         args.nb_shards,
         args.nb_replicas,
     )

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -75,7 +75,7 @@ pub fn import_stops(
         update_global_stop_index(&mut rubber, stops.iter(), dataset, &index_settings)?;
 
     info!("Importing {} stops into Mimir", stops.len());
-    let nb_stops = rubber.index(dataset, &index_settings, stops.into_iter())?;
+    let nb_stops = rubber.index(dataset, false, &index_settings, stops.into_iter())?;
     info!("Nb of indexed stops: {}", nb_stops);
 
     publish_global_index(&mut rubber, &global_index)

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -75,7 +75,7 @@ pub fn import_stops(
         update_global_stop_index(&mut rubber, stops.iter(), dataset, &index_settings)?;
 
     info!("Importing {} stops into Mimir", stops.len());
-    let nb_stops = rubber.index(dataset, false, &index_settings, stops.into_iter())?;
+    let nb_stops = rubber.public_index(dataset, &index_settings, stops.into_iter())?;
     info!("Nb of indexed stops: {}", nb_stops);
 
     publish_global_index(&mut rubber, &global_index)

--- a/tests/bragi_poi_test.rs
+++ b/tests/bragi_poi_test.rs
@@ -313,9 +313,12 @@ pub fn test_i18n_poi(mut es: crate::ElasticSearchWrapper<'_>) {
         nb_replicas: 1,
     };
     // we index the poi above
-    let _result = es
-        .rubber
-        .index("munin_poi", &index_settings, std::iter::once(colosseo));
+    let _result = es.rubber.index(
+        "munin_poi",
+        false,
+        &index_settings,
+        std::iter::once(colosseo),
+    );
 
     es.refresh();
 

--- a/tests/bragi_poi_test.rs
+++ b/tests/bragi_poi_test.rs
@@ -313,12 +313,9 @@ pub fn test_i18n_poi(mut es: crate::ElasticSearchWrapper<'_>) {
         nb_replicas: 1,
     };
     // we index the poi above
-    let _result = es.rubber.index(
-        "munin_poi",
-        false,
-        &index_settings,
-        std::iter::once(colosseo),
-    );
+    let _result = es
+        .rubber
+        .public_index("munin_poi", &index_settings, std::iter::once(colosseo));
 
     es.refresh();
 

--- a/tests/poi2mimir_test.rs
+++ b/tests/poi2mimir_test.rs
@@ -30,6 +30,7 @@
 
 use super::get_first_index_aliases;
 use reqwest;
+use serde_json::value::Value;
 use std::path::Path;
 
 /// Inserts POI into Elasticsearch and check results.
@@ -64,48 +65,66 @@ pub fn poi2mimir_sample_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         &es_wrapper,
     );
 
+    // Now import some POI. We will assume this is a private dataset, so we pass
+    // the private flag to poi2mimir.
     let poi2mimir = out_dir.join("../../../poi2mimir").display().to_string();
     crate::launch_and_assert(
         &poi2mimir,
         &[
             "--input=./tests/fixtures/poi/test.poi".into(),
             format!("--connection-string={}", es_wrapper.host()),
+            "--dataset=mti".into(),
+            "--private".into(),
         ],
         &es_wrapper,
     );
 
-    // Make sure import went smoothly by checking the number of indices.
-
-    // after an import, we should have 1 index, and some aliases to this index
+    // Now we'll make sure that the 'munin_poi_mti_{timestamp}' index is aliased by only one alias,
+    // Namely 'munin_poi_mti'. So we'll get all the aliases.
     let mut res = reqwest::get(&format!("{host}/_aliases", host = es_wrapper.host())).unwrap();
     assert_eq!(res.status(), reqwest::StatusCode::OK);
 
-    let json: serde_json::value::Value = res.json().unwrap();
+    let json: Value = res.json().unwrap();
     let raw_indexes = json.as_object().unwrap();
+
     let first_indexes: Vec<String> = raw_indexes.keys().cloned().collect();
 
-    assert_eq!(first_indexes.len(), 3); // 3 indexes
-                                        // our index should be aliased by the master_index + an alias over the document type + dataset
-    let aliases = get_first_index_aliases(raw_indexes);
+    let raw_poi_index = first_indexes
+        .iter()
+        .find(|index| index.starts_with("munin_poi_mti"))
+        .unwrap();
 
-    // for the moment 'munin' is hard coded, but hopefully that will change
-    assert_eq!(
-        aliases,
-        vec!["munin", "munin_addr", "munin_addr_fr", "munin_geo_data"]
-    );
+    // The result of raw_indexes[raw_poi_index] is an object that looks like:
+    // Object({"aliases": Object({"munin_poi_mti": Object({})})})
+    // So we turn it into a map, get the 'aliases' value,
+    // turn the result into a map, and get the key (hopefully its unique).
+    let poi_index_alias = raw_indexes
+        .get(raw_poi_index)
+        .and_then(|json| json.as_object())
+        .and_then(|s| s.get("aliases"))
+        .and_then(|json| json.as_object())
+        .and_then(|s| s.keys().cloned().next())
+        .unwrap_or_else(String::new);
 
-    // Making sure that there are as many POI in ES as there are the input file.
-    assert_eq!(es_wrapper.count("_type:poi"), 2);
+    assert_eq!(poi_index_alias, "munin_poi_mti");
+
+    //let aliases = get_first_index_aliases(raw_indexes);
+
+    // Now we're sure we're hitting the munin_poi_mti index, count how many documents
+    // we have in there.
+    assert_eq!(es_wrapper.count("munin_poi_mti", "_type:poi"), 2);
+
+    // Ok, now check that we can get a POI on that index
+    let agence_du_four = es_wrapper
+        .search_and_filter_on_index("munin_poi_mti", "label:Agence TCL Du Four", |place| {
+            place.label().starts_with("Agence TCL Du Four à Chaux")
+        })
+        .next()
+        .expect("Could not find Agence TCL Du Four");
+    assert!(agence_du_four.is_poi());
 
     // We test that the POI that was close to an address has been 'attached' to that address,
     // and inherited its admin and address: (Note that the data have been manipulated to fit)
-    let agence_du_four = es_wrapper
-        .search_and_filter("label:Agence TCL Du Four", |_| true)
-        .filter(|place| place.label().starts_with("Agence TCL Du Four à Chaux"))
-        .next()
-        .unwrap();
-    assert!(agence_du_four.is_poi());
-
     assert_eq!(
         agence_du_four
             .admins()
@@ -119,10 +138,18 @@ pub fn poi2mimir_sample_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
     // If the POI has a city admin, then its weight is that of the city (or at least != 0.0)
     assert_ne!(agence_du_four.poi().unwrap().weight, 0.0);
 
+    // Make sure that that POI is not visible from the global index
+    assert!(es_wrapper
+        .search_and_filter("label:Agence TCL Du Four", |place| {
+            place.label().starts_with("Agence TCL Du Four à Chaux")
+        })
+        .next()
+        .is_none());
+
     // We test the opposite of the previous case: a POI that is far from any address
     // Currently, this POI should not even be in the index...
     assert!(es_wrapper
-        .search_and_filter("label:Station Bellecour", |_| true)
+        .search_and_filter_on_index("munin_poi_mti", "label:Station Bellecour", |_| true)
         .filter(|place| place.label().contains("Station Bellecour"))
         .next()
         .is_none());

--- a/tests/poi2mimir_test.rs
+++ b/tests/poi2mimir_test.rs
@@ -28,7 +28,6 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use super::get_first_index_aliases;
 use reqwest;
 use serde_json::value::Value;
 use std::path::Path;
@@ -108,8 +107,6 @@ pub fn poi2mimir_sample_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
 
     assert_eq!(poi_index_alias, "munin_poi_mti");
 
-    //let aliases = get_first_index_aliases(raw_indexes);
-
     // Now we're sure we're hitting the munin_poi_mti index, count how many documents
     // we have in there.
     assert_eq!(es_wrapper.count("munin_poi_mti", "_type:poi"), 2);
@@ -149,8 +146,9 @@ pub fn poi2mimir_sample_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
     // We test the opposite of the previous case: a POI that is far from any address
     // Currently, this POI should not even be in the index...
     assert!(es_wrapper
-        .search_and_filter_on_index("munin_poi_mti", "label:Station Bellecour", |_| true)
-        .filter(|place| place.label().contains("Station Bellecour"))
+        .search_and_filter_on_index("munin_poi_mti", "label:Station Bellecour", |place| place
+            .label()
+            .contains("Station Bellecour"))
         .next()
         .is_none());
 }

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -84,7 +84,7 @@ pub fn rubber_zero_downtime_test(mut es: crate::ElasticSearchWrapper<'_>) {
     };
     let result = es
         .rubber
-        .index(dataset, false, &index_settings, std::iter::once(bob));
+        .public_index(dataset, &index_settings, std::iter::once(bob));
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1); // we have indexed 1 element
@@ -115,7 +115,7 @@ pub fn rubber_zero_downtime_test(mut es: crate::ElasticSearchWrapper<'_>) {
         nb_shards: 2,
         nb_replicas: 1,
     };
-    let result = rubber.index(dataset, false, &index_settings, checker_iter);
+    let result = rubber.public_index(dataset, &index_settings, checker_iter);
     assert!(
         result.is_ok(),
         "impossible to index bobette, res: {:?}",
@@ -182,7 +182,7 @@ pub fn rubber_custom_id(mut es: crate::ElasticSearchWrapper<'_>) {
     };
     let result = es
         .rubber
-        .index(dataset, false, &index_settings, std::iter::once(admin));
+        .public_index(dataset, &index_settings, std::iter::once(admin));
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1); // we have indexed 1 element
@@ -279,7 +279,7 @@ pub fn rubber_ghost_index_cleanup(mut es: crate::ElasticSearchWrapper<'_>) {
     };
     let result = es
         .rubber
-        .index("fr", false, &index_settings, std::iter::once(admin));
+        .public_index("fr", &index_settings, std::iter::once(admin));
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1); // we have indexed 1 element

--- a/tests/rubber_test.rs
+++ b/tests/rubber_test.rs
@@ -84,7 +84,7 @@ pub fn rubber_zero_downtime_test(mut es: crate::ElasticSearchWrapper<'_>) {
     };
     let result = es
         .rubber
-        .index(dataset, &index_settings, std::iter::once(bob));
+        .index(dataset, false, &index_settings, std::iter::once(bob));
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1); // we have indexed 1 element
@@ -115,7 +115,7 @@ pub fn rubber_zero_downtime_test(mut es: crate::ElasticSearchWrapper<'_>) {
         nb_shards: 2,
         nb_replicas: 1,
     };
-    let result = rubber.index(dataset, &index_settings, checker_iter);
+    let result = rubber.index(dataset, false, &index_settings, checker_iter);
     assert!(
         result.is_ok(),
         "impossible to index bobette, res: {:?}",
@@ -182,7 +182,7 @@ pub fn rubber_custom_id(mut es: crate::ElasticSearchWrapper<'_>) {
     };
     let result = es
         .rubber
-        .index(dataset, &index_settings, std::iter::once(admin));
+        .index(dataset, false, &index_settings, std::iter::once(admin));
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1); // we have indexed 1 element
@@ -279,7 +279,7 @@ pub fn rubber_ghost_index_cleanup(mut es: crate::ElasticSearchWrapper<'_>) {
     };
     let result = es
         .rubber
-        .index("fr", &index_settings, std::iter::once(admin));
+        .index("fr", false, &index_settings, std::iter::once(admin));
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1); // we have indexed 1 element


### PR DESCRIPTION
This commit adds a flag 'private' to rubber's `publish_index` function
so that a private index is not aliased by global indices, eg munin.

This flag is propagated to poi2mimir's command line, so that we can
import private POIs.

There are also modifications of the elastic search wrapper to allow
queries on non global indices.