### PR TITLE
allow to change the radius of proximity queries

### DIFF
--- a/config/bragi-settings.toml
+++ b/config/bragi-settings.toml
@@ -46,6 +46,6 @@ global = 1.0
     [importance_query.proximity]
     weight = 0.4
     weight_fuzzy = 0.4
-    offset_distance = 20.0  # This can be overwritten by the parameter `radius`
-    decay_distance_ratio = 6.5 # The decay distance will be offset_distance * decay_ratio
-    decay = 0.4
+    decay_distance = 130.0 # can be overwritten by query parameter
+    offset_distance = 20.0 # can be overwritten by query parameter
+    decay = 0.4 # can be overwritten by query parameter

--- a/config/bragi-settings.toml
+++ b/config/bragi-settings.toml
@@ -46,6 +46,6 @@ global = 1.0
     [importance_query.proximity]
     weight = 0.4
     weight_fuzzy = 0.4
-    decay_distance = 130.0
-    offset_distance = 20.0
+    offset_distance = 20.0  # This can be overwritten by the parameter `radius`
+    decay_distance_ratio = 6.5 # The decay distance will be offset_distance * decay_ratio
     decay = 0.4

--- a/config/bragi-settings.toml
+++ b/config/bragi-settings.toml
@@ -46,6 +46,14 @@ global = 1.0
     [importance_query.proximity]
     weight = 0.4
     weight_fuzzy = 0.4
-    decay_distance = 130.0 # can be overwritten by query parameter
-    offset_distance = 20.0 # can be overwritten by query parameter
-    decay = 0.4 # can be overwritten by query parameter
+
+        # Tune the shape of the weight applied to the results based on the
+        # proximity. These parameters can then be overridden by query
+        # parameters through `proximity_{key}`.
+        #
+        # More about elasticsearch's normal decay:
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#_supported_decay_functions
+        [importance_query.proximity.gaussian]
+        scale = 130.0
+        offset = 20.0
+        decay = 0.4

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -121,13 +121,13 @@ fn build_proximity_with_boost(coord: &Coord, infos: &Proximity, is_fuzzy: bool) 
                 None,
                 DecayOptions::new(
                     rs_u::Location::LatLon(coord.lat(), coord.lon()),
-                    rs_u::Distance::new(infos.decay_distance, rs_u::DistanceUnit::Kilometer),
+                    rs_u::Distance::new(infos.gaussian.scale, rs_u::DistanceUnit::Kilometer),
                 )
                 .with_offset(rs_u::Distance::new(
-                    infos.offset_distance,
+                    infos.gaussian.offset,
                     rs_u::DistanceUnit::Kilometer,
                 ))
