### PR TITLE
Mininale Supported Rust Toolchain version 1.39.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - 1.36.0
+  - 1.39.0
 env:
   - RUN=TEST
 script:

--- a/docker/Dockerfile_bragi
+++ b/docker/Dockerfile_bragi
@@ -1,4 +1,4 @@
-FROM rust:1.36-stretch as builder
+FROM rust:1.39-stretch as builder
 
 WORKDIR /srv/mimirsbrunn
 

--- a/docker/Dockerfile_import
+++ b/docker/Dockerfile_import
@@ -1,4 +1,4 @@
-FROM rust:1.36-stretch as builder
+FROM rust:1.39-stretch as builder
 
 WORKDIR /srv/mimirsbrunn
 


### PR DESCRIPTION
With the upcoming changes, the minimum version of the rust toolchain that compiles the project has changed from 1.36 -> 1.39.