### PR TITLE
update the minimum supported rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: rust
 cache: cargo
 rust:
   - stable
-  - beta
-  - nightly
+  - 1.36.0
 env:
   - RUN=TEST
 script:

--- a/docker/Dockerfile_bragi
+++ b/docker/Dockerfile_bragi
@@ -27,6 +27,6 @@ COPY --from=builder /srv/mimirsbrunn/target/release/bragi /srv/bragi
 
 EXPOSE 4000
 ENV BRAGI_ES http://localhost:9200/munin
-ENV RUST_LOG=debug,hyper=info
+ENV RUST_LOG=info,hyper=info
 
 CMD ["/srv/bragi", "-b", "0.0.0.0:4000"]

--- a/docker/Dockerfile_bragi
+++ b/docker/Dockerfile_bragi
@@ -1,4 +1,4 @@
-FROM rust:1.32-stretch as builder
+FROM rust:1.36-stretch as builder
 
 WORKDIR /srv/mimirsbrunn
 

--- a/docker/Dockerfile_import
+++ b/docker/Dockerfile_import
@@ -1,4 +1,4 @@
-FROM rust:1.32-stretch as builder
+FROM rust:1.36-stretch as builder
 
 WORKDIR /srv/mimirsbrunn
 


### PR DESCRIPTION
the update of the crate prometheus forces us to update the rust minimum
supported version

also remove the travis building on beta/nighlty