### PR TITLE
extern crate -> rust 2018

### DIFF
--- a/libs/bragi/src/extractors.rs
+++ b/libs/bragi/src/extractors.rs
@@ -7,6 +7,7 @@
 /// (cf https://github.com/nox/serde_urlencoded/issues/6)
 use crate::model::ApiError;
 use actix_web::{dev::Payload, FromRequest, HttpRequest};
+use failure::Fail;
 use std::ops::{Deref, DerefMut};
 
 #[derive(Fail, Debug)]

--- a/libs/bragi/src/lib.rs
+++ b/libs/bragi/src/lib.rs
@@ -29,14 +29,11 @@
 // www.navitia.io
 
 #[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
-#[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate prometheus;
+
 use mimir::rubber::Rubber;
+use slog::slog_debug;
+use slog_scope::debug;
 use std::time::Duration;
 use structopt::StructOpt;
 

--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -28,9 +28,12 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
+use failure::Fail;
 use heck::SnakeCase;
 use rs_es::error::EsError;
 use serde::{Deserialize, Serialize};
+use slog::slog_error;
+use slog_scope::error;
 use std::sync::Arc;
 
 #[derive(Fail, Debug)]

--- a/libs/bragi/src/prometheus_middleware.rs
+++ b/libs/bragi/src/prometheus_middleware.rs
@@ -3,9 +3,8 @@
 // because  we want to use the name of the endpoint for retrocompatibility
 // (and as a side effect we also added the 'in flight' queries (but for this we could have used the Registry))
 
