### PR TITLE
[FIX]: Display error in context

### DIFF
--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -561,12 +561,19 @@ impl Rubber {
 
         let dataset_index = get_main_type_and_dataset_index::<T>(dataset);
         self.alias(&dataset_index, &[index.name], &last_indexes)
-            .with_context(|_| format!("Error occurred when making alias: {}", dataset_index))?;
+            .with_context(|err| {
+                format!(
+                    "Error occurred when making alias {}: {}",
+                    dataset_index, err
+                )
+            })?;
 
         let type_index = get_main_type_index::<T>();
         if let IndexVisibility::Public = visibility {
             self.alias(&type_index, &[dataset_index], &last_indexes)
-                .with_context(|_| format!("Error occurred when making alias: {}", type_index))?;
+                .with_context(|err| {
+                    format!("Error occurred when making alias {}: {}", type_index, err)
+                })?;
         }
 
         if let IndexVisibility::Public = visibility {
@@ -583,7 +590,7 @@ impl Rubber {
 
         for i in last_indexes {
             self.delete_index(&i)
-                .with_context(|_| format!("Error occurred when deleting index: {}", i))?;
+                .with_context(|err| format!("Error occurred when deleting index {}: {}", i, err))?;
         }
         Ok(())
     }
@@ -723,7 +730,7 @@ impl Rubber {
         // TODO better error handling
         let index = self
             .make_index(dataset, index_settings)
-            .with_context(|_| format!("Error occurred when making index: {}", dataset))?;
+            .with_context(|err| format!("Error occurred when making index {}: {}", dataset, err))?;
         let nb_elements = self.bulk_index(&index, iter)?;
         self.publish_index(dataset, index, visibility)?;
         Ok(nb_elements)

--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -26,7 +26,7 @@ where
 {
     let addr_index = rubber
         .make_index(dataset, &index_settings)
-        .with_context(|_| format!("Error occurred when making index {}", dataset))?;
+        .with_context(|err| format!("Error occurred when making index {}: {}", dataset, err))?;
 
     info!("Add data in elasticsearch db.");
 

--- a/src/bin/ntfs2mimir.rs
+++ b/src/bin/ntfs2mimir.rs
@@ -217,10 +217,10 @@ fn run(args: Args) -> Result<(), transit_model::Error> {
         &args.dataset,
         index_settings,
     )
-    .with_context(|_| {
+    .with_context(|err| {
         format!(
-            "Error occurred when importing stops into {} on {}",
-            args.dataset, args.connection_string
+            "Error occurred when importing stops into {} on {}: {}",
+            args.dataset, args.connection_string, err
         )
     })?;
     Ok(())
@@ -244,7 +244,7 @@ fn test_bad_connection_string() {
     assert_eq!(
         causes,
         [
-            "Error occurred when importing stops into bob on http://localhost:1".to_string(),
+            "Error occurred when importing stops into bob on http://localhost:1: Error: HTTP Error while creating template template_addr".to_string(),
             "Error: HTTP Error while creating template template_addr".to_string(),
         ]
     );

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -161,10 +161,10 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         info!("importing streets into Mimir");
         let nb_streets = rubber
             .public_index(&args.dataset, &street_index_settings, streets.into_iter())
-            .with_context(|_| {
+            .with_context(|err| {
                 format!(
-                    "Error occurred when requesting street number in {}",
-                    args.dataset
+                    "Error occurred when requesting street number in {}: {}",
+                    args.dataset, err
                 )
             })?;
         info!("Nb of indexed street: {}", nb_streets);
@@ -180,10 +180,10 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
                 &admin_index_settings,
                 admins_geofinder.admins(),
             )
-            .with_context(|_| {
+            .with_context(|err| {
                 format!(
-                    "Error occurred when requesting admin number in {}",
-                    args.dataset
+                    "Error occurred when requesting admin number in {}: {}",
+                    args.dataset, err
                 )
             })?;
         info!("Nb of indexed admin: {}", nb_admins);
@@ -193,8 +193,12 @@ fn run(args: Args) -> Result<(), mimirsbrunn::Error> {
         let matcher = match args.poi_config {
             None => PoiConfig::default(),
             Some(path) => {
-                let r = std::fs::File::open(&path).with_context(|_| {
-                    format!("Error while opening configuration file {:?}", path)
+                let r = std::fs::File::open(&path).with_context(|err| {
+                    format!(
+                        "Error while opening configuration file {}: {}",
+                        path.display(),
+                        err
+                    )
                 })?;
                 PoiConfig::from_reader(r).unwrap()
             }


### PR DESCRIPTION
This is a stopgap fix to retrieve the error context in some situation
where it was dropped and not displayed to the user. This may not be
the way failure was meant to be used (rather using error chains), but
this solution gets the error context to the end user. A long term
solution will involve changing to eg anyhow, snafu or other error
libraries