### PR TITLE
Remove #[macro_use] warning

### DIFF
--- a/libs/bragi/src/lib.rs
+++ b/libs/bragi/src/lib.rs
@@ -32,7 +32,6 @@
 extern crate prometheus;
 
 use mimir::rubber::Rubber;
-use slog::slog_debug;
 use slog_scope::debug;
 use std::time::Duration;
 use structopt::StructOpt;

--- a/libs/bragi/src/model.rs
+++ b/libs/bragi/src/model.rs
@@ -32,7 +32,6 @@ use failure::Fail;
 use heck::SnakeCase;
 use rs_es::error::EsError;
 use serde::{Deserialize, Serialize};
-use slog::slog_error;
 use slog_scope::error;
 use std::sync::Arc;
 

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -42,7 +42,6 @@ use rs_es::query::Query;
 use rs_es::units as rs_u;
 use serde;
 use serde_json;
-use slog::{slog_debug, slog_error, slog_warn};
 use slog_scope::{debug, error, warn};
 use std::{fmt, iter};
 

--- a/libs/docker_wrapper/src/lib.rs
+++ b/libs/docker_wrapper/src/lib.rs
@@ -27,14 +27,10 @@
 // IRC #navitia on freenode
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
-use retry;
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
-
 use mimir::rubber::Rubber;
 use reqwest;
+use retry;
+use slog_scope::{info, warn};
 use std::error::Error;
 use std::process::Command;
 use std::time::Duration;

--- a/libs/tools/src/lib.rs
+++ b/libs/tools/src/lib.rs
@@ -1,12 +1,8 @@
 use docker_wrapper::*;
 use serde_json::value::Value;
 use serde_json::Map;
+use slog_scope::info;
 use std::time::Duration;
-
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
 
 pub struct ElasticSearchWrapper<'a> {
     pub docker_wrapper: &'a DockerWrapper,

--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -5,7 +5,6 @@ use mimir::rubber::{IndexSettings, IndexVisibility, Rubber};
 use mimir::Addr;
 use par_map::ParMap;
 use serde::de::DeserializeOwned;
-use slog::{slog_debug, slog_error, slog_info};
 use slog_scope::{debug, error, info};
 use std::marker::{Send, Sync};
 use std::path::PathBuf;

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -28,11 +28,6 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
-
 use lazy_static::lazy_static;
 use mimir::objects::Admin;
 use mimir::rubber::{IndexSettings, Rubber};
@@ -40,6 +35,7 @@ use mimirsbrunn::addr_reader::import_addresses;
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use mimirsbrunn::labels;
 use serde::{Deserialize, Serialize};
+use slog_scope::{info, warn};
 use std::collections::BTreeMap;
 use std::fs;
 use std::ops::Deref;

