### PR TITLE
fix openaddresses2mimir skipping non-compressed files

### DIFF
--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -214,9 +214,9 @@ fn run(args: Args) -> Result<(), failure::Error> {
                 .map(|p| p.unwrap().into_path())
                 .filter(|p| {
                     let f = p
-                        .extension()
-                        .and_then(|e| e.to_str())
-                        .map(|e| e == "gz")
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .map(|name| name.ends_with(".csv") || name.ends_with(".csv.gz"))
                         .unwrap_or(false);
                     if !f {
                         info!("skipping file {} as it is not a csv", p.display());


### PR DESCRIPTION
This is just a dumb mistake introduced in https://github.com/CanalTP/mimirsbrunn/pull/375.

I think it was introduced because I have been careless when applying changes for https://github.com/CanalTP/mimirsbrunn/pull/375#discussion_r380779014 (which also applied to this section of code).