### PR TITLE
Fix progressive focus

### DIFF
--- a/config/bragi-settings.toml
+++ b/config/bragi-settings.toml
@@ -29,17 +29,17 @@ global = 1.0
     street = 0.5
     radius_range = [100, 10_000]
 
-        [importance_query.weights.max_radius_prefix]
+        [importance_query.weights.min_radius_prefix]
         admin = 0.12
         factor = 0.4
         missing = 0.0
 
-        [importance_query.weights.max_radius_fuzzy]
+        [importance_query.weights.min_radius_fuzzy]
         admin = 0.03
         factor = 0.15
         missing = 0.0
 
-        [importance_query.weights.min_radius]
+        [importance_query.weights.max_radius]
         admin = 0.03
         factor = 0.75
         missing = 0.0

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -286,16 +286,9 @@ fn build_query<'a>(
     let mut importance_queries = vec![build_with_weight(&weights, &settings.types)];
 
     if let Some(ref coord) = coord {
-        let weights = query_settings.importance_query.proximity;
-        let weights = Proximity {
-            weight: (1. - zoom_ratio) * weights.weight,
-            weight_fuzzy: (1. - zoom_ratio) * weights.weight_fuzzy,
-            gaussian: weights.gaussian,
-        };
-
         importance_queries.push(build_proximity_with_boost(
             coord,
-            &weights,
+            &query_settings.importance_query.proximity,
             match_type == MatchType::Fuzzy,
         ))
     }

--- a/libs/bragi/src/query_settings.rs
+++ b/libs/bragi/src/query_settings.rs
@@ -56,9 +56,9 @@ pub struct BuildWeight {
 #[derive(Clone, Debug, Deserialize)]
 pub struct Weights {
     pub radius_range: (f64, f64),
-    pub min_radius: BuildWeight,
-    pub max_radius_prefix: BuildWeight,
-    pub max_radius_fuzzy: BuildWeight,
+    pub max_radius: BuildWeight,
+    pub min_radius_prefix: BuildWeight,
+    pub min_radius_fuzzy: BuildWeight,
     #[serde(flatten)]
     pub types: Types,
 }


### PR DESCRIPTION
This is a correction for two changes from https://github.com/CanalTP/mimirsbrunn/pull/423:

 1. There was a confusion between `max_radius` and `min_radius` settings that were not consistent with previous settings: a large radius correspond with a flexible use of the focus, which is closest to what `no_coord` was (and vice-versa for `min_radius` and `coord`)
 2. We were reducing the impact of the proximity for large radius [here](https://github.com/CanalTP/mimirsbrunn/compare/master...remi-dupre:fix-progressive-focus?expand=1#diff-1ac92e7119dffce18713ecd2b8626802L290) which doesn't seem really relevant. The proximity will already not penalize many POIs because the radius is so large, so this behavior mostly made the proximity part useless with larger zoom.