### PR TITLE
bragi: Follow best practices for prometheus metrics endpoint

### DIFF
--- a/libs/bragi/src/prometheus_middleware.rs
+++ b/libs/bragi/src/prometheus_middleware.rs
@@ -6,7 +6,7 @@
 use actix_service::{Service, Transform};
 use actix_web::{
     dev::{Body, BodySize, MessageBody, ResponseBody, ServiceRequest, ServiceResponse},
-    http::{Method, StatusCode},
+    http::{header, Method, StatusCode},
     web::Bytes,
     Error,
 };
@@ -224,6 +224,10 @@ where
             // the middleware and tell us what the endpoint should be.
             if inner.matches(&path, &method) {
                 head.status = StatusCode::OK;
+                head.headers.insert(
+                    header::CONTENT_TYPE,
+                    header::HeaderValue::from_static("text/plain; charset=utf-8"),
+                );
                 body = ResponseBody::Other(Body::from_message(inner.metrics()));
             }
             ResponseBody::Body(StreamLog {

--- a/libs/bragi/src/prometheus_middleware.rs
+++ b/libs/bragi/src/prometheus_middleware.rs
@@ -36,11 +36,12 @@ fn get_ressource_name(path: &str) -> String {
     // so we use an hardcoded associated table
     PATH_TO_NAME
         .get(path)
+        .copied()
         .unwrap_or_else(|| {
             if path.starts_with("/features") {
                 &FEATURES_ROUTE
             } else {
-                &path
+                ""
             }
         })
         .to_string()


### PR DESCRIPTION
Two small fixes about prometheus metrics:

* Do not use an arbitrary path as the "handler" label.
Prometheus recommends not to use metric labels to store an unbounded number of values. In the current implementation, any 404 request with an incorrect path would create a new time series in the prometheus response, that could lead to memory exhaustion in the monitoring stack.  
See https://prometheus.io/docs/practices/naming/#labels for more details  
This PR suggests to use an empty string as a fallback value for unknown paths.

* Set a correct `Content-Type` header value on the /metrics response. 
 Bragi currently sets a `Content-Type: application/json` header on this endpoint, which is incorrect as the prometheus metrics are plain text.