### PR TITLE
Feature: Add explain to bragi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_qs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1520,7 +1520,7 @@ dependencies = [
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1564,7 +1564,7 @@ dependencies = [
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rs-es 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rs-es 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2538,7 +2538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rs-es"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3849,7 +3849,7 @@ dependencies = [
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
 "checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
-"checksum rs-es 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b733dc5b57d1fe2697d2f06c75a82e4eb17d6645e7864a0ab216aa1c64df619a"
+"checksum rs-es 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ad4518f08ae3b50d9fdf37b5ba607c49f6573050fe212b7e8b27083e52bf20c9"
 "checksum rstar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "120bfe4837befb82c5a637a5a8c490a27d25524ac19fffec5b4e555ca6e36ee8"
 "checksum rust_decimal 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "01363ad33ac8028c767d907fed45381e223cfbe65db17016d12f56307074993c"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"

--- a/libs/bragi/Cargo.toml
+++ b/libs/bragi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 structopt = "0.2"
 slog = { version = "2.4", features = ["max_level_trace", "release_max_level_info"]}
 slog-scope = "4.1"
-rs-es = { version = "^0.12.0", features = ["geo"]}
+rs-es = { version = "^0.12.2", features = ["geo"]}
 serde = {version = "1", features = ["rc"]}
 serde_json = "1"
 geojson = { version = "0.16", features = ["geo-types"] }

--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -116,6 +116,8 @@ pub struct Feature {
     pub properties: Properties,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub distance: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explanation: Option<mimir::Explanation>,
 }
 
 #[derive(Serialize, Debug)]
@@ -253,6 +255,7 @@ impl FromWithLang<mimir::Place> for Feature {
     fn from_with_lang(other: mimir::Place, lang: Option<&str>) -> Feature {
         let geom = other.to_geom();
         let distance = other.distance();
+        let explanation = other.explanation();
         let geocoding = match other {
             mimir::Place::Admin(admin) => GeocodingResponse::from_with_lang(admin, lang),
             mimir::Place::Street(street) => GeocodingResponse::from_with_lang(street, lang),
@@ -267,6 +270,7 @@ impl FromWithLang<mimir::Place> for Feature {
                 geocoding: geocoding,
             },
             distance: distance,
+            explanation: explanation,
         }
     }
 }

--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -117,7 +117,7 @@ pub struct Feature {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub distance: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<mimir::Explanation>,
+    pub context: Option<mimir::Context>,
 }
 
 #[derive(Serialize, Debug)]
@@ -255,7 +255,7 @@ impl FromWithLang<mimir::Place> for Feature {
     fn from_with_lang(other: mimir::Place, lang: Option<&str>) -> Feature {
         let geom = other.to_geom();
         let distance = other.distance();
-        let explanation = other.explanation();
+        let context = other.context();
         let geocoding = match other {
             mimir::Place::Admin(admin) => GeocodingResponse::from_with_lang(admin, lang),
             mimir::Place::Street(street) => GeocodingResponse::from_with_lang(street, lang),
@@ -270,7 +270,7 @@ impl FromWithLang<mimir::Place> for Feature {
                 geocoding: geocoding,
             },
             distance: distance,
-            explanation: explanation,
+            context: context,
         }
     }
 }

--- a/libs/bragi/src/routes/autocomplete.rs
+++ b/libs/bragi/src/routes/autocomplete.rs
@@ -80,6 +80,9 @@ pub struct Params {
     #[serde(default, rename = "poi_type")]
     poi_types: Vec<PoiType>,
     lang: Option<String>,
+    // Forwards a request for explanation to Elastic Search.
+    // This parameter is useful to analyze the order in which search results appear.
+    debug: Option<bool>,
 }
 
 impl Params {
@@ -157,6 +160,7 @@ pub fn call_autocomplete(
         &params.poi_types_as_str(),
         &langs,
         rubber,
+        params.debug.unwrap_or(false),
     );
     res.map(|r| Autocomplete::from_with_lang(r, langs.into_iter().next()))
         .map(Json)

--- a/libs/bragi/src/routes/autocomplete.rs
+++ b/libs/bragi/src/routes/autocomplete.rs
@@ -82,6 +82,8 @@ pub struct Params {
     lang: Option<String>,
     // Forwards a request for explanation to Elastic Search.
     // This parameter is useful to analyze the order in which search results appear.
+    // It is prefixed by an underscore to indicate its not a public parameter.
+    #[serde(default, rename = "_debug")]
     debug: Option<bool>,
 }
 

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -33,7 +33,7 @@ use navitia_poi_model;
 use serde::de::{self, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
-// use slog::slog_warn;
+use slog::slog_warn;
 use slog_scope::warn;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -164,25 +164,25 @@ impl Place {
         }
     }
 
-    pub fn set_explanation(&mut self, explanation: Explanation) {
+    pub fn set_context(&mut self, context: Context) {
         match self {
-            Place::Admin(ref mut o) => o.explanation = Some(explanation),
-            Place::Street(ref mut o) => o.explanation = Some(explanation),
-            Place::Addr(ref mut o) => o.explanation = Some(explanation),
-            Place::Poi(ref mut o) => o.explanation = Some(explanation),
-            Place::Stop(ref mut o) => o.explanation = Some(explanation),
+            Place::Admin(ref mut o) => o.context = Some(context),
+            Place::Street(ref mut o) => o.context = Some(context),
+            Place::Addr(ref mut o) => o.context = Some(context),
+            Place::Poi(ref mut o) => o.context = Some(context),
+            Place::Stop(ref mut o) => o.context = Some(context),
         }
     }
 
-    /* We can afford to clone the explanation because we're in debug mode
+    /* We can afford to clone the context because we're in debug mode
      * and performance are less critical */
-    pub fn explanation(&self) -> Option<Explanation> {
+    pub fn context(&self) -> Option<Context> {
         match self {
-            Place::Admin(ref o) => o.explanation.clone(),
-            Place::Street(ref o) => o.explanation.clone(),
-            Place::Addr(ref o) => o.explanation.clone(),
-            Place::Poi(ref o) => o.explanation.clone(),
-            Place::Stop(ref o) => o.explanation.clone(),
+            Place::Admin(ref o) => o.context.clone(),
+            Place::Street(ref o) => o.context.clone(),
+            Place::Addr(ref o) => o.context.clone(),
+            Place::Poi(ref o) => o.context.clone(),
+            Place::Stop(ref o) => o.context.clone(),
         }
     }
 }
@@ -266,7 +266,7 @@ pub struct Poi {
     #[serde(default, skip)]
     pub distance: Option<u32>,
 
-    pub explanation: Option<Explanation>,
+    pub context: Option<Context>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -511,7 +511,7 @@ pub struct Stop {
     #[serde(default)]
     pub country_codes: Vec<String>,
 
-    pub explanation: Option<Explanation>,
+    pub context: Option<Context>,
 }
 
 impl MimirObject for Stop {
@@ -584,7 +584,7 @@ pub struct Admin {
     #[serde(default, skip)]
     pub distance: Option<u32>,
 
-    pub explanation: Option<Explanation>,
+    pub context: Option<Context>,
 }
 
 impl Admin {
@@ -731,7 +731,7 @@ pub struct Street {
     #[serde(default, skip)]
     pub distance: Option<u32>,
 
-    pub explanation: Option<Explanation>,
+    pub context: Option<Context>,
 }
 impl Incr for Street {
     fn id(&self) -> &str {
@@ -785,7 +785,7 @@ pub struct Addr {
     #[serde(default, skip)]
     pub distance: Option<u32>,
 
-    pub explanation: Option<Explanation>,
+    pub context: Option<Context>,
 }
 
 impl MimirObject for Addr {
@@ -957,6 +957,14 @@ impl From<&navitia_poi_model::Coord> for Coord {
     fn from(coord: &navitia_poi_model::Coord) -> Coord {
         Coord::new(coord.lon(), coord.lat())
     }
+}
+
+/// Contextual information related to the query. It can be used to store information
+/// for monitoring performance, search relevance, ...
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Context {
+    /// Elasticsearch explanation
+    pub explanation: Option<Explanation>,
 }
 
 /// This structure is used when analyzing the result of an Elasticsearch 'explanation' query,

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -28,7 +28,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-use super::objects::{Admin, Explanation, MimirObject};
+use super::objects::{Admin, Context, Explanation, MimirObject};
 use super::objects::{AliasOperation, AliasOperations, AliasParameter, Coord, Place};
 use failure::{bail, format_err, Error, ResultExt};
 use prometheus::{exponential_buckets, histogram_opts, register_histogram, Histogram};
@@ -216,7 +216,9 @@ pub fn make_place(
         Some(explanation) => match serde_json::from_value::<Explanation>(explanation) {
             Ok(explanation) => match place {
                 Some(mut place) => {
-                    place.set_explanation(explanation);
+                    place.set_context(Context {
+                        explanation: Some(explanation),
+                    });
                     Some(place)
                 }
                 None => None,

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -221,7 +221,7 @@ pub fn make_place(
                 }
                 None => None,
             },
-            Err(err) => place,
+            Err(_err) => place,
         },
         None => place,
     }

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -134,7 +134,7 @@ impl Bano {
             approx_coord: None,
             distance: None,
             country_codes: country_codes.clone(),
-            explanation: None,
+            context: None,
         };
         mimir::Addr {
             id: format!(
@@ -168,7 +168,7 @@ impl Bano {
             zip_codes: vec![self.zip.clone()],
             distance: None,
             country_codes,
-            explanation: None,
+            context: None,
         }
     }
 }

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -134,6 +134,7 @@ impl Bano {
             approx_coord: None,
             distance: None,
             country_codes: country_codes.clone(),
+            explanation: None,
         };
         mimir::Addr {
             id: format!(
@@ -167,6 +168,7 @@ impl Bano {
             zip_codes: vec![self.zip.clone()],
             distance: None,
             country_codes,
+            explanation: None,
         }
     }
 }

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -121,6 +121,7 @@ impl IntoAdmin for Zone {
                 .filter(|(k, _)| langs.contains(&k))
                 .collect(),
             distance: None,
+            explanation: None,
         }
     }
 }

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -121,7 +121,7 @@ impl IntoAdmin for Zone {
                 .filter(|(k, _)| langs.contains(&k))
                 .collect(),
             distance: None,
-            explanation: None,
+            context: None,
         }
     }
 }

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -102,6 +102,7 @@ impl OpenAddresse {
             approx_coord: None,
             distance: None,
             country_codes: country_codes.clone(),
+            explanation: None,
         };
 
         mimir::Addr {
@@ -136,6 +137,7 @@ impl OpenAddresse {
             zip_codes: vec![self.postcode],
             distance: None,
             country_codes,
+            explanation: None,
         }
     }
 }

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -102,7 +102,7 @@ impl OpenAddresse {
             approx_coord: None,
             distance: None,
             country_codes: country_codes.clone(),
-            explanation: None,
+            context: None,
         };
 
         mimir::Addr {
@@ -137,7 +137,7 @@ impl OpenAddresse {
             zip_codes: vec![self.postcode],
             distance: None,
             country_codes,
-            explanation: None,
+            context: None,
         }
     }
 }

--- a/src/bin/poi2mimir.rs
+++ b/src/bin/poi2mimir.rs
@@ -108,6 +108,7 @@ fn into_mimir_poi(
         names: I18nProperties::default(),
         labels: I18nProperties::default(),
         distance: None,
+        explanation: None,
     };
 
     Ok(poi)

--- a/src/bin/poi2mimir.rs
+++ b/src/bin/poi2mimir.rs
@@ -108,7 +108,7 @@ fn into_mimir_poi(
         names: I18nProperties::default(),
         labels: I18nProperties::default(),
         distance: None,
-        explanation: None,
+        context: None,
     };
 
     Ok(poi)

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -177,6 +177,7 @@ pub fn read_administrative_regions(
                 names: mimir::I18nProperties::default(),
                 labels: mimir::I18nProperties::default(),
                 distance: None,
+                explanation: None,
             };
             administrative_regions.push(admin);
         }

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -177,7 +177,7 @@ pub fn read_administrative_regions(
                 names: mimir::I18nProperties::default(),
                 labels: mimir::I18nProperties::default(),
                 distance: None,
-                explanation: None,
+                context: None,
             };
             administrative_regions.push(admin);
         }

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -265,6 +265,7 @@ fn parse_poi(
         labels: mimir::I18nProperties::default(),
         distance: None,
         country_codes,
+        explanation: None,
     })
 }
 

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -265,7 +265,7 @@ fn parse_poi(
         labels: mimir::I18nProperties::default(),
         distance: None,
         country_codes,
-        explanation: None,
+        context: None,
     })
 }
 

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -106,7 +106,7 @@ pub fn streets(
                     approx_coord: Some(coord.into()),
                     distance: None,
                     country_codes,
-                    explanation: None,
+                    context: None,
                 })
             })
             .next()
@@ -162,7 +162,7 @@ pub fn streets(
             approx_coord: Some(coord.into()),
             distance: None,
             country_codes,
-            explanation: None,
+            context: None,
         })
     });
     street_list.extend(streets);

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -106,6 +106,7 @@ pub fn streets(
                     approx_coord: Some(coord.into()),
                     distance: None,
                     country_codes,
+                    explanation: None,
                 })
             })
             .next()
@@ -161,6 +162,7 @@ pub fn streets(
             approx_coord: Some(coord.into()),
             distance: None,
             country_codes,
+            explanation: None,
         })
     });
     street_list.extend(streets);


### PR DESCRIPTION
This change adds a query url parameter to bragi (`debug=true`),
which triggers a so called explain query in elasticsearch, and
forwards the results back as json.

By default, when the parameter is not present, the flag debug is false.

This new feature can be used to analyze the score assigned by
elasticsearch to a result.

This change adds an 'explain' object to a geocodejson feature object,
which is not part of the initial specification.

This change addresses issue #214 