### PR TITLE
update docker images to rust 1.44

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - 1.42.0
+  - 1.44.0
 env:
   - RUN=TEST
 script:

--- a/docker/Dockerfile_bragi
+++ b/docker/Dockerfile_bragi
@@ -1,4 +1,4 @@
-FROM rust:1.39-stretch as builder
+FROM rust:1.44-stretch as builder
 
 WORKDIR /srv/mimirsbrunn
 

--- a/docker/Dockerfile_import
+++ b/docker/Dockerfile_import
@@ -1,4 +1,4 @@
-FROM rust:1.39-stretch as builder
+FROM rust:1.44-stretch as builder
 
 WORKDIR /srv/mimirsbrunn
 


### PR DESCRIPTION
Automated build of the docker image using Rust 1.39 where failing since https://github.com/CanalTP/mimirsbrunn/pull/385.

While I was on it I updated everything to 1.44 (latest stable version).