### PR TITLE
Bump navitia_poi_model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,7 +1494,7 @@ dependencies = [
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "humanesort 0.1.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "navitia-poi-model 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "navitia-poi-model 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "par-map 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1537,7 +1537,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mimir 1.2.0",
- "navitia-poi-model 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "navitia-poi-model 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "osm_boundaries_utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "navitia-poi-model"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3677,7 +3677,7 @@ dependencies = [
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
-"checksum navitia-poi-model 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea91394d9427b385fa2d43e4ff1e878d5f48a1b197fec1d4173a44ce33e3be1d"
+"checksum navitia-poi-model 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f2fc8427757bf937df73d82eb9d2afe4d2d040dd7dc6ccb639d4408539ade49"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ num_cpus = "1.10"
 assert_float_eq = "1"
 humanesort = "0.1.0-alpha"
 address-formatter = "^0.2.1"
-navitia-poi-model = "0.2.0"
+navitia-poi-model = "0.2.1"
 walkdir = "2"
 rusqlite = "0.20"
 


### PR DESCRIPTION
This change from navitia_poi_model fixes an error that occured when
importing poi files. The absence of 'poi_properties.txt' would be
flagged as an error, but in fact it just means that there is no
additional properties.

I have tested this change by creating a poi file without poi_properties.txt, and importing it
with poi2mimir.