### PR TITLE
Stop overriding package version at compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,7 +1625,6 @@ dependencies = [
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "humanesort 0.1.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-version 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mimir 1.15.0",
@@ -1193,6 +1194,26 @@ dependencies = [
 name = "git-version"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "git-version"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "git-version-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "glob"
@@ -3738,6 +3759,8 @@ dependencies = [
 "checksum geojson 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4ac03428b3276fc7f1756eba0c76c7c0c91ef77e1c43fbdd47a460238419cb9"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a1bc37021f50d852a4b134b05722b1c8e0ec7cd14262471e89a14a3df12c44a6"
+"checksum git-version 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "94918e83f1e01dedc2e361d00ce9487b14c58c7f40bab148026fa39d42cb41e2"
+"checksum git-version-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "34a97a52fdee1870a34fa6e4b77570cba531b27d1838874fef4429a791a3d657"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum handlebars 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "af92141a22acceb515fb6b13ac59d6d0b3dd3437e13832573af8e0d3247f29d5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,6 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "git-version 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1189,11 +1188,6 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "git-version"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "git-version"
@@ -3758,7 +3752,6 @@ dependencies = [
 "checksum geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22b37e57c7f498be81360116a489ebad0b133557e87d8b4f82d51bebd1c3ef9e"
 "checksum geojson 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4ac03428b3276fc7f1756eba0c76c7c0c91ef77e1c43fbdd47a460238419cb9"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-"checksum git-version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a1bc37021f50d852a4b134b05722b1c8e0ec7cd14262471e89a14a3df12c44a6"
 "checksum git-version 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "94918e83f1e01dedc2e361d00ce9487b14c58c7f40bab148026fa39d42cb41e2"
 "checksum git-version-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "34a97a52fdee1870a34fa6e4b77570cba531b27d1838874fef4429a791a3d657"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ tools = { path = "libs/tools" }
 docker_wrapper = { path = "libs/docker_wrapper" }
 
 [build-dependencies]
-git-version = "0.2"
 json = "0.12"
 
 # we just call one test method: cf. tests::all_tests()

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-use git_version;
 use json;
 
 use std::ffi::OsStr;
@@ -13,6 +12,11 @@ fn validate_json_files(dir: &Path) -> io::Result<()> {
         if path.is_dir() {
             validate_json_files(&path)?;
         } else if path.extension() == Some(OsStr::new("json")) {
+            println!(
+                "cargo:rerun-if-changed={}",
+                path.to_str().expect("invalid UTF-8 for path")
+            );
+
             let mut reader = BufReader::new(File::open(&path)?);
             let mut content = String::new();
             reader.read_to_string(&mut content)?;
@@ -33,5 +37,4 @@ fn main() {
         eprintln!("=> Failure in JSON validation!\n=> {}", e);
         panic!("");
     }
-    git_version::set_env_with_name("CARGO_PKG_VERSION");
 }

--- a/libs/bragi/Cargo.toml
+++ b/libs/bragi/Cargo.toml
@@ -29,6 +29,7 @@ serde_qs = "0.5"
 futures = "0.1"
 mimir = { path = "../mimir" }
 toml = "0.5.6"
+git-version = "0.3"
 
 [dev-dependencies]
 reqwest = "=0.9.16"

--- a/libs/bragi/Cargo.toml
+++ b/libs/bragi/Cargo.toml
@@ -35,6 +35,3 @@ git-version = "0.3"
 reqwest = "=0.9.16"
 docker_wrapper = { path = "../docker_wrapper" }
 tools = { path = "../tools" }
-
-[build-dependencies]
-git-version = "0.2"

--- a/libs/bragi/build.rs
+++ b/libs/bragi/build.rs
@@ -1,5 +1,0 @@
-extern crate git_version;
-
-fn main() {
-    git_version::set_env_with_name("CARGO_PKG_VERSION");
-}

--- a/libs/bragi/src/lib.rs
+++ b/libs/bragi/src/lib.rs
@@ -29,6 +29,9 @@
 // www.navitia.io
 
 #[macro_use]
+extern crate git_version;
+
+#[macro_use]
 extern crate prometheus;
 
 use mimir::rubber::Rubber;

--- a/libs/bragi/src/routes/status.rs
+++ b/libs/bragi/src/routes/status.rs
@@ -11,7 +11,7 @@ pub struct Status {
 
 pub fn status(state: Data<Context>) -> Json<Status> {
     Json(Status {
-        version: env!("CARGO_PKG_VERSION").to_string(),
+        version: git_version!().to_string(),
         es: state.cnx_string.clone(),
         status: "good".to_string(),
     })


### PR DESCRIPTION
We are currently using a build hook for Bragi that overrides the version number specified in `Cargo.toml`. The same behavior is implemented for the top-level package but I don't think we actually take benefit of it.

I think it is a rather heavy behavior to keep as it implies that cargo will rebuild all binaries at each invocation, which is rather slow.