-use std::marker::PhantomData;
-use std::sync::Arc;
-use std::time::SystemTime;
+// #[macro_use]
+// extern crate prometheus;
 
 use actix_service::{Service, Transform};
 use actix_web::{
@@ -16,7 +15,10 @@ use actix_web::{
 };
 use futures::future::{ok, FutureResult};
 use futures::{Async, Future, Poll};
-use prometheus::{opts, Encoder, TextEncoder};
+use prometheus::{self, Encoder, TextEncoder};
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::SystemTime;
 
 lazy_static::lazy_static! {
     static ref PATH_TO_NAME: std::collections::HashMap<&'static str, &'static str> = {
@@ -54,6 +56,7 @@ lazy_static::lazy_static! {
         &["handler", "method", "status"]
     )
     .unwrap();
+
     static ref HTTP_REQ_HISTOGRAM: prometheus::HistogramVec = prometheus::register_histogram_vec!(
         "bragi_http_request_duration_seconds",
         "The HTTP request latencies in seconds.",
@@ -61,6 +64,7 @@ lazy_static::lazy_static! {
         prometheus::exponential_buckets(0.001, 1.5, 25).unwrap()
     )
     .unwrap();
+
     static ref HTTP_IN_FLIGHT: prometheus::Gauge = prometheus::register_gauge!(
         "bragi_http_requests_in_flight",
         "current number of http request being served"

--- a/libs/bragi/src/prometheus_middleware.rs
+++ b/libs/bragi/src/prometheus_middleware.rs
@@ -3,9 +3,6 @@
 // because  we want to use the name of the endpoint for retrocompatibility
 // (and as a side effect we also added the 'in flight' queries (but for this we could have used the Registry))
 
-// #[macro_use]
-// extern crate prometheus;
-
 use actix_service::{Service, Transform};
 use actix_web::{
     dev::{Body, BodySize, MessageBody, ResponseBody, ServiceRequest, ServiceResponse},

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -42,6 +42,8 @@ use rs_es::query::Query;
 use rs_es::units as rs_u;
 use serde;
 use serde_json;
+use slog::{slog_debug, slog_error, slog_warn};
+use slog_scope::{debug, error, warn};
 use std::{fmt, iter};
 
 lazy_static::lazy_static! {

--- a/libs/mimir/src/lib.rs
+++ b/libs/mimir/src/lib.rs
@@ -28,19 +28,20 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
-#[macro_use]
-extern crate failure;
+// #[macro_use]
+// extern crate slog;
+// #[macro_use]
+// extern crate slog_scope;
+// #[macro_use]
+// extern crate failure;
 
 pub mod objects;
 pub mod rubber;
 
 pub use crate::objects::*;
-use slog::Drain;
-use slog::Never;
+use slog::{self, o, slog_o, Drain, Never};
+use slog_json;
+use slog_scope;
 use std::env;
 
 pub fn logger_init() -> (slog_scope::GlobalLoggerGuard, ()) {

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -33,6 +33,8 @@ use navitia_poi_model;
 use serde::de::{self, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
+use slog::slog_warn;
+use slog_scope::warn;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt;

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -30,7 +30,7 @@
 
 use super::objects::{Admin, MimirObject};
 use super::objects::{AliasOperation, AliasOperations, AliasParameter, Coord, Place};
-use failure::{Error, ResultExt};
+use failure::{bail, format_err, Error, ResultExt};
 use prometheus::{exponential_buckets, histogram_opts, register_histogram, Histogram};
 use reqwest::StatusCode;
 use rs_es::error::EsError;
@@ -40,6 +40,8 @@ use rs_es::query::Query;
 use rs_es::units as rs_u;
 use rs_es::units::Duration;
 use rs_es::EsResponse;
+use slog::{slog_debug, slog_info, slog_warn};
+use slog_scope::{debug, info, warn};
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use std::time;
@@ -242,7 +244,7 @@ pub fn get_indexes(
         if poi_datasets.is_empty() {
             t != "public_transport:stop_area"
         } else {
-            t != "public_transport:stop_area" && t != "poi"
+            t != "public_transport:stop_area" || t != "poi"
         }
     };
 

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -244,7 +244,7 @@ pub fn get_indexes(
         if poi_datasets.is_empty() {
             t != "public_transport:stop_area"
         } else {
-            t != "public_transport:stop_area" || t != "poi"
+            t != "public_transport:stop_area" && t != "poi"
         }
     };
 

--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -5,6 +5,8 @@ use mimir::rubber::{IndexSettings, IndexVisibility, Rubber};
 use mimir::Addr;
 use par_map::ParMap;
 use serde::de::DeserializeOwned;
+use slog::{slog_debug, slog_error, slog_info};
+use slog_scope::{debug, error, info};
 use std::marker::{Send, Sync};
 use std::path::PathBuf;
 

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -2,6 +2,9 @@
 /// the current format is '{nice name} ({city})'
 /// the {nice name} being for addresses the housenumber and the street (correctly ordered)
 /// and for the rest of the objects, only their names
+use slog::slog_warn;
+use slog_scope::warn;
+
 fn format_label<'a>(
     nice_name: String,
     admins: impl Iterator<Item = &'a mimir::Admin> + Clone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,6 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
-
 pub mod addr_reader;
 pub mod admin_geofinder;
 pub mod labels;

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -34,6 +34,8 @@ use cosmogony::ZoneType;
 use geo::bounding_rect::BoundingRect;
 use itertools::Itertools;
 use osm_boundaries_utils::build_boundary;
+use slog::{slog_info, slog_warn};
+use slog_scope::{info, warn};
 use std::collections::BTreeSet;
 
 pub type StreetsVec = Vec<mimir::Street>;

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -37,6 +37,8 @@ use mimir::{rubber, Poi, PoiType};
 use osm_boundaries_utils::build_boundary;
 use serde::{Deserialize, Serialize};
 use serde_json;
+use slog::{slog_info, slog_warn};
+use slog_scope::{info, warn};
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::io;

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -32,6 +32,8 @@ use super::OsmPbfReader;
 use crate::admin_geofinder::AdminGeoFinder;
 use crate::{labels, utils, Error};
 use failure::ResultExt;
+use slog::slog_info;
+use slog_scope::info;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;
 use std::sync::Arc;

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -34,6 +34,8 @@ use failure::format_err;
 use failure::{Error, ResultExt};
 use mimir;
 use mimir::rubber::{IndexSettings, Rubber, TypedIndex};
+use slog::{slog_info, slog_warn};
+use slog_scope::{info, warn};
 use std::collections::HashMap;
 use std::mem::replace;
 use std::ops::Deref;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,6 +30,8 @@
 
 use crate::Error;
 use mimir;
+use slog::slog_error;
+use slog_scope::error;
 use std::process::exit;
 use std::sync::Arc;
 use structopt::StructOpt;


### PR DESCRIPTION
I need a tool that targets bragi's web API.
This tool needs to be aware of the parameters used by bragi.
These parameters were not publicly exposed.

There is also a function to generate query parameters, so that they can be easily incorporated in, eg reqwest:

```
let bragi_params = Params { ... };
let query_params = autocomplete_params_to_query_params(bragi_params);
Client::new().post(...).query(query_params).send()...
```

An alternative to the function might be to use Into<Vec<String, String>> ?

An alternative would be to use OpenAPI, to open the bragi API to other languages...