### PR TITLE
Greatly improve memory usage in osm2mimir streets computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "osmpbfreader 0.13.1",
+ "osmpbfreader 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1579,7 +1579,7 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "osm_boundaries_utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "osmpbfreader 0.13.1",
+ "osmpbfreader 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1909,12 +1909,13 @@ dependencies = [
  "geo 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "osmpbfreader 0.13.1",
+ "osmpbfreader 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "osmpbfreader"
-version = "0.13.1"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "flat_map 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3816,6 +3817,7 @@ dependencies = [
 "checksum openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)" = "b5ba300217253bcc5dc68bed23d782affa45000193866e025329aa8a7a9f05b8"
 "checksum ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e312d9bf410688e9c292d9e7da4567143c0ad18df8fceb6ce99156f40cef2"
 "checksum osm_boundaries_utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d38b9e11cbea4e9bc126c0331f1fdd78104494f99df105dd6e9f7a294ecd8973"
+"checksum osmpbfreader 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "01162280c9655665f21a7f4751d9494c4da221f2ef9e0b21e7a7d4b8af5e20b2"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2f05b290991702bb8140cf70915b82b0ae1ec7fe478db97305af990048040095"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,6 +1570,7 @@ dependencies = [
  "address-formatter 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_float_eq 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bragi 1.2.0",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cosmogony 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3662,6 +3673,7 @@ dependencies = [
 "checksum backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "88fb679bc9af8fa639198790a77f52d345fe13656c08b43afa9424c206b731c6"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "osmpbfreader 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osmpbfreader 0.13.1",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1002,6 +1002,16 @@ dependencies = [
 [[package]]
 name = "fake-simd"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1400,6 +1410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,11 +1579,12 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "osm_boundaries_utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "osmpbfreader 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osmpbfreader 0.13.1",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "rs-es 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1889,20 +1909,19 @@ dependencies = [
  "geo 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "osmpbfreader 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "osmpbfreader 0.13.1",
 ]
 
 [[package]]
 name = "osmpbfreader"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.13.1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "flat_map 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf-codegen-pure 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen-pure 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pub-iterator-type 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rental 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2158,31 +2177,31 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "procinfo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "protobuf"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "protobuf-codegen-pure"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf-codegen 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2556,6 +2575,20 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pdqselect 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3690,6 +3723,8 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+"checksum fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 "checksum flat_map 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1e755d8e793606696d7175b6a823db01a1e16d67ff1bed82c59a817084fd8878"
 "checksum flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -3734,6 +3769,7 @@ dependencies = [
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
 "checksum libflate 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "90c6f86f4b0caa347206f916f8b687b51d77c6ef8ff18d52dd007491fd580529"
+"checksum libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
@@ -3780,7 +3816,6 @@ dependencies = [
 "checksum openssl-sys 0.9.48 (registry+https://github.com/rust-lang/crates.io-index)" = "b5ba300217253bcc5dc68bed23d782affa45000193866e025329aa8a7a9f05b8"
 "checksum ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e312d9bf410688e9c292d9e7da4567143c0ad18df8fceb6ce99156f40cef2"
 "checksum osm_boundaries_utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d38b9e11cbea4e9bc126c0331f1fdd78104494f99df105dd6e9f7a294ecd8973"
-"checksum osmpbfreader 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f294f513f55f4f09b881e9d727d4e2232b3841eb9a23cedc226590a8ae71a11"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2f05b290991702bb8140cf70915b82b0ae1ec7fe478db97305af990048040095"
@@ -3809,9 +3844,9 @@ dependencies = [
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum procinfo 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f42e8578852a3306838981aedad8c5642ba794929aa12af0c9eb6c072b77af6c"
 "checksum prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5567486d5778e2c6455b1b90ff1c558f29e751fc018130fa182e15828e728af1"
-"checksum protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f00e4a3cb64ecfeac2c0a73c74c68ae3439d7a6bead3870be56ad5dd2620a6f"
-"checksum protobuf-codegen 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2c6e555166cdb646306f599da020e01548e9f4d6ec2fd39802c6db2347cbd3e"
-"checksum protobuf-codegen-pure 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a7c75610cc3f41f4d2c1e048d6e4f857361cf26e63b3faf0b3ba1331c94b21"
+"checksum protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8aefcec9f142b524d98fc81d07827743be89dd6586a1ba6ab21fa66a500b3fa5"
+"checksum protobuf-codegen 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31539be8028d6b9e8e1b3b7c74e2fa3555302e27b2cc20dbaee6ffba648f75e2"
+"checksum protobuf-codegen-pure 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00993dc5fbbfcf9d8a005f6b6c29fd29fd6d86deba3ae3f41fd20c624c414616"
 "checksum pub-iterator-type 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "858afdbecdce657c6e32031348cf7326da7700c869c368a136d31565972f7018"
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -3851,6 +3886,7 @@ dependencies = [
 "checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 "checksum rs-es 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ad4518f08ae3b50d9fdf37b5ba607c49f6573050fe212b7e8b27083e52bf20c9"
 "checksum rstar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "120bfe4837befb82c5a637a5a8c490a27d25524ac19fffec5b4e555ca6e36ee8"
+"checksum rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a194373ef527035645a1bc21b10dc2125f73497e6e155771233eb187aedd051"
 "checksum rust_decimal 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "01363ad33ac8028c767d907fed45381e223cfbe65db17016d12f56307074993c"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,13 @@ humanesort = "0.1.0-alpha"
 address-formatter = "^0.2.1"
 navitia-poi-model = "0.2.0"
 walkdir = "2"
+rusqlite = "0.20"
 
 mimir = { path = "libs/mimir" }
 bragi = { path = "libs/bragi" }
+
+[patch.crates-io]
+osmpbfreader = { path = "../osmpbfreader-rs" }
 
 [dev-dependencies]
 reqwest = "=0.9.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ osmpbfreader = "0.13.2"
 chrono = "0.4"
 serde = {version = "1", features = ["rc"]}
 serde_json = "1"
+bincode = "1.1"
 geo = "0.12"
 geo-types = "0.4"
 gst = "0.1" # todo remove this dependency in favor of https://github.com/Stoeoef/rstar/blob/master/rstar/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ structopt = "0.2"
 csv = "1"
 rs-es = { version = "^0.12.0", features = ["geo"]}
 regex = "1"
-osmpbfreader = "0.13"
+osmpbfreader = "0.13.2"
 chrono = "0.4"
 serde = {version = "1", features = ["rc"]}
 serde_json = "1"
@@ -43,9 +43,6 @@ rusqlite = "0.20"
 
 mimir = { path = "libs/mimir" }
 bragi = { path = "libs/bragi" }
-
-[patch.crates-io]
-osmpbfreader = { path = "../osmpbfreader-rs" }
 
 [dev-dependencies]
 reqwest = "=0.9.16"

--- a/docker/Dockerfile_import
+++ b/docker/Dockerfile_import
@@ -18,7 +18,7 @@ WORKDIR /srv
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
-    && apt-get install -y libcurl3 \
+    && apt-get install -y libcurl3 sqlite3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -93,6 +93,9 @@ struct Args {
     /// DB file.
     #[structopt(long = "db-file", parse(from_os_str))]
     db_file: Option<PathBuf>,
+    /// DB buffer size.
+    #[structopt(long = "db-buffer-size", default_value = "50000")]
+    db_buffer_size: usize,
 }
 
 fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
@@ -113,7 +116,12 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
     let admins_geofinder = admins.into_iter().collect::<AdminGeoFinder>();
     {
         info!("Extracting streets from osm");
-        let mut streets = streets(&mut osm_reader, &admins_geofinder, &args.db_file)?;
+        let mut streets = streets(
+            &mut osm_reader,
+            &admins_geofinder,
+            &args.db_file,
+            args.db_buffer_size,
+        )?;
 
         info!("computing street weight");
         compute_street_weight(&mut streets);

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -90,6 +90,9 @@ struct Args {
     /// Number of replicas for the es index
     #[structopt(long = "nb-poi-replicas", default_value = "1")]
     nb_poi_replicas: usize,
+    /// DB file.
+    #[structopt(long = "db-file", parse(from_os_str))]
+    db_file: Option<PathBuf>,
 }
 
 fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
@@ -110,7 +113,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
     let admins_geofinder = admins.into_iter().collect::<AdminGeoFinder>();
     {
         info!("Extracting streets from osm");
-        let mut streets = streets(&mut osm_reader, &admins_geofinder)?;
+        let mut streets = streets(&mut osm_reader, &admins_geofinder, &args.db_file)?;
 
         info!("computing street weight");
         compute_street_weight(&mut streets);

--- a/src/osm_reader/osm_utils.rs
+++ b/src/osm_reader/osm_utils.rs
@@ -33,10 +33,10 @@ use osmpbfreader;
 
 use geo::centroid::Centroid;
 use geo::MultiPolygon;
-use std::collections::BTreeMap;
+use osmpbfreader::StoreObjs;
 
-pub fn get_way_coord(
-    obj_map: &BTreeMap<osmpbfreader::OsmId, osmpbfreader::OsmObj>,
+pub fn get_way_coord<T: StoreObjs>(
+    obj_map: &T,
     way: &osmpbfreader::objects::Way,
 ) -> mimir::Coord {
     /*
@@ -49,8 +49,11 @@ pub fn get_way_coord(
         .iter()
         .skip(nb_nodes / 2)
         .filter_map(|node_id| obj_map.get(&(*node_id).into()))
-        .filter_map(|obj| obj.node())
-        .map(|node| mimir::Coord::new(node.lon(), node.lat()))
+        .filter(|obj| obj.node().is_some())
+        .map(|obj| {
+            let node = obj.node().unwrap();
+            mimir::Coord::new(node.lon(), node.lat())
+        })
         .next()
         .unwrap_or_else(mimir::Coord::default)
 }

--- a/src/osm_reader/osm_utils.rs
+++ b/src/osm_reader/osm_utils.rs
@@ -50,11 +50,7 @@ pub fn get_way_coord<T: StoreObjs + Getter>(
         .iter()
         .skip(nb_nodes / 2)
         .filter_map(|node_id| obj_map.get(&(*node_id).into()))
-        .filter(|obj| obj.node().is_some())
-        .map(|obj| {
-            let node = obj.node().unwrap();
-            mimir::Coord::new(node.lon(), node.lat())
-        })
+        .filter_map(|obj| obj.node().map(|node| mimir::Coord::new(node.lon(), node.lat())))
         .next()
         .unwrap_or_else(mimir::Coord::default)
 }

--- a/src/osm_reader/osm_utils.rs
+++ b/src/osm_reader/osm_utils.rs
@@ -34,8 +34,9 @@ use osmpbfreader;
 use geo::centroid::Centroid;
 use geo::MultiPolygon;
 use osmpbfreader::StoreObjs;
+use super::street::Getter;
 
-pub fn get_way_coord<T: StoreObjs>(
+pub fn get_way_coord<T: StoreObjs + Getter>(
     obj_map: &T,
     way: &osmpbfreader::objects::Way,
 ) -> mimir::Coord {

--- a/src/osm_reader/osm_utils.rs
+++ b/src/osm_reader/osm_utils.rs
@@ -31,10 +31,10 @@
 use mimir;
 use osmpbfreader;
 
+use super::street::Getter;
 use geo::centroid::Centroid;
 use geo::MultiPolygon;
 use osmpbfreader::StoreObjs;
-use super::street::Getter;
 
 pub fn get_way_coord<T: StoreObjs + Getter>(
     obj_map: &T,
@@ -50,7 +50,10 @@ pub fn get_way_coord<T: StoreObjs + Getter>(
         .iter()
         .skip(nb_nodes / 2)
         .filter_map(|node_id| obj_map.get(&(*node_id).into()))
-        .filter_map(|obj| obj.node().map(|node| mimir::Coord::new(node.lon(), node.lat())))
+        .filter_map(|obj| {
+            obj.node()
+                .map(|node| mimir::Coord::new(node.lon(), node.lat()))
+        })
         .next()
         .unwrap_or_else(mimir::Coord::default)
 }

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -101,7 +101,7 @@ impl<'a> DB<'a> {
 
         conn.execute(
             "CREATE TABLE ids (
-                id   INTEGER,
+                id   INTEGER NOT NULL,
                 obj  TEXT NOT NULL,
                 kind TEXT NOT NULL,
                 UNIQUE(id, kind)
@@ -124,10 +124,10 @@ impl<'a> DB<'a> {
         );
         while let Some(row) = err_logger!(iter.next(), "DB::get_from_id: next failed") {
             let obj: String = err_logger!(row.get(0), "DB::get_from_id: failed to get obj field");
-            err_logger!(
+            return err_logger!(
                 serde_json::from_str(&obj),
                 "DB::get_from_id: conversion from string failed"
-            )
+            );
         }
         None
     }

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -32,22 +32,51 @@ use super::OsmPbfReader;
 use crate::admin_geofinder::AdminGeoFinder;
 use crate::{labels, utils, Error};
 use failure::ResultExt;
-use slog_scope::info;
+use slog_scope::{error, info};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;
+use std::path::PathBuf;
 use std::sync::Arc;
-use osmpbfreader::{StoreObjs, OsmId, OsmObj, NodeId, WayId, RelationId};
+use osmpbfreader::{StoreObjs, OsmId, OsmObj};
 use rusqlite::{Connection, ToSql, NO_PARAMS};
 use serde_json;
 use std::fs;
 use std::borrow::Cow;
 
-// TODO: regarder si diesel serait mieux
-struct DB {
-    conn: Connection,
+macro_rules! err_logger {
+    ($obj:expr, $err_msg:expr) => {
+        match $obj {
+            Ok(x) => Some(x),
+            Err(e) => {
+                error!("{}: {}", $err_msg, e);
+                None
+            }
+        }?
+    };
+    ($obj:expr, $err_msg:expr, $ret:expr) => {
+        match $obj {
+            Ok(x) => x,
+            Err(e) => {
+                error!("{}: {}", $err_msg, e);
+                return $ret;
+            }
+        }
+    }
 }
 
-const DB_FILE_PATH: &str = "./cosmogony_db.db3";
+macro_rules! get_kind {
+    ($obj:expr) => {
+        if $obj.is_node() {
+            &"node"
+        } else if $obj.is_way() {
+            &"way"
+        } else if $obj.is_relation() {
+            &"relation"
+        } else {
+            panic!("Unknown OSM object kind!")
+        }
+    }
+}
 
 pub trait Getter {
     fn get(&self, key: &OsmId) -> Option<Cow<OsmObj>>;
@@ -59,86 +88,94 @@ impl Getter for BTreeMap<OsmId, OsmObj> {
     }
 }
 
-impl DB {
-    fn new() -> DB {
-        let _ = fs::remove_file(DB_FILE_PATH); // we ignore any potential error
-        let conn = Connection::open(&DB_FILE_PATH).expect("failed to open SQLITE connection");
+struct DB<'a> {
+    conn: Connection,
+    db_file: &'a PathBuf,
+}
+
+impl<'a> DB<'a> {
+    fn new(db_file: &'a PathBuf) -> Result<DB<'a>, String> {
+        let _ = fs::remove_file(db_file); // we ignore any potential error
+        let conn = Connection::open(&db_file)
+            .map_err(|e| format!("failed to open SQLITE connection: {}", e))?;
 
         conn.execute(
             "CREATE TABLE ids (
-                id   INTEGER PRIMARY KEY,
+                id   INTEGER,
                 obj  TEXT NOT NULL,
-                UNIQUE(id)
+                kind TEXT NOT NULL,
+                UNIQUE(id, kind)
              )",
             NO_PARAMS,
-        ).expect("failed to create table");
-        DB {
+        ).map_err(|e| format!("failed to create table: {}", e))?;
+        Ok(DB {
             conn,
-        }
+            db_file,
+        })
     }
 
     fn get_from_id(&self, id: &OsmId) -> Option<OsmObj> {
-        let mut stmt = self.conn
-            .prepare("SELECT obj FROM ids WHERE id=?1").expect("prepare failed");
-        let mut iter = stmt.query(&[&id.inner_id() as &dyn ToSql]).expect("query_map failed");
-        while let Some(row) = iter.next().expect("next failed") {
-            let obj: String = row.get(0).expect("failed to get obj field");
-            return serde_json::from_str(&obj).expect("conversion from string failed")
+        let mut stmt = err_logger!(self.conn.prepare("SELECT obj FROM ids WHERE id=?1 AND kind=?2"),
+            "DB::get_from_id: prepare failed");
+        let mut iter = err_logger!(stmt.query(&[&id.inner_id() as &dyn ToSql, get_kind!(id)]),
+            "DB::get_from_id: query_map failed");
+        while let Some(row) = err_logger!(iter.next(), "DB::get_from_id: next failed") {
+            let obj: String = err_logger!(row.get(0), "DB::get_from_id: failed to get obj field");
+            err_logger!(serde_json::from_str(&obj),
+                "DB::get_from_id: conversion from string failed")
         }
         None
     }
 
-    fn iter<F: FnMut(OsmId, OsmObj)>(&self, mut f: F) {
-        let mut stmt = self.conn
-            .prepare("SELECT id, obj FROM ids").expect("prepare failed");
-        let mut rows = stmt.query(NO_PARAMS).expect("query_map failed");
-        while let Some(row) = rows.next().expect("next() failed") {
-            let id = row.get(0).expect("failed to get id field");
-            let obj: String = row.get(1).expect("failed to get obj field");
+    fn for_each<F: FnMut(Cow<OsmObj>)>(&self, mut f: F) {
+        let mut stmt = err_logger!(self.conn.prepare("SELECT obj FROM ids"),
+            "DB::for_each: prepare failed", ());
+        let mut rows = err_logger!(stmt.query(NO_PARAMS), "DB::for_each: query_map failed", ());
+        while let Some(row) = err_logger!(rows.next(), "DB::for_each: next failed", ()) {
+            let obj: String = err_logger!(row.get(0), "DB::for_each: failed to get obj field", ());
 
-            let obj: OsmObj = serde_json::from_str(&obj).expect("serde conversion failed");
-            let id = if obj.is_node() {
-                OsmId::Node(NodeId(id))
-            } else if obj.is_way() {
-                OsmId::Way(WayId(id))
-            } else {
-                OsmId::Relation(RelationId(id))
-            };
-            f(id, obj);
+            let obj: OsmObj = err_logger!(serde_json::from_str(&obj),
+                "DB::for_each: serde conversion failed",
+                ());
+            f(Cow::Owned(obj));
         }
     }
 }
 
-impl StoreObjs for DB {
+impl<'a> StoreObjs for DB<'a> {
     fn insert(&mut self, id: OsmId, obj: OsmObj) {
-        let obj = serde_json::to_string(&obj).expect("failed to convert to json");
-        self.conn.execute(
-            "INSERT OR IGNORE INTO ids(id, obj) VALUES (?1, ?2)",
-            &[&id.inner_id() as &dyn ToSql, &obj],
-        ).expect("failed to insert values");
+        let kind = get_kind!(obj);
+        let obj = err_logger!(serde_json::to_string(&obj),
+            "DB::insert: failed to convert to json", ());
+        err_logger!(self.conn.execute(
+            "INSERT OR IGNORE INTO ids(id, obj, kind) VALUES (?1, ?2, ?3)",
+            &[&id.inner_id() as &dyn ToSql, &obj, kind]),
+            "DB::insert: insert failed",
+            ());
     }
 
     fn contains_key(&self, id: &OsmId) -> bool {
-        let mut stmt = self.conn
-            .prepare("SELECT id FROM ids WHERE id=?1").expect("prepare failed");
-        let mut iter = stmt.query(&[&id.inner_id() as &dyn ToSql]).expect("query_map failed");
-        iter.next().expect("no row").is_some()
+        let mut stmt = err_logger!(self.conn.prepare("SELECT id FROM ids WHERE id=?1 AND kind=?2"),
+            "DB::contains_key: prepare failed",
+            false);
+        let mut iter = err_logger!(stmt.query(&[&id.inner_id() as &dyn ToSql, get_kind!(id)]),
+            "DB::contains_key: query_map failed",
+            false);
+        err_logger!(iter.next(), "DB::contains_key: no row", false).is_some()
     }
 }
 
-impl Getter for DB {
+impl<'a> Getter for DB<'a> {
     fn get(&self, key: &OsmId) -> Option<Cow<OsmObj>> {
         self.get_from_id(key).map(|x| Cow::Owned(x))
     }
 }
 
-impl Drop for DB {
+impl<'a> Drop for DB<'a> {
     fn drop(&mut self) {
-        let _ = fs::remove_file(DB_FILE_PATH); // we ignore any potential error
+        let _ = fs::remove_file(self.db_file); // we ignore any potential error
     }
 }
-
-// TODO: impl drop to remove sql file
 
 pub type AdminSet = BTreeSet<Arc<mimir::Admin>>;
 pub type NameAdminMap = BTreeMap<StreetKey, Vec<osmpbfreader::OsmId>>;
@@ -151,9 +188,66 @@ pub struct StreetKey {
     pub admins: AdminSet,
 }
 
+enum ObjWrapper<'a> {
+    Map(BTreeMap<osmpbfreader::OsmId, osmpbfreader::OsmObj>),
+    DB(DB<'a>),
+}
+
+impl<'a> ObjWrapper<'a> {
+    fn new(db_file: &'a Option<PathBuf>) -> Result<ObjWrapper<'a>, Error> {
+        Ok(if let Some(ref db_file) = db_file {
+            info!("Running with DB storage");
+            ObjWrapper::DB(DB::new(db_file).map_err(|e| failure::err_msg(e))?)
+        } else {
+            info!("Running with BTreeMap (RAM) storage");
+            ObjWrapper::Map(BTreeMap::new())
+        })
+    }
+
+    fn for_each<F: FnMut(Cow<OsmObj>)>(&self, mut f: F) {
+        match *self {
+            ObjWrapper::Map(ref m) => {
+                let mut values = m.values();
+                while let Some(value) = values.next() {
+                    f(Cow::Borrowed(value));
+                }
+            }
+            ObjWrapper::DB(ref db) => db.for_each(f),
+        }
+    }
+}
+
+impl<'a> Getter for ObjWrapper<'a> {
+    fn get(&self, key: &OsmId) -> Option<Cow<OsmObj>> {
+        match *self {
+            ObjWrapper::Map(ref m) => m.get(key).map(|x| Cow::Borrowed(x)),
+            ObjWrapper::DB(ref db) => db.get(key),
+        }
+    }
+}
+
+impl<'a> StoreObjs for ObjWrapper<'a> {
+    fn insert(&mut self, id: OsmId, obj: OsmObj) {
+        match *self {
+            ObjWrapper::Map(ref mut m) => {
+                m.insert(id, obj);
+            }
+            ObjWrapper::DB(ref mut db) => db.insert(id, obj),
+        }
+    }
+
+    fn contains_key(&self, id: &OsmId) -> bool {
+        match *self {
+            ObjWrapper::Map(ref m) => m.contains_key(id),
+            ObjWrapper::DB(ref db) => db.contains_key(id),
+        }
+    }
+}
+
 pub fn streets(
     pbf: &mut OsmPbfReader,
     admins_geofinder: &AdminGeoFinder,
+    db_file: &Option<PathBuf>,
 ) -> Result<StreetsVec, Error> {
     fn is_valid_obj(obj: &osmpbfreader::OsmObj) -> bool {
         match *obj {
@@ -169,7 +263,7 @@ pub fn streets(
         }
     }
     info!("reading pbf...");
-    let mut objs_map = DB::new();
+    let mut objs_map = ObjWrapper::new(db_file)?;
     pbf.get_objs_and_deps_store(is_valid_obj, &mut objs_map)
         .context("Error occurred when reading pbf")?;
     info!("reading pbf done.");
@@ -181,47 +275,50 @@ pub fn streets(
     // to group all these "way"s. In order not to have duplicates in autocompletion, we should tag
     // the osm ways in the relation not to index them twice.
 
-    objs_map.iter(|_, obj| {
-        if let Some(rel) = obj.relation() {
-            let way_name = rel.tags.get("name");
-            rel.refs
-                .iter()
-                .filter(|ref_obj| ref_obj.member.is_way() && ref_obj.role == "street")
-                .filter_map(|ref_obj| {
-                    let obj = objs_map.get(&ref_obj.member)?;
-                    let way = obj.way()?;
-                    let way_name = way_name.or_else(|| way.tags.get("name"))?;
-                    let admins = get_street_admin(admins_geofinder, &objs_map, way);
-                    let country_codes = utils::find_country_codes(admins.iter().map(|a| a.deref()));
-                    let street_label = labels::format_street_label(
-                        &way_name,
-                        admins.iter().map(|a| a.deref()),
-                        &country_codes,
-                    );
-                    let coord = get_way_coord(&objs_map, way);
-                    Some(mimir::Street {
-                        id: format!("street:osm:relation:{}", rel.id.0.to_string()),
-                        name: way_name.to_string(),
-                        label: street_label,
-                        weight: 0.,
-                        zip_codes: utils::get_zip_codes_from_admins(&admins),
-                        administrative_regions: admins,
-                        coord: get_way_coord(&objs_map, way),
-                        approx_coord: Some(coord.into()),
-                        distance: None,
-                        country_codes,
-                        context: None,
-                    })
+    objs_map.for_each(|obj| {
+        let relation = obj.relation();
+        if relation.is_none() {
+            return;
+        }
+        let rel = obj.relation().expect("impossible unwrap failure occured");
+        let way_name = rel.tags.get("name");
+        rel.refs
+            .iter()
+            .filter(|ref_obj| ref_obj.member.is_way() && ref_obj.role == "street")
+            .filter_map(|ref_obj| {
+                let obj = objs_map.get(&ref_obj.member)?;
+                let way = obj.way()?;
+                let way_name = way_name.or_else(|| way.tags.get("name"))?;
+                let admins = get_street_admin(admins_geofinder, &objs_map, way);
+                let country_codes = utils::find_country_codes(admins.iter().map(|a| a.deref()));
+                let street_label = labels::format_street_label(
+                    &way_name,
+                    admins.iter().map(|a| a.deref()),
+                    &country_codes,
+                );
+                let coord = get_way_coord(&objs_map, way);
+                Some(mimir::Street {
+                    id: format!("street:osm:relation:{}", rel.id.0.to_string()),
+                    name: way_name.to_string(),
+                    label: street_label,
+                    weight: 0.,
+                    zip_codes: utils::get_zip_codes_from_admins(&admins),
+                    administrative_regions: admins,
+                    coord: get_way_coord(&objs_map, way),
+                    approx_coord: Some(coord.into()),
+                    distance: None,
+                    country_codes,
+                    context: None,
                 })
-                .next()
-                .map(|street| street_list.push(street));
+            })
+            .next()
+            .map(|street| street_list.push(street));
 
-            // Add osmid of all the relation members in the set
-            // We don't create any street for all the osmid present in street_rel
-            for ref_obj in &rel.refs {
-                if ref_obj.member.is_way() {
-                    street_rel.insert(ref_obj.member);
-                }
+        // Add osmid of all the relation members in the set
+        // We don't create any street for all the osmid present in street_rel
+        for ref_obj in &rel.refs {
+            if ref_obj.member.is_way() {
+                street_rel.insert(ref_obj.member);
             }
         }
     });
@@ -229,7 +326,8 @@ pub fn streets(
     // we merge all the ways with a key = way_name + admin list of level(=city_level)
     // we use a map NameAdminMap <key, value> to manage the merging of ways
     let mut name_admin_map = NameAdminMap::default();
-    objs_map.iter(|osmid, obj| {
+    objs_map.for_each(|obj| {
+        let osmid = obj.id();
         if street_rel.contains(&osmid) {
             return;
         }

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -210,23 +210,7 @@ impl<'a> StoreObjs for DB<'a> {
         if self.buffer.len() >= self.db_buffer_size {
             self.flush_buffer();
         }
-        /*let kind = get_kind!(obj);
-        let ser_obj = err_logger!(
-            bincode::serialize(&obj),
-            "DB::insert: failed to convert to json",
-            ()
-        );
-        err_logger!(
-            self.conn.execute(
-                "INSERT OR IGNORE INTO ids(id, obj, kind) VALUES (?1, ?2, ?3)",
-                &[&id.inner_id() as &dyn ToSql, &ser_obj, kind]
-            ),
-            "DB::insert: insert failed",
-            ()
-        );*/
-        if !self.contains_key(&id) {
-            self.buffer.insert(id, obj);
-        }
+        self.buffer.insert(id, obj);
     }
 
     fn contains_key(&self, id: &OsmId) -> bool {

--- a/tests/osm2mimir_test.rs
+++ b/tests/osm2mimir_test.rs
@@ -73,6 +73,7 @@ pub fn osm2mimir_sample_test_sqlite(es_wrapper: crate::ElasticSearchWrapper<'_>)
             "--level=8".into(),
             "--level=7".into(),
             "--db-file=test-db.sqlite3".into(),
+            "--db-buffer-size=1".into(),
             format!("--connection-string={}", es_wrapper.host()),
         ],
         &es_wrapper,
@@ -122,7 +123,12 @@ fn check_results(es_wrapper: crate::ElasticSearchWrapper<'_>, test_name: &str) {
     assert!(res.len() != 0, "{}", test_name);
     assert!(res[0].is_street(), "{}", test_name);
     // The first hit should be "Rue des Près"
-    assert_eq!(res[0].label(), "Rue des Près (Livry-sur-Seine)", "{}", test_name);
+    assert_eq!(
+        res[0].label(),
+        "Rue des Près (Livry-sur-Seine)",
+        "{}",
+        test_name
+    );
 
     // And there should be only ONE "Rue des Près"
     assert_eq!(
@@ -154,13 +160,17 @@ fn check_results(es_wrapper: crate::ElasticSearchWrapper<'_>, test_name: &str) {
     assert_eq!(nb, 1, "{}", test_name);
 
     // Test the id is the min(=40812939) of all the ways composing the street
-    assert!(four_a_chaux_street[0].address().map_or(false, |a| {
-        if let mimir::Address::Street(s) = a {
-            s.id == "street:osm:way:40812939"
-        } else {
-            false
-        }
-    }), "{}", test_name);
+    assert!(
+        four_a_chaux_street[0].address().map_or(false, |a| {
+            if let mimir::Address::Street(s) = a {
+                s.id == "street:osm:way:40812939"
+            } else {
+                false
+            }
+        }),
+        "{}",
+        test_name
+    );
 
     // Test: Streets having the same label in different cities
     let place_filter = |place: &mimir::Place| {
@@ -197,15 +207,23 @@ fn check_results(es_wrapper: crate::ElasticSearchWrapper<'_>, test_name: &str) {
     assert!(res.len() != 0, "{}", test_name);
 
     let poi_type_post_office = "poi_type:amenity:post_office";
-    assert!(res.iter().any(|r| r
-        .poi()
-        .map_or(false, |poi| poi.poi_type.id == poi_type_post_office)), "{}", test_name);
+    assert!(
+        res.iter().any(|r| r
+            .poi()
+            .map_or(false, |poi| poi.poi_type.id == poi_type_post_office)),
+        "{}",
+        test_name
+    );
 
     let res: Vec<_> = es_wrapper
         .search_and_filter("label:Melun Rp", |_| true)
         .collect();
     assert!(res.len() != 0, "{}", test_name);
-    assert!(res.iter().any(|r| r
-        .poi()
-        .map_or(false, |poi| poi.poi_type.id == poi_type_post_office)), "{}", test_name);
+    assert!(
+        res.iter().any(|r| r
+            .poi()
+            .map_or(false, |poi| poi.poi_type.id == poi_type_post_office)),
+        "{}",
+        test_name
+    );
 }

--- a/tests/osm2mimir_test.rs
+++ b/tests/osm2mimir_test.rs
@@ -53,6 +53,35 @@ pub fn osm2mimir_sample_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         &es_wrapper,
     );
 
+    check_results(es_wrapper);
+}
+
+/// Simple call to a BANO load into ES base
+/// Checks that we are able to find one object (a specific address)
+pub fn osm2mimir_sample_test_sqlite(es_wrapper: crate::ElasticSearchWrapper<'_>) {
+    let osm2mimir = Path::new(env!("OUT_DIR"))
+        .join("../../../osm2mimir")
+        .display()
+        .to_string();
+    crate::launch_and_assert(
+        &osm2mimir,
+        &[
+            "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--import-way".into(),
+            "--import-admin".into(),
+            "--import-poi".into(),
+            "--level=8".into(),
+            "--level=7".into(),
+            "--db-file=test-db.sqlite3".into(),
+            format!("--connection-string={}", es_wrapper.host()),
+        ],
+        &es_wrapper,
+    );
+
+    check_results(es_wrapper);
+}
+
+fn check_results(es_wrapper: crate::ElasticSearchWrapper<'_>) {
     // Test: Import of Admin
     let res: Vec<_> = es_wrapper
         .search_and_filter("label:Livry-sur-Seine", |_| true)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -131,6 +131,7 @@ fn all_tests() {
     // we call all tests here
     bano2mimir_test::bano2mimir_sample_test(ElasticSearchWrapper::new(&docker_wrapper));
     osm2mimir_test::osm2mimir_sample_test(ElasticSearchWrapper::new(&docker_wrapper));
+    osm2mimir_test::osm2mimir_sample_test_sqlite(ElasticSearchWrapper::new(&docker_wrapper));
     stops2mimir_test::stops2mimir_sample_test(ElasticSearchWrapper::new(&docker_wrapper));
     osm2mimir_bano2mimir_test::osm2mimir_bano2mimir_test(ElasticSearchWrapper::new(
         &docker_wrapper,


### PR DESCRIPTION
Depends on https://github.com/TeXitoi/osmpbfreader-rs/pull/22

When running on central america with osm2mimir, the memory consumption goes from 5464 MB to 4790 MB. Considering this is a **very** small file, I expect the difference to be way bigger for the whole world. Only question: should I provide an option for this or not?