### PR TITLE
[FEAT]: Make use of BulkResult

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,8 +2919,8 @@ dependencies = [
 
 [[package]]
 name = "rs-es"
-version = "0.12.2"
-source = "git+https://github.com/canaltp/rs-es#f029b406de0788c001a19f91602f83a38b8dc62c"
+version = "0.12.3"
+source = "git+https://github.com/canaltp/rs-es#ce83c8bb38c44ceb26bcc9255abc1d8d31d13c10"
 dependencies = [
  "geojson",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ slog-envlogger = "2.2"
 slog-async = "2.5"
 structopt = "0.3"
 csv = "1.1"
-rs-es = { git = "https://github.com/canaltp/rs-es", features = ["geo"]}
+rs-es = { git = "https://github.com/canaltp/rs-es", features = ["geo"], version = "0.12.3"}
 regex = "1"
 osmpbfreader = "0.13"
 osm_boundaries_utils = "0.6"

--- a/libs/bragi/Cargo.toml
+++ b/libs/bragi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 structopt = "0.3"
 slog = { version = "2.5", features = ["max_level_trace", "release_max_level_info"]}
 slog-scope = "4.3"
-rs-es = { git = "https://github.com/canaltp/rs-es", features = ["geo"]}
+rs-es = { git = "https://github.com/canaltp/rs-es", features = ["geo"], version = "0.12.3" }
 serde = { version = "1", features = ["rc"]}
 serde_json = "1"
 geojson = { version = "0.19", features = ["geo-types"] }

--- a/libs/mimir/Cargo.toml
+++ b/libs/mimir/Cargo.toml
@@ -12,7 +12,7 @@ slog-scope = "4.3"
 slog-envlogger = "2.2"
 slog-stdlog = "4.0"
 slog-async = "2.5"
-rs-es = { git = "https://github.com/canaltp/rs-es", features = ["geo"]}
+rs-es = { git = "https://github.com/canaltp/rs-es", features = ["geo"], version = "0.12.3"}
 serde = { version = "1", features = ["rc"]}
 serde_json = "1"
 chrono = "0.4"

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -690,8 +690,8 @@ impl Rubber {
                                     .unwrap_or_else(|_| String::from("Could not serialize error"));
 
                                 warn!(
-                                    "An error occured while importing stop '{}': {}",
-                                    action_res.inner.id, error
+                                    "An error occured while importing {} '{}': {}",
+                                    T::doc_type(), action_res.inner.id, error
                                 );
                             }
                         });

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -671,13 +671,31 @@ impl Rubber {
             })
             .with_nb_threads(self.nb_insert_threads)
             .par_map(move |chunk| {
-                client
+                let res = client
                     .clone()
                     .bulk(&chunk)
                     .with_index(&index_name)
                     .with_doc_type(T::doc_type())
                     .send()?;
 
+                if res.errors {
+                    res.items
+                        .iter()
+                        .filter(|action_res| action_res.inner.status != 200)
+                        .for_each(|action_res| {
+                            // We only display a warning if it brings some information, otherwise
+                            // the log is distracting
+                            if let Some(ref error) = action_res.inner.error {
+                                let error = serde_json::to_string(error)
+                                    .unwrap_or(String::from("Could not serialize error"));
+
+                                warn!(
+                                    "An error occured while importing stop '{}': {}",
+                                    action_res.inner.id, error
+                                );
+                            }
+                        });
+                }
                 Ok(chunk.len())
             })
             .try_fold(0, |sum, res| res.map(|chunk_len| sum + chunk_len))

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -687,7 +687,7 @@ impl Rubber {
                             // the log is distracting
                             if let Some(ref error) = action_res.inner.error {
                                 let error = serde_json::to_string(error)
-                                    .unwrap_or(String::from("Could not serialize error"));
+                                    .unwrap_or_else(|_| String::from("Could not serialize error"));
 
                                 warn!(
                                     "An error occured while importing stop '{}': {}",

--- a/libs/mimir/src/rubber.rs
+++ b/libs/mimir/src/rubber.rs
@@ -691,7 +691,9 @@ impl Rubber {
 
                                 warn!(
                                     "An error occured while importing {} '{}': {}",
-                                    T::doc_type(), action_res.inner.id, error
+                                    T::doc_type(),
+                                    action_res.inner.id,
+                                    error
                                 );
                             }
                         });

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -68,7 +68,7 @@ pub fn streets(
         .street
         .clone()
         .map(|street| street.exclusion.highways.unwrap_or_else(Vec::new))
-        .unwrap_or(Vec::new());
+        .unwrap_or_default();
 
     let is_valid_highway = |tag: &str| -> bool { !invalid_highways.iter().any(|k| k == tag) };
 


### PR DESCRIPTION
This patch adds a warning in the logs for each stop which result in an insertion error from Elasticsearch (and for which Elasticsearch returns error information)