### PR TITLE
[FEAT]: Add custom settings for osm2mimir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "rand 0.7.3",
  "regex",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "serde_urlencoded",
  "sha1",
@@ -113,7 +113,7 @@ dependencies = [
  "http 0.1.21",
  "log",
  "net2",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "serde_urlencoded",
  "sha1",
@@ -133,7 +133,7 @@ dependencies = [
  "http 0.1.21",
  "log",
  "regex",
- "serde",
+ "serde 1.0.114",
  "string",
 ]
 
@@ -270,7 +270,7 @@ dependencies = [
  "net2",
  "parking_lot",
  "regex",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "serde_urlencoded",
  "time",
@@ -310,10 +310,10 @@ dependencies = [
  "include_dir",
  "itertools 0.8.2",
  "lazy_static",
- "linked-hash-map",
+ "linked-hash-map 0.5.3",
  "log",
  "regex",
- "serde",
+ "serde 1.0.114",
  "serde_yaml",
  "strum",
  "strum_macros",
@@ -365,7 +365,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.12",
 ]
 
 [[package]]
@@ -449,7 +449,7 @@ dependencies = [
  "mime",
  "percent-encoding 2.1.0",
  "rand 0.7.3",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "serde_urlencoded",
  "tokio-timer",
@@ -497,7 +497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
  "byteorder 1.3.4",
- "serde",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -562,7 +562,7 @@ dependencies = [
  "prometheus",
  "reqwest",
  "rs-es",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "serde_qs",
  "slog",
@@ -601,7 +601,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
  "num-integer",
- "num-traits",
+ "num-traits 0.2.12",
  "time",
 ]
 
@@ -710,6 +710,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "config"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
+dependencies = [
+ "lazy_static",
+ "nom 5.1.2",
+ "rust-ini",
+ "serde 1.0.114",
+ "serde-hjson",
+ "serde_json",
+ "toml",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -775,7 +791,7 @@ dependencies = [
  "geojson",
  "log",
  "osmpbfreader",
- "serde",
+ "serde 1.0.114",
  "serde_derive",
  "serde_json",
 ]
@@ -871,7 +887,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -1054,7 +1070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2436d68e28d1ec1646f3e54003c6b4c4e192785532a687d52a3d2ba56c346bb"
 dependencies = [
  "array-macro",
- "serde",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -1126,7 +1142,7 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbb562ef75bc322a6d4b5860794457438b89079f23471fb2ba876c2f39b24e5"
 dependencies = [
- "serde",
+ "serde 1.0.114",
  "serde_derive",
 ]
 
@@ -1279,7 +1295,7 @@ checksum = "89ce8faa25a6f5ce8ea98faa95247d66377a843408eb4418332ec37de96850b0"
 dependencies = [
  "failure",
  "geo-types 0.4.3",
- "num-traits",
+ "num-traits 0.2.12",
  "rstar 0.2.0",
 ]
 
@@ -1291,7 +1307,7 @@ checksum = "83c9d9fae66201de057478341f4256125db9b08d9813a32e400c1cc575c6c597"
 dependencies = [
  "geo-types 0.6.0",
  "geographiclib-rs",
- "num-traits",
+ "num-traits 0.2.12",
  "rstar 0.8.1",
 ]
 
@@ -1301,7 +1317,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "866e8f6dbd2218b05ea8a25daa1bfac32b0515fe7e0a37cb6a7b9ed0ed82a07e"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.12",
  "rstar 0.2.0",
 ]
 
@@ -1312,7 +1328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "407043938de169e80c31cef3c46c99faccd4d002ea8120c637f29a6958820c62"
 dependencies = [
  "approx",
- "num-traits",
+ "num-traits 0.2.12",
  "rstar 0.8.1",
 ]
 
@@ -1332,8 +1348,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da98686bca3298df46f3957c78166cfbf0fa399e9efcdac0cb7ff2cfed1fd2ab"
 dependencies = [
  "geo-types 0.6.0",
- "num-traits",
- "serde",
+ "num-traits 0.2.12",
+ "serde 1.0.114",
  "serde_json",
 ]
 
@@ -1430,7 +1446,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "quick-error",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "walkdir",
 ]
@@ -1450,7 +1466,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
 dependencies = [
- "serde",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -1748,6 +1764,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +1790,16 @@ checksum = "1e704a02bcaecd4a08b93a23f6be59d0bd79cd161e0963e9499165a0a35df7bd"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
+dependencies = [
+ "serde 0.8.23",
+ "serde_test",
 ]
 
 [[package]]
@@ -1793,7 +1832,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
- "linked-hash-map",
+ "linked-hash-map 0.5.3",
 ]
 
 [[package]]
@@ -1876,7 +1915,7 @@ dependencies = [
  "reqwest",
  "rs-es",
  "rstar 0.8.1",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "slog",
  "slog-async",
@@ -1900,6 +1939,7 @@ dependencies = [
  "bincode",
  "bragi",
  "chrono",
+ "config",
  "cosmogony",
  "csv",
  "docker_wrapper",
@@ -1923,7 +1963,7 @@ dependencies = [
  "rs-es",
  "rstar 0.8.1",
  "rusqlite",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "slog",
  "slog-async",
@@ -2056,7 +2096,7 @@ dependencies = [
  "failure",
  "geo 0.14.1",
  "itertools 0.9.0",
- "serde",
+ "serde 1.0.114",
  "zip",
 ]
 
@@ -2078,13 +2118,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 
 [[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg 1.0.0",
- "num-traits",
+ "num-traits 0.2.12",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.12",
 ]
 
 [[package]]
@@ -2183,7 +2243,7 @@ dependencies = [
  "protobuf-codegen-pure",
  "pub-iterator-type",
  "rental",
- "serde",
+ "serde 1.0.114",
  "serde_derive",
 ]
 
@@ -2430,7 +2490,7 @@ checksum = "f42e8578852a3306838981aedad8c5642ba794929aa12af0c9eb6c072b77af6c"
 dependencies = [
  "byteorder 0.5.3",
  "libc",
- "nom",
+ "nom 1.2.4",
  "rustc_version 0.1.7",
 ]
 
@@ -2827,7 +2887,7 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -2866,7 +2926,7 @@ dependencies = [
  "geojson",
  "log",
  "reqwest",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "thiserror",
  "url 2.1.1",
@@ -2878,7 +2938,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "120bfe4837befb82c5a637a5a8c490a27d25524ac19fffec5b4e555ca6e36ee8"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.12",
  "pdqselect",
  "threadpool",
 ]
@@ -2890,7 +2950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e46bec73564751b8f0a240780db62d8dc850bd9d8f3742eeba99623f18e048"
 dependencies = [
  "heapless",
- "num-traits",
+ "num-traits 0.2.12",
  "pdqselect",
  "smallvec 1.4.1",
 ]
@@ -2924,13 +2984,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
+
+[[package]]
 name = "rust_decimal"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95ba36e8c41bf675947e200af432325f332f60a0aea0ef2dc456636c2f6037d7"
 dependencies = [
- "num-traits",
- "serde",
+ "num-traits 0.2.12",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -3034,11 +3100,30 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
+
+[[package]]
+name = "serde"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-hjson"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
+dependencies = [
+ "lazy_static",
+ "linked-hash-map 0.3.0",
+ "num-traits 0.1.43",
+ "regex",
+ "serde 0.8.23",
 ]
 
 [[package]]
@@ -3060,7 +3145,7 @@ checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "itoa",
  "ryu",
- "serde",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -3072,7 +3157,16 @@ dependencies = [
  "data-encoding",
  "error-chain",
  "percent-encoding 1.0.1",
- "serde",
+ "serde 1.0.114",
+]
+
+[[package]]
+name = "serde_test"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
+dependencies = [
+ "serde 0.8.23",
 ]
 
 [[package]]
@@ -3083,7 +3177,7 @@ checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa",
- "serde",
+ "serde 1.0.114",
  "url 2.1.1",
 ]
 
@@ -3094,8 +3188,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 dependencies = [
  "dtoa",
- "linked-hash-map",
- "serde",
+ "linked-hash-map 0.5.3",
+ "serde 1.0.114",
  "yaml-rust",
 ]
 
@@ -3182,7 +3276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 dependencies = [
  "chrono",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "slog",
 ]
@@ -3261,6 +3355,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string"
@@ -3674,7 +3774,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
- "serde",
+ "serde 1.0.114",
 ]
 
 [[package]]
@@ -3744,12 +3844,12 @@ dependencies = [
  "minidom",
  "minidom_ext",
  "minidom_writer",
- "num-traits",
+ "num-traits 0.2.12",
  "pretty_assertions",
  "quick-xml 0.18.1",
  "relational_types",
  "rust_decimal",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "skip_error",
  "tempfile",
@@ -3817,7 +3917,7 @@ checksum = "20c992a23515d92622a9860b62e1b62adfcfcb82c71207c8977a6ff2817697d9"
 dependencies = [
  "derivative 2.1.1",
  "log",
- "serde",
+ "serde 1.0.114",
  "thiserror",
 ]
 
@@ -3964,7 +4064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edbcc9536ab7eababcc6d2374a0b7bfe13a2b6d562c5e07f370456b1a8f33d"
 dependencies = [
  "cfg-if",
- "serde",
+ "serde 1.0.114",
  "serde_json",
  "wasm-bindgen-macro",
 ]
@@ -4127,7 +4227,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
 dependencies = [
- "linked-hash-map",
+ "linked-hash-map 0.5.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 db-storage = [ "rusqlite" ]
 
 [dependencies]
+config = "0.10"
 log = { version = "0.4", features = ["release_max_level_debug"] }
 slog = { version = "2.5", features = ["max_level_trace", "release_max_level_debug"]}
 slog-scope = "4.3"

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,0 +1,12 @@
+[street]
+
+  [street.exclusion]
+
+  # See [OSM Key Highway](https://wiki.openstreetmap.org/wiki/Key:highway) for background.
+  highways = [
+    "bus_guideway",
+    "bus_stop",
+    "elevator",
+    "escape",
+    "platform"
+  ]

--- a/config/kisio.toml
+++ b/config/kisio.toml
@@ -1,0 +1,17 @@
+[street]
+
+  [street.exclusion]
+
+  # See [OSM Key Highway](https://wiki.openstreetmap.org/wiki/Key:highway) for background.
+  highways = [
+    "bus_guideway",
+    "bus_stop",
+    "elevator",
+    "escape",
+    "motorway",
+    "motorway_link",
+    "platform",
+    "raceway",
+    "trunk",
+    "trunk_line"
+  ]

--- a/docker/Dockerfile_import
+++ b/docker/Dockerfile_import
@@ -22,7 +22,10 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+RUN mkdir /etc/mimirsbrunn
+
 COPY --from=builder /srv/mimirsbrunn/target/release/osm2mimir /usr/bin/osm2mimir
 COPY --from=builder /srv/mimirsbrunn/target/release/cosmogony2mimir /usr/bin/cosmogony2mimir
 COPY --from=builder /srv/mimirsbrunn/target/release/bano2mimir /usr/bin/bano2mimir
 COPY --from=builder /srv/mimirsbrunn/target/release/openaddresses2mimir /usr/bin/openaddresses2mimir
+COPY --from=builder /srv/mimirsbrunn/config/* /etc/mimirsbrunn/

--- a/scripts/autocomplete.sh
+++ b/scripts/autocomplete.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+query="$*"
+bragi_endpoint="http://localhost:4000/autocomplete"
+pt_dataset="fr"
+input_type=""
+limit=10
+
+curl_cmd="curl -s --data-urlencode \"q=${query}\""
+  [[ ! -z "${pt_dataset}" ]] && curl_cmd="${curl_cmd} --data-urlencode pt_dataset[]=${pt_dataset}"
+  [[ ! -z "${input_type}" ]] && curl_cmd="${curl_cmd} --data-urlencode type[]=${input_type}"
+curl_cmd="${curl_cmd} --data-urlencode limit=${limit}"
+curl_cmd="${curl_cmd} --data-urlencode _debug=true"
+curl_cmd="${curl_cmd} --get ${bragi_endpoint}"
+
+#
+# # This is an alternative that uses a shape to constrain the results to a geographic area.
+# # curl_cmd="curl -s -d @idf.geojson -X POST \"http://localhost:4000/autocomplete?q=stade&pt_dataset[]=stif&_debug=true\" --header \"Content-Type:application/json\""
+#
+# echo "${curl_cmd}"
+resp=$(eval ${curl_cmd})
+# echo "${resp}"
+echo "${resp}" | jq '[ .features[] | { "label": .properties.geocoding.label, "type": .properties.geocoding.type, "zone_type": .properties.geocoding.zone_type, "level": .properties.geocoding.level } ]'

--- a/scripts/import2mimir.sh
+++ b/scripts/import2mimir.sh
@@ -32,6 +32,7 @@ usage()
   echo ""
   echo "${APPLICATION} "
   echo "  [ -d ]                Data Directory"
+  echo "  [ -c ]                Configuration File"
   echo "  [ -V ]                Displays version information"
   echo "  [ -q ]                Quiet, doesn't display to stdout or stderr"
   echo "  [ -h ]                Displays this message"
@@ -227,7 +228,7 @@ import_osm() {
   local INPUT="${DATA_DIR}/osm/${OSM_REGION}-latest.osm.pbf"
   [[ -f "${INPUT}" ]] || { log_error "osm2mimir cannot run: Missing input ${INPUT}"; return 1; }
 
-  "${OSM2MIMIR}" --import-way --import-poi --input "${DATA_DIR}/osm/${OSM_REGION}-latest.osm.pbf" -c "http://localhost:${ES_PORT}/${ES_INDEX}" > /dev/null 2> /dev/null
+  "${OSM2MIMIR}" --import-way --import-poi --input "${DATA_DIR}/osm/${OSM_REGION}-latest.osm.pbf" --config-dir "${SCRIPT_DIR}/../config" -c "http://localhost:${ES_PORT}/${ES_INDEX}" > /dev/null 2> /dev/null
   [[ $? != 0 ]] && { log_error "Could not import OSM PBF data for ${OSM_REGION} into mimir. Aborting"; return 1; }
   return 0
 }
@@ -303,9 +304,10 @@ download_bano_region_csv() {
 
 ########################### START ############################
 
-while getopts "e:r:d:Vqh" opt; do
+while getopts "d:c:Vqh" opt; do
     case $opt in
         d) DATA_DIR="$OPTARG";;
+        c) CONFIG_FILE="$OPTARG";;
         V) version; exit 0 ;;
         q) QUIET=true ;;
         h) usage; exit 0 ;;

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -109,12 +109,15 @@ struct Args {
     /// Path to the config directory
     /// osm2mimir will read the default configuration in there, and maybe
     /// more depending on the settings option.
+    /// If no option is given, we'll just read the ./config/default.toml
+    /// at compile time.
     #[structopt(short = "D", long = "config-dir")]
-    config_dir: PathBuf,
+    config_dir: Option<PathBuf>,
 
     /// Specific configuration, on top of the default ones.
-    /// You should provide the basename of the file, eg kisio, so that
-    /// osm2mimir will use {config-dir}/kisio.toml
+    /// You should provide the basename of the file, eg acme, so that
+    /// osm2mimir will use {config-dir}/acme.toml. (Requires config_dir to
+    /// be set)
     #[structopt(short = "s", long = "settings")]
     settings: Option<String>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod addr_reader;
 pub mod admin_geofinder;
 pub mod labels;
 pub mod osm_reader;
+pub mod settings;
 pub mod stops;
 pub mod utils;
 pub type Error = failure::Error;

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -67,7 +67,7 @@ pub fn streets(
     let invalid_highways = &settings
         .street
         .clone()
-        .map(|street| street.exclusion.highways.unwrap_or(Vec::new()))
+        .map(|street| street.exclusion.highways.unwrap_or_else(Vec::new))
         .unwrap_or(Vec::new());
 
     let is_valid_highway = |tag: &str| -> bool { !invalid_highways.iter().any(|k| k == tag) };

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,82 @@
+use config::{Config, File};
+use failure::ResultExt;
+use serde::Deserialize;
+use std::path::Path;
+
+use crate::Error;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StreetExclusion {
+    pub highways: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Street {
+    pub exclusion: StreetExclusion,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Poi {}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Admin {}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Settings {
+    pub street: Option<Street>,
+    pub poi: Option<Poi>,
+    pub admin: Option<Admin>,
+}
+
+impl Settings {
+    pub fn new(config_dir: &Path, name: &Option<String>) -> Result<Self, Error> {
+        let mut config = Config::new();
+
+        let default_path = config_dir.join("default");
+        // Start off by merging in the "default" configuration file
+
+        if let Some(path) = default_path.to_str() {
+            config.merge(File::with_name(path)).with_context(|e| {
+                format!(
+                    "Could not merge default configuration from file {}: {}",
+                    path, e
+                )
+            })?;
+        } else {
+            return Err(failure::err_msg(format!(
+                "Could not read default settings in '{}'",
+                default_path.display()
+            )));
+        }
+
+        // If we provided a special configuration, merge it.
+        if let Some(name) = name {
+            let name_path = config_dir.join(name);
+
+            if let Some(path) = name_path.to_str() {
+                config
+                    .merge(File::with_name(path).required(true))
+                    .with_context(|e| {
+                        format!(
+                            "Could not merge {} configuration in file {}: {}",
+                            name, path, e
+                        )
+                    })?;
+            } else {
+                return Err(failure::err_msg(format!(
+                    "Could not read {} settings in '{}'",
+                    name,
+                    name_path.display()
+                )));
+            }
+        }
+
+        // You can deserialize (and thus freeze) the entire configuration as
+        config.try_into().map_err(|e| {
+            failure::err_msg(format!(
+                "Could not generate settings from configuration: {}",
+                e
+            ))
+        })
+    }
+}

--- a/tests/bragi_filter_types_test.rs
+++ b/tests/bragi_filter_types_test.rs
@@ -49,6 +49,7 @@ pub fn bragi_filter_types_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         &osm2mimir,
         &[
             "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--config-dir=./config".into(),
             "--import-way".into(),
             "--import-admin".into(),
             "--import-poi".into(),

--- a/tests/bragi_osm_test.rs
+++ b/tests/bragi_osm_test.rs
@@ -49,6 +49,7 @@ pub fn bragi_osm_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         &osm2mimir,
         &[
             "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--config-dir=./config".into(),
             "--import-admin".into(),
             "--import-way".into(),
             "--level=8".into(),

--- a/tests/bragi_poi_test.rs
+++ b/tests/bragi_poi_test.rs
@@ -69,6 +69,7 @@ pub fn bragi_poi_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         &osm2mimir,
         &[
             "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--config-dir=./config".into(),
             "--import-admin".into(),
             "--import-way".into(),
             "--import-poi".into(),

--- a/tests/bragi_postcode_test.rs
+++ b/tests/bragi_postcode_test.rs
@@ -46,6 +46,7 @@ pub fn bragi_postcode_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         &osm2mimir,
         &[
             "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--config-dir=./config".into(),
             "--import-admin".into(),
             "--import-way".into(),
             "--level=8".into(),

--- a/tests/bragi_stops_test.rs
+++ b/tests/bragi_stops_test.rs
@@ -50,6 +50,7 @@ pub fn bragi_stops_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         &osm2mimir,
         &[
             "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--config-dir=./config".into(),
             "--import-admin".into(),
             "--level=8".into(),
             format!("--connection-string={}", es_wrapper.host()),

--- a/tests/bragi_synonyms_test.rs
+++ b/tests/bragi_synonyms_test.rs
@@ -48,6 +48,7 @@ pub fn bragi_synonyms_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         &osm2mimir,
         &[
             "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--config-dir=./config".into(),
             "--import-way".into(),
             "--import-admin".into(),
             "--import-poi".into(),

--- a/tests/bragi_three_cities_test.rs
+++ b/tests/bragi_three_cities_test.rs
@@ -50,6 +50,7 @@ pub fn bragi_three_cities_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         &osm2mimir,
         &[
             "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--config-dir=./config".into(),
             "--import-admin".into(),
             "--import-way".into(),
             "--level=8".into(),

--- a/tests/canonical_import_process_test.rs
+++ b/tests/canonical_import_process_test.rs
@@ -78,6 +78,7 @@ pub fn canonical_import_process_test(es_wrapper: crate::ElasticSearchWrapper<'_>
         &osm2mimir,
         &[
             "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--config-dir=./config".into(),
             "--import-way".into(),
             "--import-poi".into(),
             format!("--connection-string={}", es_wrapper.host()),

--- a/tests/osm2mimir_bano2mimir_test.rs
+++ b/tests/osm2mimir_bano2mimir_test.rs
@@ -38,6 +38,7 @@ pub fn osm2mimir_bano2mimir_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         &osm2mimir,
         &[
             "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--config-dir=./config".into(),
             "--import-way".into(),
             "--import-admin".into(),
             "--import-poi".into(),

--- a/tests/osm2mimir_test.rs
+++ b/tests/osm2mimir_test.rs
@@ -43,6 +43,7 @@ pub fn osm2mimir_sample_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         &osm2mimir,
         &[
             "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--config-dir=./config".into(),
             "--import-way".into(),
             "--import-admin".into(),
             "--import-poi".into(),
@@ -67,6 +68,7 @@ pub fn osm2mimir_sample_test_sqlite(es_wrapper: crate::ElasticSearchWrapper<'_>)
         &osm2mimir,
         &[
             "--input=./tests/fixtures/osm_fixture.osm.pbf".into(),
+            "--config-dir=./config".into(),
             "--import-way".into(),
             "--import-admin".into(),
             "--import-poi".into(),


### PR DESCRIPTION
This patch introduces 2 new CLI arguments for osm2mimir:
-  `--config-dir` to point to a directory where configuration are stored
-  `--settings` to identify custom settings.

The motivation is to have different settings depending on the context.

It uses these new settings to expand the list of invalid highways.

It introduces a new dependency, [config](https://docs.rs/config/0.10.1/config/), to read a `.toml` file.
This config crate has possibly many functionalities, like merging configuration files (like specific settings, on top of default ones),
overwriting values with environment variables, ...