### PR TITLE
Don't parse and extract streets if we don't import ways.

### DIFF
--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -114,7 +114,7 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         rubber.get_all_admins()?
     };
     let admins_geofinder = admins.into_iter().collect::<AdminGeoFinder>();
-    {
+    if args.import_way {
         info!("Extracting streets from osm");
         let mut streets = streets(
             &mut osm_reader,
@@ -126,22 +126,20 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         info!("computing street weight");
         compute_street_weight(&mut streets);
 
-        if args.import_way {
-            let street_index_settings = IndexSettings {
-                nb_shards: args.nb_street_shards,
-                nb_replicas: args.nb_street_replicas,
-            };
-            info!("importing streets into Mimir");
-            let nb_streets = rubber
-                .public_index(&args.dataset, &street_index_settings, streets.into_iter())
-                .with_context(|_| {
-                    format!(
-                        "Error occurred when requesting street number in {}",
-                        args.dataset
-                    )
-                })?;
-            info!("Nb of indexed street: {}", nb_streets);
-        }
+        let street_index_settings = IndexSettings {
+            nb_shards: args.nb_street_shards,
+            nb_replicas: args.nb_street_replicas,
+        };
+        info!("importing streets into Mimir");
+        let nb_streets = rubber
+            .public_index(&args.dataset, &street_index_settings, streets.into_iter())
+            .with_context(|_| {
+                format!(
+                    "Error occurred when requesting street number in {}",
+                    args.dataset
+                )
+            })?;
+        info!("Nb of indexed street: {}", nb_streets);
     }
     if args.import_admin {
         let admin_index_settings = IndexSettings {


### PR DESCRIPTION
When importing OSM, streets were parsed and extracted regardless of whether or not they were needed.

This patch puts all the street parsing and extracting in the conditional that checks for `--import-way`. 

On imports with `osm2mimir` that don't have `--import-way` set, this greatly improves performance. Especially on OSM files with lots of streets (obviously).

Here's a rough timer ran on before and after the patch. CPU-time improved by 33%.

```
148M mei  5 02:03 /mnt/sda/OSM/mimir/osm/netherlands-gelderland-latest.osm.pbf

before:
time RUST_LOG=error ./target/release/osm2mimir --dataset=nl --input /mnt/sda/OSM/mimir/osm/netherlands-gelderland-latest.osm.pbf --poi-config ./poi_config.json --import-poi

real	1m54,401s
user	2m36,302s
sys	0m8,153s

after:
time RUST_LOG=error ./target/release/osm2mimir --dataset=nl --input /mnt/sda/OSM/mimir/osm/netherlands-gelderland-latest.osm.pbf --poi-config ./poi_config.json --import-poi

real	1m34,879s
user	1m34,825s
sys	0m5,450s
```