### PR TITLE
Progressive focus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "bragi"
-version = "1.15.1"
+version = "1.16.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "docker_wrapper"
-version = "1.15.1"
+version = "1.16.0"
 dependencies = [
  "mimir",
  "reqwest",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "mimir"
-version = "1.15.1"
+version = "1.16.0"
 dependencies = [
  "address-formatter",
  "chrono",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "mimirsbrunn"
-version = "1.15.1"
+version = "1.16.0"
 dependencies = [
  "actix-web",
  "address-formatter",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.15.1"
+version = "1.16.0"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/config/bragi-settings.toml
+++ b/config/bragi-settings.toml
@@ -33,12 +33,14 @@ global = 1.0
         factor = 0.15
         missing = 0.0
 
-        [importance_query.weights.coords]
+        [importance_query.weights.max_zoom]
+        radius = 100
         admin = 0.12
         factor = 0.4
         missing = 0.0
 
-        [importance_query.weights.no_coords]
+        [importance_query.weights.min_zoom]
+        radius = 10000
         admin = 0.03
         factor = 0.75
         missing = 0.0

--- a/config/bragi-settings.toml
+++ b/config/bragi-settings.toml
@@ -27,20 +27,19 @@ global = 1.0
     poi = 0.5
     stop = 1.0
     street = 0.5
+    radius_range = [100, 10_000]
 
-        [importance_query.weights.coords_fuzzy]
-        admin = 0.03
-        factor = 0.15
-        missing = 0.0
-
-        [importance_query.weights.max_zoom]
-        radius = 100
+        [importance_query.weights.max_radius_prefix]
         admin = 0.12
         factor = 0.4
         missing = 0.0
 
-        [importance_query.weights.min_zoom]
-        radius = 10000
+        [importance_query.weights.max_radius_fuzzy]
+        admin = 0.03
+        factor = 0.15
+        missing = 0.0
+
+        [importance_query.weights.min_radius]
         admin = 0.03
         factor = 0.75
         missing = 0.0

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -268,13 +268,13 @@ fn build_query<'a>(
             Some(_) => {
                 let (min_radius, max_radius) = settings.radius_range;
                 let curve = query_settings.importance_query.proximity.gaussian;
-                let radius = curve.offset + curve.scale;
-                0f64.max(1f64.min((radius - min_radius) / (max_radius - min_radius)))
+                let radius = (curve.offset + curve.scale).min(max_radius).max(min_radius);
+                (radius.ln_1p() - min_radius.ln_1p()) / (max_radius.ln_1p() - min_radius.ln_1p())
             }
         };
 
         let weighted = move |val: &dyn Fn(BuildWeight) -> f64| {
-            zoom_ratio * val(min_weights) + (1. - zoom_ratio) * val(max_weights)
+            (1. - zoom_ratio) * val(min_weights) + zoom_ratio * val(max_weights)
         };
 
         BuildWeight {

--- a/libs/bragi/src/query_settings.rs
+++ b/libs/bragi/src/query_settings.rs
@@ -53,18 +53,12 @@ pub struct BuildWeight {
     pub missing: f64,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize)]
-pub struct BuildWeightWithRadius {
-    #[serde(flatten)]
-    pub weight: BuildWeight,
-    pub radius: f64,
-}
-
 #[derive(Clone, Debug, Deserialize)]
 pub struct Weights {
-    pub coords_fuzzy: BuildWeight,
-    pub max_zoom: BuildWeightWithRadius,
-    pub min_zoom: BuildWeightWithRadius,
+    pub radius_range: (f64, f64),
+    pub min_radius: BuildWeight,
+    pub max_radius_prefix: BuildWeight,
+    pub max_radius_fuzzy: BuildWeight,
     #[serde(flatten)]
     pub types: Types,
 }

--- a/libs/bragi/src/query_settings.rs
+++ b/libs/bragi/src/query_settings.rs
@@ -39,25 +39,32 @@ pub struct Proximity {
     pub gaussian: Gaussian,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Deserialize)]
 pub struct Gaussian {
     pub scale: f64,
     pub offset: f64,
     pub decay: f64,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Deserialize)]
 pub struct BuildWeight {
     pub admin: f64,
     pub factor: f64,
     pub missing: f64,
 }
 
