### PR TITLE
Prevent unwanted alias removal

### DIFF
--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -456,7 +456,7 @@ impl Rubber {
         base_index: &str,
     ) -> Result<BTreeMap<String, Vec<String>>, Error> {
         let res = self
-            .get(&format!("{}*/_aliases", base_index))
+            .get(&format!("{}_*/_aliases", base_index))
             .with_context(|_| format!("Error occurred when getting {}*/_aliases", base_index))?;
         match res.status() {
             StatusCode::OK => {


### PR DESCRIPTION
This PR fixes an issue we have in production where updating a coverage may accidentally delete another unrelated coverage.

The name of the coverage is embedded in the alias. If you have a coverage 'foo', then the alias will start with 'munin_foo'.

Now, if you have another coverage 'foo_bar', it will start with 'munin_foo_bar'. When you update 'foo', it will probably delete
'munin_foo' and 'munin_foo_bar'.

Warning (this PR is based on a branch 'update_dependencies')