### PR TITLE
send batches from several threads in Rubber's bulk_index

### DIFF
--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -202,6 +202,10 @@ struct Args {
         default_value = &DEFAULT_NB_THREADS
     )]
     nb_threads: usize,
+    /// Number of threads to use to insert into Elasticsearch. Note that Elasticsearch is not able
+    /// to handle values that are too high.
+    #[structopt(short = "T", long = "nb-insert-threads", default_value = "1")]
+    nb_insert_threads: usize,
     /// Number of shards for the es index
     #[structopt(short = "s", long = "nb-shards", default_value = "5")]
     nb_shards: usize,
@@ -217,7 +221,9 @@ struct Args {
 fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
     info!("importing bano into Mimir");
 
-    let mut rubber = Rubber::new(&args.connection_string);
+    let mut rubber =
+        Rubber::new(&args.connection_string).with_nb_insert_threads(args.nb_insert_threads);
+
     let index_settings = IndexSettings {
         nb_shards: args.nb_shards,
         nb_replicas: args.nb_replicas,

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -165,6 +165,10 @@ struct Args {
         default_value = &DEFAULT_NB_THREADS
     )]
     nb_threads: usize,
+    /// Number of threads to use to insert into Elasticsearch. Note that Elasticsearch is not able
+    /// to handle values that are too high.
+    #[structopt(short = "T", long = "nb-insert-threads", default_value = "1")]
+    nb_insert_threads: usize,
     /// Number of shards for the es index
     #[structopt(short = "s", long = "nb-shards", default_value = "5")]
     nb_shards: usize,
@@ -184,7 +188,9 @@ fn run(args: Args) -> Result<(), failure::Error> {
         warn!("city-level option is deprecated, it now has no effect.");
     }
 
-    let mut rubber = Rubber::new(&args.connection_string);
+    let mut rubber =
+        Rubber::new(&args.connection_string).with_nb_insert_threads(args.nb_insert_threads);
+
     let index_settings = IndexSettings {
         nb_shards: args.nb_shards,
         nb_replicas: args.nb_replicas,

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -96,6 +96,10 @@ struct Args {
     /// DB buffer size.
     #[structopt(long = "db-buffer-size", default_value = "50000")]
     db_buffer_size: usize,
+    /// Number of threads to use to insert into Elasticsearch. Note that Elasticsearch is not able
+    /// to handle values that are too high.
+    #[structopt(short = "T", long = "nb-insert-threads", default_value = "1")]
+    nb_insert_threads: usize,
 }
 
 fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
@@ -104,7 +108,8 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
 
     let mut osm_reader = make_osm_reader(&args.input)?;
     debug!("creation of indexes");
-    let mut rubber = Rubber::new(&args.connection_string);
+    let mut rubber =
+        Rubber::new(&args.connection_string).with_nb_insert_threads(args.nb_insert_threads);
     rubber.initialize_templates()?;
 
     info!("creating adminstrative regions");


### PR DESCRIPTION
Send `bulk_index`'s batches in parallel. The number of threads can be defined in a distinct CLI parameter `-T`.

Note that when the number of threads is too high (eg. `-T=16` on my local tests), Elasticsearch may crash during the import (the max number of threads is probably related to the number of shards?). Thus, the default number of threads is set to 1 in order to make sure that the caller sets the right amount.

Performances
---

Here are some benchmarks obtained by importing OpenAddresses data for Denmark (~3M8 addresses) using openaddresses2mimir.

##### ES on the same machine as openaddresses2mimir

(my CPU already struggles at `--nb-insert-threads=2`, I can't get any better result).

|    branch   |      |
|:-----------:|-----:|
|    master   | 5:29 |
| HEAD (-T 1) | 5:35 |
| HEAD (-T 2) | 4:33 |

##### ES on a separate machine

I tried to distribute the CPU stress of the import using a second machine in order to get more room for improvement. The issue here is that it seems that my networking is introducing a lot of variations.

|    branch   |      |
|:-----------:|-----:|
|    master   | 12:39 |
| HEAD (-T 1) | 13:04 |
| HEAD (-T 8) | 6:29 |

*(edit)*

We just imported BANO in our development pipeline using this branch and 5 threads to communicate with ES. We registered a x3.5 improvement speedup:

|    branch   |      |
|:-----------:|-----:|
|    master   | ~2 h 33 min |
| HEAD (-T 5) | ~42 min |