### PR TITLE
add a gzip option for CSV addresses importers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,6 +1396,17 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libflate"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "mimirsbrunn"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "actix-web 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "address-formatter 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1535,6 +1546,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mimir 1.2.0",
  "navitia-poi-model 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2424,6 +2436,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rs-es"
@@ -3658,6 +3675,7 @@ dependencies = [
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
+"checksum libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
 "checksum libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
@@ -3762,6 +3780,7 @@ dependencies = [
 "checksum reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddcfd2c13c6af0f9c45a1086be3b9c68af79e4430b42790759e2d34cce2a6c60"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
+"checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 "checksum rs-es 0.12.2 (git+https://github.com/canaltp/rs-es)" = "<none>"
 "checksum rstar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "120bfe4837befb82c5a637a5a8c490a27d25524ac19fffec5b4e555ca6e36ee8"
 "checksum rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a194373ef527035645a1bc21b10dc2125f73497e6e155771233eb187aedd051"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,17 +1396,6 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "libflate"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1527,7 @@ dependencies = [
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "docker_wrapper 1.2.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1546,7 +1536,6 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mimir 1.2.0",
  "navitia-poi-model 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2436,11 +2425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rs-es"
@@ -3675,7 +3659,6 @@ dependencies = [
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lexical-core 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
-"checksum libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
 "checksum libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
@@ -3780,7 +3763,6 @@ dependencies = [
 "checksum reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddcfd2c13c6af0f9c45a1086be3b9c68af79e4430b42790759e2d34cce2a6c60"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29460f6011a25fc70b22010e796bd98330baccaa0005cba6f90b858a510dec0d"
-"checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 "checksum rs-es 0.12.2 (git+https://github.com/canaltp/rs-es)" = "<none>"
 "checksum rstar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "120bfe4837befb82c5a637a5a8c490a27d25524ac19fffec5b4e555ca6e36ee8"
 "checksum rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a194373ef527035645a1bc21b10dc2125f73497e6e155771233eb187aedd051"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ address-formatter = "^0.2.1"
 navitia-poi-model = "0.2.1"
 walkdir = "2"
 rusqlite = "0.20"
+libflate = "0.1"
 
 mimir = { path = "libs/mimir" }
 bragi = { path = "libs/bragi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ address-formatter = "^0.2.1"
 navitia-poi-model = "0.2.1"
 walkdir = "2"
 rusqlite = "0.20"
-libflate = "0.1"
+flate2 = "1.0"
 
 mimir = { path = "libs/mimir" }
 bragi = { path = "libs/bragi" }

--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -12,13 +12,12 @@ use std::io::Read;
 use std::marker::{Send, Sync};
 use std::path::PathBuf;
 
-pub fn import_addresses<T, F>(
+fn import_addresses<T, F>(
     rubber: &mut Rubber,
-    has_headers: bool,
     nb_threads: usize,
     index_settings: IndexSettings,
     dataset: &str,
-    files: impl IntoIterator<Item = PathBuf>,
+    addresses: impl IntoIterator<Item = T>,
     into_addr: F,
 ) -> Result<(), Error>
 where
@@ -28,39 +27,10 @@ where
     let addr_index = rubber
         .make_index(dataset, &index_settings)
         .with_context(|_| format!("Error occurred when making index {}", dataset))?;
-    info!("Add data in elasticsearch db.");
 
-    let iter = files
+    info!("Add data in elasticsearch db.");
+    let iter = addresses
         .into_iter()
-        .filter_map(|path| {
-            info!("importing {:?}...", &path);
-            let with_gzip = path
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .map(|ext| ext == "gz" || ext.ends_with(".gz"))
-                .unwrap_or(false);
-            File::open(&path)
-                .map_err(|err| error!("Impossible to read file {:?}, error: {}", path, err))
-                .map(|file| {
-                    if with_gzip {
-                        let decoder = GzDecoder::new(file);
-                        Box::new(decoder) as Box<dyn Read>
-                    } else {
-                        Box::new(file) as Box<dyn Read>
-                    }
-                })
-                .ok()
-        })
-        .flat_map(|stream| {
-            csv::ReaderBuilder::new()
-                .has_headers(has_headers)
-                .from_reader(stream)
-                .into_deserialize()
-        })
-        .filter_map(|line| {
-            line.map_err(|e| warn!("Impossible to read line, error: {}", e))
-                .ok()
-        })
         .with_nb_threads(nb_threads)
         .par_map(into_addr)
         .filter_map(|ra| match ra {
@@ -77,13 +47,89 @@ where
                 None
             }
         });
+
     let nb = rubber
         .bulk_index(&addr_index, iter)
-        .with_context(|_| format!("failed to bulk insert"))?;
+        .with_context(|_| "failed to bulk insert")?;
     info!("importing addresses: {} addresses added.", nb);
 
     rubber
         .publish_index(dataset, addr_index, IndexVisibility::Public)
         .context("Error while publishing the index")?;
     Ok(())
+}
+
+pub fn import_addresses_from_streams<T, F>(
+    rubber: &mut Rubber,
+    has_headers: bool,
+    nb_threads: usize,
+    index_settings: IndexSettings,
+    dataset: &str,
+    streams: impl IntoIterator<Item = impl Read>,
+    into_addr: F,
+) -> Result<(), Error>
+where
+    F: Fn(T) -> Result<Addr, Error> + Send + Sync + 'static,
+    T: DeserializeOwned + Send + 'static,
+{
+    let iter = streams
+        .into_iter()
+        .flat_map(|stream| {
+            csv::ReaderBuilder::new()
+                .has_headers(has_headers)
+                .from_reader(stream)
+                .into_deserialize()
+        })
+        .filter_map(|line| {
+            line.map_err(|e| warn!("Impossible to read line, error: {}", e))
+                .ok()
+        });
+
+    import_addresses(rubber, nb_threads, index_settings, dataset, iter, into_addr)
+}
+
+pub fn import_addresses_from_files<T, F>(
+    rubber: &mut Rubber,
+    has_headers: bool,
+    nb_threads: usize,
+    index_settings: IndexSettings,
+    dataset: &str,
+    files: impl IntoIterator<Item = PathBuf>,
+    into_addr: F,
+) -> Result<(), Error>
+where
+    F: Fn(T) -> Result<Addr, Error> + Send + Sync + 'static,
+    T: DeserializeOwned + Send + 'static,
+{
+    let streams = files.into_iter().filter_map(|path| {
+        info!("importing {:?}...", &path);
+
+        let with_gzip = path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext == "gz")
+            .unwrap_or(false);
+
+        File::open(&path)
+            .map_err(|err| error!("Impossible to read file {:?}, error: {}", path, err))
+            .map(|file| {
+                if with_gzip {
+                    let decoder = GzDecoder::new(file);
+                    Box::new(decoder) as Box<dyn Read>
+                } else {
+                    Box::new(file) as Box<dyn Read>
+                }
+            })
+            .ok()
+    });
+
+    import_addresses_from_streams(
+        rubber,
+        has_headers,
+        nb_threads,
+        index_settings,
+        dataset,
+        streams,
+        into_addr,
+    )
 }

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -185,6 +185,7 @@ fn index_bano<I>(
     nb_threads: usize,
     nb_shards: usize,
     nb_replicas: usize,
+    with_gzip: bool,
     use_old_index_format: bool,
 ) -> Result<(), mimirsbrunn::Error>
 where
@@ -218,6 +219,7 @@ where
     import_addresses(
         &mut rubber,
         false,
+        with_gzip,
         nb_threads,
         index_settings,
         dataset,
@@ -231,6 +233,9 @@ struct Args {
     /// Bano files. Can be either a directory or a file.
     #[structopt(short = "i", long = "input", parse(from_os_str))]
     input: PathBuf,
+    /// The input CSV file has been compressed using gzip.
+    #[structopt(short = "x", long)]
+    gzip: bool,
     /// Elasticsearch parameters.
     #[structopt(
         short = "c",
@@ -271,6 +276,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
             args.nb_threads,
             args.nb_shards,
             args.nb_replicas,
+            args.gzip,
             args.use_old_index_format,
         )
     } else {
@@ -281,6 +287,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
             args.nb_threads,
             args.nb_shards,
             args.nb_replicas,
+            args.gzip,
             args.use_old_index_format,
         )
     }

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -185,7 +185,6 @@ fn index_bano<I>(
     nb_threads: usize,
     nb_shards: usize,
     nb_replicas: usize,
-    with_gzip: bool,
     use_old_index_format: bool,
 ) -> Result<(), mimirsbrunn::Error>
 where
@@ -219,7 +218,6 @@ where
     import_addresses(
         &mut rubber,
         false,
-        with_gzip,
         nb_threads,
         index_settings,
         dataset,
@@ -233,9 +231,6 @@ struct Args {
     /// Bano files. Can be either a directory or a file.
     #[structopt(short = "i", long = "input", parse(from_os_str))]
     input: PathBuf,
-    /// The input CSV file has been compressed using gzip.
-    #[structopt(short = "x", long)]
-    gzip: bool,
     /// Elasticsearch parameters.
     #[structopt(
         short = "c",
@@ -276,7 +271,6 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
             args.nb_threads,
             args.nb_shards,
             args.nb_replicas,
-            args.gzip,
             args.use_old_index_format,
         )
     } else {
@@ -287,7 +281,6 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
             args.nb_threads,
             args.nb_shards,
             args.nb_replicas,
-            args.gzip,
             args.use_old_index_format,
         )
     }

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -144,7 +144,6 @@ fn index_oa<I>(
     index_settings: IndexSettings,
     files: I,
     nb_threads: usize,
-    with_gzip: bool,
     use_old_index_format: bool,
 ) -> Result<(), mimirsbrunn::Error>
 where
@@ -164,7 +163,6 @@ where
     import_addresses(
         &mut rubber,
         true,
-        with_gzip,
         nb_threads,
         index_settings,
         dataset,
@@ -178,9 +176,6 @@ struct Args {
     /// openaddresses files. Can be either a directory or a file.
     #[structopt(short = "i", long = "input", parse(from_os_str))]
     input: PathBuf,
-    /// The input CSV file(s) have been compressed using gzip.
-    #[structopt(short = "x", long)]
-    gzip: bool,
     /// Elasticsearch parameters.
     #[structopt(
         short = "c",
@@ -246,7 +241,6 @@ fn run(args: Args) -> Result<(), failure::Error> {
             index_settings,
             path_iter,
             args.nb_threads,
-            args.gzip,
             args.use_old_index_format,
         )
     } else {
@@ -256,7 +250,6 @@ fn run(args: Args) -> Result<(), failure::Error> {
             index_settings,
             std::iter::once(args.input),
             args.nb_threads,
-            args.gzip,
             args.use_old_index_format,
         )
     }

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -144,6 +144,7 @@ fn index_oa<I>(
     index_settings: IndexSettings,
     files: I,
     nb_threads: usize,
+    with_gzip: bool,
     use_old_index_format: bool,
 ) -> Result<(), mimirsbrunn::Error>
 where
@@ -163,6 +164,7 @@ where
     import_addresses(
         &mut rubber,
         true,
+        with_gzip,
         nb_threads,
         index_settings,
         dataset,
@@ -176,6 +178,9 @@ struct Args {
     /// openaddresses files. Can be either a directory or a file.
     #[structopt(short = "i", long = "input", parse(from_os_str))]
     input: PathBuf,
+    /// The input CSV file(s) have been compressed using gzip.
+    #[structopt(short = "x", long)]
+    gzip: bool,
     /// Elasticsearch parameters.
     #[structopt(
         short = "c",
@@ -228,7 +233,7 @@ fn run(args: Args) -> Result<(), failure::Error> {
                 let f = p
                     .extension()
                     .and_then(|e| e.to_str())
-                    .map(|e| e == "csv")
+                    .map(|e| e == "csv" || e == ".csv.gz")
                     .unwrap_or(false);
                 if !f {
                     info!("skipping file {} as it is not a csv", p.display());
@@ -241,6 +246,7 @@ fn run(args: Args) -> Result<(), failure::Error> {
             index_settings,
             path_iter,
             args.nb_threads,
+            args.gzip,
             args.use_old_index_format,
         )
     } else {
@@ -250,6 +256,7 @@ fn run(args: Args) -> Result<(), failure::Error> {
             index_settings,
             std::iter::once(args.input),
             args.nb_threads,
+            args.gzip,
             args.use_old_index_format,
         )
     }


### PR DESCRIPTION
Add a `gzip` parameter for BANO and OpenAddresses importers, this allows to import gziped CSV files. For example:

```bash
cargo run --release --bin openaddresses2mimir -- --gzip --input=luxembourg.csv.gz --connection-string=$ES_ADDRESS
```

Our use-case is that we intend to import a big amount of addresses that were obtained by merging several sources and that we output using OpenAddresses format.

In general it may still be a nice feature, at least for BANO importer as compressed CSV files are distributed.