+#[derive(Copy, Clone, Debug, Deserialize)]
+pub struct BuildWeightWithRadius {
+    #[serde(flatten)]
+    pub weight: BuildWeight,
+    pub radius: f64,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct Weights {
     pub coords_fuzzy: BuildWeight,
-    pub coords: BuildWeight,
-    pub no_coords: BuildWeight,
+    pub max_zoom: BuildWeightWithRadius,
+    pub min_zoom: BuildWeightWithRadius,
     #[serde(flatten)]
     pub types: Types,
 }

--- a/libs/bragi/src/query_settings.rs
+++ b/libs/bragi/src/query_settings.rs
@@ -32,7 +32,7 @@ pub struct StringQuery {
     pub boosts: StringQueryBoosts,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize)]
 pub struct Proximity {
     pub weight: f64,
     pub weight_fuzzy: f64,

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -361,7 +361,7 @@ impl Rubber {
     ) -> Result<TypedIndex<T>, Error> {
         let index_name = get_date_index_name(&get_main_type_and_dataset_index::<T>(dataset));
         info!("creating index {}", index_name);
-        self.create_index(&index_name.to_string(), index_settings)?;
+        self.create_index(&index_name, index_settings)?;
         Ok(TypedIndex::new(index_name))
     }
 

--- a/src/admin_geofinder.rs
+++ b/src/admin_geofinder.rs
@@ -175,13 +175,13 @@ impl AdminGeoFinder {
             } else if boundary.contains(&geo_types::Point(*coord)) {
                 // we found a valid admin, we save it's hierarchy not to have to test their boundaries
                 if let Some(zt) = admin.zone_type {
-                    added_zone_types.insert(zt.clone());
+                    added_zone_types.insert(zt);
                 }
                 let mut admin_parent_id = admin.parent_id.clone();
                 while let Some(id) = admin_parent_id {
                     let admin_parent = self.admin_by_id.get(&id);
                     if let Some(zt) = admin_parent.as_ref().and_then(|a| a.zone_type) {
-                        added_zone_types.insert(zt.clone());
+                        added_zone_types.insert(zt);
                     }
                     if !tested_hierarchy.insert(id) {
                         break; // stop the exploration of the hierarchy since we have already added this one

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -163,7 +163,7 @@ impl Bano {
             coord,
             approx_coord: Some(coord.into()),
             weight,
-            zip_codes: vec![self.zip.clone()],
+            zip_codes: vec![self.zip],
             distance: None,
             country_codes,
             context: None,

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -176,7 +176,7 @@ fn index_cosmogony(args: Args) -> Result<(), Error> {
             Some(City) => admin::read_insee(&z.tags).map(|s| s.to_owned()),
             _ => None,
         };
-        cosmogony_id_to_osm_id.insert(z.id.clone(), (z.osm_id.clone(), insee));
+        cosmogony_id_to_osm_id.insert(z.id, (z.osm_id.clone(), insee));
     }
     let cosmogony_id_to_osm_id = cosmogony_id_to_osm_id;
 

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -158,7 +158,7 @@ pub fn streets(
                     .collect();
                 name_admin_map
                     .entry(StreetKey { name, admins })
-                    .or_insert_with(|| vec![])
+                    .or_insert_with(Vec::new)
                     .push(osmid);
             }
         }


### PR DESCRIPTION
https://github.com/CanalTP/mimirsbrunn/pull/417 introduced a way to apply a very slight proximity boost for a very large region. However it kept the previous behavior of using different weights in a proximity context and out of a proximity context, this makes it hard to benefit from the feature as some proximity-specific behaviors would raise for quite generic requests (eg. decreasing the importance of the weight consequently).

This PR addresses the issue by computing a smooth transitions of the weights used to build ES queries when the radius changes:

 - the new setting `radius_range` gives an interval for this behavior of "transition" base on the value of `curve.offset + curve.scale`
 - if `curve.offset + curve.scale` is above `radius_range`, we use weights from `max_radius_fuzzy` or `max_radius_prefix` like we did before when proximity was disabled
 - if `curve.offset + curve.scale` is below `radius_range`, we use weights from `min_radius` like we did before when proximity was enabled
- if `curve.offset + curve.scale` is inside `radius_range`, we compute weights as a combination of the two previous cases. When the radius increases it converges logarithmically to weights from `max_radius_fuzzy`. The choice of the logarithm is influenced by the observation that cartographic tools typically increases the scale exponentially when the user zooms in.

![tt](https://user-images.githubusercontent.com/1173464/94439967-602f3100-01a1-11eb-8298-81dc27d6d416.png)
