### PR TITLE
Change hardcoded -broken- bash path for *nixes

### DIFF
--- a/scripts/import2mimir.sh
+++ b/scripts/import2mimir.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset


### PR DESCRIPTION
For portability /usr/bin/bash should not be used: it does not exist on
most *nixes (instead it is /bin/bash on most Linuxes). /usr/bin/env bash
can be run on most *nixes including BSD families and Linuxes.

See: https://stackoverflow.com/a/10383546/73673