--- a/src/bin/bragi.rs
+++ b/src/bin/bragi.rs
@@ -28,10 +28,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
+use slog_scope::debug;
 
 fn main() {
     let _guard = mimir::logger_init();

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -28,11 +28,6 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
-
 use cosmogony::{Zone, ZoneIndex};
 use failure::Error;
 use mimir::objects::Admin;
@@ -40,6 +35,7 @@ use mimir::rubber::{IndexSettings, Rubber};
 use mimirsbrunn::osm_reader::admin;
 use mimirsbrunn::osm_reader::osm_utils;
 use mimirsbrunn::utils;
+use slog_scope::{info, warn};
 use std::collections::BTreeMap;
 use structopt::StructOpt;
 
@@ -139,10 +135,8 @@ fn send_to_es(
 }
 
 fn read_zones(input: &str) -> Result<impl Iterator<Item = Zone>, Error> {
-    Ok(cosmogony::read_zones_from_file(input)?.filter_map(|r| {
-        r.map_err(|e| log::warn!("impossible to read zone: {}", e))
-            .ok()
-    }))
+    Ok(cosmogony::read_zones_from_file(input)?
+        .filter_map(|r| r.map_err(|e| warn!("impossible to read zone: {}", e)).ok()))
 }
 
 fn index_cosmogony(args: Args) -> Result<(), Error> {

--- a/src/bin/mimir_init.rs
+++ b/src/bin/mimir_init.rs
@@ -28,10 +28,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
+use slog_scope::info;
 
 use mimir::rubber::Rubber;
 use structopt::StructOpt;

--- a/src/bin/ntfs2mimir.rs
+++ b/src/bin/ntfs2mimir.rs
@@ -28,14 +28,10 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
-
 use failure::ResultExt;
 use mimir::rubber::IndexSettings;
 use mimirsbrunn::stops::*;
+use slog_scope::{info, warn};
 use std::path::PathBuf;
 use structopt::StructOpt;
 use transit_model::collection::Idx;

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -28,17 +28,13 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
-
 use lazy_static::lazy_static;
 use mimir::rubber::{IndexSettings, Rubber};
 use mimirsbrunn::addr_reader::import_addresses;
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use mimirsbrunn::{labels, utils};
 use serde::{Deserialize, Serialize};
+use slog_scope::{info, warn};
 use std::ops::Deref;
 use std::path::PathBuf;
 use structopt::StructOpt;

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -28,11 +28,6 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
-
 use failure::ResultExt;
 use mimir::rubber::{IndexSettings, Rubber};
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
@@ -40,6 +35,7 @@ use mimirsbrunn::osm_reader::admin::read_administrative_regions;
 use mimirsbrunn::osm_reader::make_osm_reader;
 use mimirsbrunn::osm_reader::poi::{add_address, compute_poi_weight, pois, PoiConfig};
 use mimirsbrunn::osm_reader::street::{compute_street_weight, streets};
+use slog_scope::{debug, info};
 use std::path::PathBuf;
 use structopt::StructOpt;
 

--- a/src/bin/poi2mimir.rs
+++ b/src/bin/poi2mimir.rs
@@ -28,10 +28,7 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
+use slog_scope::info;
 
 use failure::format_err;
 use lazy_static::lazy_static;

--- a/src/bin/stops2mimir.rs
+++ b/src/bin/stops2mimir.rs
@@ -28,15 +28,11 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
-#[macro_use]
-extern crate slog;
-#[macro_use]
-extern crate slog_scope;
-
 use failure::ResultExt;
 use mimir::rubber::IndexSettings;
 use mimirsbrunn::stops::*;
 use serde::Deserialize;
+use slog_scope::{info, warn};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use structopt::StructOpt;

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -2,7 +2,6 @@
 /// the current format is '{nice name} ({city})'
 /// the {nice name} being for addresses the housenumber and the street (correctly ordered)
 /// and for the rest of the objects, only their names
-use slog::slog_warn;
 use slog_scope::warn;
 
 fn format_label<'a>(

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -34,7 +34,6 @@ use cosmogony::ZoneType;
 use geo::bounding_rect::BoundingRect;
 use itertools::Itertools;
 use osm_boundaries_utils::build_boundary;
-use slog::{slog_info, slog_warn};
 use slog_scope::{info, warn};
 use std::collections::BTreeSet;
 

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -37,7 +37,6 @@ use mimir::{rubber, Poi, PoiType};
 use osm_boundaries_utils::build_boundary;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use slog::{slog_info, slog_warn};
 use slog_scope::{info, warn};
 use std::collections::BTreeMap;
 use std::error::Error;

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -32,7 +32,6 @@ use super::OsmPbfReader;
 use crate::admin_geofinder::AdminGeoFinder;
 use crate::{labels, utils, Error};
 use failure::ResultExt;
-use slog::slog_info;
 use slog_scope::info;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;

--- a/src/stops.rs
+++ b/src/stops.rs
@@ -34,7 +34,6 @@ use failure::format_err;
 use failure::{Error, ResultExt};
 use mimir;
 use mimir::rubber::{IndexSettings, Rubber, TypedIndex};
-use slog::{slog_info, slog_warn};
 use slog_scope::{info, warn};
 use std::collections::HashMap;
 use std::mem::replace;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,7 +30,6 @@
 
 use crate::Error;
 use mimir;
-use slog::slog_error;
 use slog_scope::error;
 use std::process::exit;
 use std::sync::Arc;


### PR DESCRIPTION
This change removes a lot of compilation warnings I have, and that were due to rust 2018 compliance