### PR TITLE
WIP: Let both GET and POST autocomplete handle a json shape in the body.

### DIFF
--- a/libs/bragi/src/routes/mod.rs
+++ b/libs/bragi/src/routes/mod.rs
@@ -5,7 +5,7 @@ mod params;
 mod reverse;
 mod status;
 
-pub use autocomplete::{autocomplete, post_autocomplete, JsonParams};
+pub use autocomplete::{autocomplete, JsonParams};
 pub use entry_point::entry_point;
 pub use features::features;
 pub use reverse::reverse;

--- a/libs/bragi/src/server.rs
+++ b/libs/bragi/src/server.rs
@@ -1,6 +1,6 @@
 use crate::extractors::ActixError;
 use crate::routes::{
-    autocomplete, entry_point, features, post_autocomplete, reverse, status, JsonParams,
+    autocomplete, entry_point, features, reverse, status, JsonParams,
 };
 use crate::{Args, Context};
 use actix_web::FromRequest;
@@ -22,7 +22,7 @@ pub fn configure_server(cfg: &mut web::ServiceConfig) {
         web::resource("/autocomplete")
             .name("autocomplete")
             .route(web::get().to(autocomplete))
-            .route(web::post().to(post_autocomplete))
+            .route(web::post().to(autocomplete))
             .data(web::Json::<JsonParams>::configure(|cfg| {
                 cfg.error_handler(|err, _req| ActixError::InvalidJson(format!("{}", err)).into())
             })),


### PR DESCRIPTION
GET can handle a body in HTTP, as is seen in e.g. Elasticsearch which we
use a lot. Some client libs have difficulty with this, so we should
leave the POST in place as well.

This makes both behave the same. Making the code a little easier by
removing some wrapper function callsLet both GET and POST autocomplete
handle a json shape in the body.

GET can handle a body in HTTP, as is seen in e.g. Elasticsearch which we
use a lot. Some client libs have difficulty with this, so we should
leave the POST in place as well.

This makes both behave the same. Making the code a little easier by
removing some wrapper function calls.