-                .with_decay(infos.decay)
+                .with_decay(infos.gaussian.decay)
                 .build("coord")
                 .build_exp(),
                 None,

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -121,10 +121,7 @@ fn build_proximity_with_boost(coord: &Coord, infos: &Proximity, is_fuzzy: bool) 
                 None,
                 DecayOptions::new(
                     rs_u::Location::LatLon(coord.lat(), coord.lon()),
-                    rs_u::Distance::new(
-                        infos.offset_distance * infos.decay_distance_ratio,
-                        rs_u::DistanceUnit::Kilometer,
-                    ),
+                    rs_u::Distance::new(infos.decay_distance, rs_u::DistanceUnit::Kilometer),
                 )
                 .with_offset(rs_u::Distance::new(
                     infos.offset_distance,

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -121,7 +121,10 @@ fn build_proximity_with_boost(coord: &Coord, infos: &Proximity, is_fuzzy: bool) 
                 None,
                 DecayOptions::new(
                     rs_u::Location::LatLon(coord.lat(), coord.lon()),
-                    rs_u::Distance::new(infos.decay_distance, rs_u::DistanceUnit::Kilometer),
+                    rs_u::Distance::new(
+                        infos.offset_distance * infos.decay_distance_ratio,
+                        rs_u::DistanceUnit::Kilometer,
+                    ),
                 )
                 .with_offset(rs_u::Distance::new(
                     infos.offset_distance,

--- a/libs/bragi/src/query_settings.rs
+++ b/libs/bragi/src/query_settings.rs
@@ -36,8 +36,8 @@ pub struct StringQuery {
 pub struct Proximity {
     pub weight: f64,
     pub weight_fuzzy: f64,
-    pub decay_distance: f64,
     pub offset_distance: f64,
+    pub decay_distance_ratio: f64,
     pub decay: f64,
 }
 

--- a/libs/bragi/src/query_settings.rs
+++ b/libs/bragi/src/query_settings.rs
@@ -36,8 +36,8 @@ pub struct StringQuery {
 pub struct Proximity {
     pub weight: f64,
     pub weight_fuzzy: f64,
+    pub decay_distance: f64,
     pub offset_distance: f64,
-    pub decay_distance_ratio: f64,
     pub decay: f64,
 }
 

--- a/libs/bragi/src/query_settings.rs
+++ b/libs/bragi/src/query_settings.rs
@@ -36,8 +36,13 @@ pub struct StringQuery {
 pub struct Proximity {
     pub weight: f64,
     pub weight_fuzzy: f64,
-    pub decay_distance: f64,
-    pub offset_distance: f64,
+    pub gaussian: Gaussian,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Gaussian {
+    pub scale: f64,
+    pub offset: f64,
     pub decay: f64,
 }
 

--- a/libs/bragi/src/routes/autocomplete.rs
+++ b/libs/bragi/src/routes/autocomplete.rs
@@ -77,9 +77,9 @@ pub struct Params {
     lon: Option<f64>,
     // If specified, override parameters for the normal decay computed by elasticsearch around the
     // position: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#_supported_decay_functions
-    focus_decay_distance: Option<f64>,
-    focus_offset_distance: Option<f64>,
-    focus_decay: Option<f64>,
+    proximity_scale: Option<f64>,
+    proximity_offset: Option<f64>,
+    proximity_decay: Option<f64>,
     #[serde(default, rename = "type")]
     types: Vec<Type>,
     #[serde(default, rename = "zone_type")]
@@ -149,16 +149,16 @@ pub fn call_autocomplete(
     let rubber = state.get_rubber_for_autocomplete(params.timeout());
     let mut query_settings = state.get_query_settings().clone();
 
-    if let Some(decay_distance) = params.focus_decay_distance {
-        query_settings.importance_query.proximity.decay_distance = decay_distance;
+    if let Some(scale) = params.proximity_scale {
+        query_settings.importance_query.proximity.gaussian.scale = scale;
     }
 
-    if let Some(offset_distance) = params.focus_offset_distance {
-        query_settings.importance_query.proximity.offset_distance = offset_distance;
+    if let Some(offset) = params.proximity_offset {
+        query_settings.importance_query.proximity.gaussian.offset = offset;
     }
 
-    if let Some(decay) = params.focus_decay {
-        query_settings.importance_query.proximity.decay = decay;
+    if let Some(decay) = params.proximity_decay {
+        query_settings.importance_query.proximity.gaussian.decay = decay;
     }
 
     let res = query::autocomplete(


### PR DESCRIPTION
Add query parameters `proximity_scale`, `proximity_offset` and `proximity_decay` which allows to tweak the weight computed from the distance in proximity queries.

These parameters reflect the parameters used by Elasticsearch itself. See [this](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-decay) for more details.

## Current behavior

The score of such a query is computed from the distance of documents to input `lat`/`lon` based on a gaussian distribution:

[![](https://www.elastic.co/guide/en/elasticsearch/reference/current/images/decay_2d.png)](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#_supported_decay_functions)

Currently, this score function is the same for all queries, only tweakable through settings, [by default](https://github.com/CanalTP/mimirsbrunn/blob/master/config/bragi-settings.toml#L49-L51) we currently have:

 - offset = 20km (any document less than 20km of the center of the query have a score of 1)
 - scale = 130km
 - decay = 0.4 (any document less than 20 + 130 km if the center of the query have a score greater than 0.4)

## Motivation

Our motivation is to have a way of using the proximity filter to boost results at larger scale (like a region or a country) based on the zoom level on our application. Note that this could probably be used to make queries over smaller zones but we won't try to use it in this purpose, at least for now.