### PR TITLE
Add cache header to bragi http response

### DIFF
--- a/libs/bragi/src/lib.rs
+++ b/libs/bragi/src/lib.rs
@@ -91,6 +91,16 @@ pub struct Args {
         env = "BRAGI_MAX_ES_FEATURES_TIMEOUT"
     )]
     pub max_es_features_timeout: Option<u64>,
+
+    /// Cache duration for http response served by bragi
+    /// This only set the Cache-control Header, it doesn't enable cache on bragi side
+    /// The duration is in seconds
+    #[structopt(
+        long = "http-cache-duration",
+        env = "BRAGI_HTTP_CACHE_DURATION",
+        default_value = "3600"
+    )]
+    pub http_cache_duration: u32,
 }
 
 #[derive(Clone, Debug)]
@@ -99,6 +109,7 @@ pub struct Context {
     features_rubber: Rubber,
     autocomplete_rubber: Rubber,
     pub cnx_string: String,
+    pub http_cache_duration: u32,
     // pub rubber: Rubber,
 }
 
@@ -131,6 +142,7 @@ impl From<&Args> for Context {
                 bounded_timeout(args.max_es_autocomplete_timeout),
             ),
             cnx_string: args.connection_string.clone(),
+            http_cache_duration: args.http_cache_duration.clone(),
         }
     }
 }

--- a/libs/bragi/src/routes/features.rs
+++ b/libs/bragi/src/routes/features.rs
@@ -1,6 +1,7 @@
 use crate::extractors::BragiQuery;
 use crate::{model, model::FromWithLang, query, Context};
-use actix_web::web::{Data, Json, Path};
+use actix_http::http::header::{CacheControl, CacheDirective};
+use actix_web::web::{Data, HttpResponse, Path};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -20,7 +21,7 @@ pub fn features(
     params: BragiQuery<Params>,
     state: Data<Context>,
     id: Path<String>,
-) -> Result<Json<model::Autocomplete>, model::BragiError> {
+) -> Result<HttpResponse, model::BragiError> {
     let rubber = state.get_rubber_for_features(params.timeout.map(Duration::from_millis));
     let features = query::features(
         &params
@@ -39,5 +40,11 @@ pub fn features(
     );
     features
         .map(|r| model::Autocomplete::from_with_lang(r, None))
-        .map(Json)
+        .map(|v| {
+            HttpResponse::Ok()
+                .set(CacheControl(vec![CacheDirective::MaxAge(
+                    state.http_cache_duration,
+                )]))
+                .json(v)
+        })
 }

--- a/libs/bragi/src/routes/reverse.rs
+++ b/libs/bragi/src/routes/reverse.rs
@@ -1,7 +1,8 @@
 use crate::extractors::BragiQuery;
 use crate::routes::params;
 use crate::{model, model::FromWithLang, Context};
-use actix_web::web::{Data, Json};
+use actix_http::http::header::{CacheControl, CacheDirective};
+use actix_web::web::{Data, HttpResponse};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -16,12 +17,18 @@ pub struct Params {
 pub fn reverse(
     params: BragiQuery<Params>,
     state: Data<Context>,
-) -> Result<Json<model::Autocomplete>, model::BragiError> {
+) -> Result<HttpResponse, model::BragiError> {
     let mut rubber = state.get_rubber_for_reverse(params.timeout.map(Duration::from_millis));
     let coord = params::make_coord(params.lon, params.lat)?;
     rubber
         .get_address(&coord)
         .map_err(model::BragiError::from)
         .map(|r| model::Autocomplete::from_with_lang(r, None))
-        .map(Json)
+        .map(|v| {
+            HttpResponse::Ok()
+                .set(CacheControl(vec![CacheDirective::MaxAge(
+                    state.http_cache_duration,
+                )]))
+                .json(v)
+        })
 }


### PR DESCRIPTION
This PR make bragi output a cache header for every requests on
/features, /autocomplete, /reverse.
By default cache is enabled and set to 1H.
This header will be used by http clients to cache results, it will also
be used by caching proxy like varnish.