### PR TITLE
Fix timeout issue in test

### DIFF
--- a/libs/docker_wrapper/src/lib.rs
+++ b/libs/docker_wrapper/src/lib.rs
@@ -33,11 +33,11 @@ extern crate slog;
 #[macro_use]
 extern crate slog_scope;
 
-use std::error::Error;
-use std::process::Command;
-
 use mimir::rubber::Rubber;
 use reqwest;
+use std::error::Error;
+use std::process::Command;
+use std::time::Duration;
 
 /// This struct wraps a docker (for the moment explicitly ElasticSearch)
 /// Allowing to setup a docker, tear it down and to provide its address and port
@@ -94,7 +94,7 @@ impl DockerWrapper {
     pub fn new() -> Result<DockerWrapper, Box<dyn Error>> {
         let mut wrapper = DockerWrapper { ip: "".to_string() };
         wrapper.setup()?;
-        let rubber = Rubber::new(&wrapper.host());
+        let rubber = Rubber::new_with_timeout(&wrapper.host(), Duration::from_secs(10)); // use a long timeout
         rubber.initialize_templates().unwrap();
         Ok(wrapper)
     }

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -286,7 +286,11 @@ impl Rubber {
         }
     }
 
-    pub fn new_with_timeout(cnx: &str, timeout: Option<time::Duration>) -> Rubber {
+    pub fn new_with_timeout<T>(cnx: &str, timeout: T) -> Rubber
+    where
+        T: Into<Option<time::Duration>>,
+    {
+        let timeout = timeout.into();
         Rubber {
             es_client: rs_es::Client::init_with_timeout(&cnx, timeout).unwrap(),
             http_client: reqwest::Client::builder().timeout(timeout).build().unwrap(),


### PR DESCRIPTION
A test which targets an invalid elastic search URL may or may not fail:

The test expects a 503 response from Bragi, but if Bragi's timeout is
shorter than the DNS, then a get() would return a future timeout, which
fails the test.

This change introduces:

1. A large (10 secs) timeout on docker_wrapper's rubber
2. A slight modification of the Rubber::new_with_timeout function,
  which now takes an Into<Option<Duration>> instead of just an
  Option<Duration>