### PR TITLE
config: share "settings" field for index templates

### DIFF
--- a/config/index_templates/addr_template.json
+++ b/config/index_templates/addr_template.json
@@ -1,57 +1,6 @@
 {
     "template": "munin_addr_*",
-    "settings": {
-        "analysis": {
-            "filter": {
-                "prefix_filter": {
-                    "type": "edge_ngram",
-                    "min_gram": 1,
-                    "max_gram": 20
-                },
-                "ngram_filter": {
-                    "type": "nGram",
-                    "min_gram": "3",
-                    "max_gram": "3"
-                },
-                "synonym_filter": {
-                    "type": "synonym",
-                    "synonyms": ["hackwillbereplacedatindexcreation,hackwillbereplacedatindexcreation"]
-                }
-            },
-            "analyzer": {
-                "word": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding" ],
-                    "char_filter" : [ ]
-                },
-                "prefix": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding", "synonym_filter", "prefix_filter" ],
-                    "char_filter" : [ ]
-                },
-                "ngram_with_synonyms": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding", "synonym_filter", "ngram_filter" ],
-                    "char_filter" : [ ]
-                },
-                "ngram": {
-                    "tokenizer": "my_ngram_tokenizer",
-                    "filter": [ "lowercase", "asciifolding" ]
-                }
-            },
-            "tokenizer": {
-                "my_ngram_tokenizer": {
-                    "type": "nGram",
-                    "min_gram": "3",
-                    "max_gram": "3",
-                    "token_chars": [ "letter", "digit" ]
-                }
-            }
-        }
-    },
+    "settings": null,
     "mappings": {
         "addr": {
             "dynamic": "false",

--- a/config/index_templates/admin_template.json
+++ b/config/index_templates/admin_template.json
@@ -1,58 +1,6 @@
 {
     "template": "munin_admin_*",
-    "settings": {
-        "refresh_interval" : "60s",
-        "analysis": {
-            "filter": {
-                "prefix_filter": {
-                    "type":     "edge_ngram",
-                    "min_gram": 1,
-                    "max_gram": 20
-                },
-                "ngram_filter": {
-                    "type": "nGram",
-                    "min_gram": "3",
-                    "max_gram": "3"
-                },
-                "synonym_filter": {
-                    "type": "synonym",
-                    "synonyms": ["hackwillbereplacedatindexcreation,hackwillbereplacedatindexcreation"]
-                }
-            },
-            "analyzer": {
-                "word": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding" ],
-                    "char_filter" : [ ]
-                },
-                "prefix": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding", "synonym_filter", "prefix_filter" ],
-                    "char_filter" : [ ]
-                },
-                "ngram_with_synonyms": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding", "synonym_filter", "ngram_filter" ],
-                    "char_filter" : [ ]
-                },
-                "ngram": {
-                    "tokenizer": "my_ngram_tokenizer",
-                    "filter": [ "lowercase", "asciifolding" ]
-                }
-            },
-            "tokenizer": {
-                "my_ngram_tokenizer": {
-                    "type": "nGram",
-                    "min_gram": "3",
-                    "max_gram": "3",
-                    "token_chars": [ "letter", "digit" ]
-                }
-            }
-        }
-    },
+    "settings": null,
     "mappings": {
         "admin": {
             "_all": {

--- a/config/index_templates/default_settings.json
+++ b/config/index_templates/default_settings.json
@@ -1,0 +1,52 @@
+{
+    "analysis": {
+        "filter": {
+            "prefix_filter": {
+                "type":     "edge_ngram",
+                "min_gram": 1,
+                "max_gram": 20
+            },
+            "ngram_filter": {
+                "type": "nGram",
+                "min_gram": "3",
+                "max_gram": "3"
+            },
+            "synonym_filter": {
+                "type": "synonym",
+                "synonyms": ["hackwillbereplacedatindexcreation,hackwillbereplacedatindexcreation"]
+            }
+        },
+        "analyzer": {
+            "word": {
+                "type": "custom",
+                "tokenizer": "standard",
+                "filter": [ "lowercase", "asciifolding" ],
+                "char_filter" : [ ]
+            },
+            "prefix": {
+                "type": "custom",
+                "tokenizer": "standard",
+                "filter": [ "lowercase", "asciifolding", "synonym_filter", "prefix_filter" ],
+                "char_filter" : [ ]
+            },
+            "ngram_with_synonyms": {
+                "type": "custom",
+                "tokenizer": "standard",
+                "filter": [ "lowercase", "asciifolding", "synonym_filter", "ngram_filter" ],
+                "char_filter" : [ ]
+            },
+            "ngram": {
+                "tokenizer": "my_ngram_tokenizer",
+                "filter": [ "lowercase", "asciifolding" ]
+            }
+        },
+        "tokenizer": {
+            "my_ngram_tokenizer": {
+                "type": "nGram",
+                "min_gram": "3",
+                "max_gram": "3",
+                "token_chars": [ "letter", "digit" ]
+            }
+        }
+    }
+}

--- a/config/index_templates/poi_template.json
+++ b/config/index_templates/poi_template.json
@@ -1,58 +1,6 @@
 {
     "template": "munin_poi_*",
-    "settings": {
-        "refresh_interval" : "60s",
-        "analysis": {
-            "filter": {
-                "prefix_filter": {
-                    "type":     "edge_ngram",
-                    "min_gram": 1,
-                    "max_gram": 20
-                },
-                "ngram_filter": {
-                    "type": "nGram",
-                    "min_gram": "3",
-                    "max_gram": "3"
-                },
-                "synonym_filter": {
-                    "type": "synonym",
-                    "synonyms": ["hackwillbereplacedatindexcreation,hackwillbereplacedatindexcreation"]
-                }
-            },
-            "analyzer": {
-                "word": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding" ],
-                    "char_filter" : [ ]
-                },
-                "prefix": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding", "synonym_filter", "prefix_filter" ],
-                    "char_filter" : [ ]
-                },
-                "ngram_with_synonyms": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding", "synonym_filter", "ngram_filter" ],
-                    "char_filter" : [ ]
-                },
-                "ngram": {
-                    "tokenizer": "my_ngram_tokenizer",
-                    "filter": [ "lowercase", "asciifolding" ]
-                }
-            },
-            "tokenizer": {
-                "my_ngram_tokenizer": {
-                    "type": "nGram",
-                    "min_gram": "3",
-                    "max_gram": "3",
-                    "token_chars": [ "letter", "digit" ]
-                }
-            }
-        }
-    },
+    "settings": null,
     "mappings": {
         "poi": {
             "_all": {

--- a/config/index_templates/stop_template.json
+++ b/config/index_templates/stop_template.json
@@ -1,74 +1,16 @@
 {
-    "template": "munin_street_*",
-    "settings": {
-        "analysis": {
-            "filter": {
-                "prefix_filter": {
-                    "type":     "edge_ngram",
-                    "min_gram": 1,
-                    "max_gram": 20
-                },
-                "ngram_filter": {
-                    "type": "nGram",
-                    "min_gram": "3",
-                    "max_gram": "3"
-                },
-                "synonym_filter": {
-                    "type": "synonym",
-                    "synonyms": ["hackwillbereplacedatindexcreation,hackwillbereplacedatindexcreation"]
-                }
-            },
-            "analyzer": {
-                "word": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding" ],
-                    "char_filter" : [ ]
-                },
-                "prefix": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding", "synonym_filter", "prefix_filter" ],
-                    "char_filter" : [ ]
-                },
-                "ngram_with_synonyms": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding", "synonym_filter", "ngram_filter" ],
-                    "char_filter" : [ ]
-                },
-                "ngram": {
-                    "tokenizer": "my_ngram_tokenizer",
-                    "filter": [ "lowercase", "asciifolding" ]
-                }
-            },
-            "tokenizer": {
-                "my_ngram_tokenizer": {
-                    "type": "nGram",
-                    "min_gram": "3",
-                    "max_gram": "3",
-                    "token_chars": [ "letter", "digit" ]
-                }
-            }
-        }
-    },
+    "template": "munin_*stop*",
+    "settings": null,
     "mappings": {
-        "street": {
+        "stop": {
             "dynamic": "false",
             "properties": {
-                "id": { "type": "string", "index": "not_analyzed" },
-                "name": {
+                "id": {
                     "type": "string",
-                    "index_options": "docs",
-                    "analyzer": "word",
-                    "fields": {
-                        "prefix": {
-                            "type": "string",
-                            "index_options": "docs",
-                            "analyzer": "prefix",
-                            "search_analyzer": "word"
-                        }
-                    }
+                    "index": "not_analyzed"
+                },
+                "name": {
+                    "type": "string"
                 },
                 "zip_codes": {
                     "type": "string",
@@ -151,7 +93,13 @@
                         "enabled": false
                     }
                 },
-                "weight": { "type": "double" }
+                "weight": {
+                    "type": "double"
+                },
+                "coverages": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                }
             }
         }
     }

--- a/config/index_templates/street_template.json
+++ b/config/index_templates/street_template.json
@@ -1,67 +1,23 @@
 {
-    "template": "munin_*stop*",
-    "settings": {
-        "analysis": {
-            "filter": {
-                "prefix_filter": {
-                    "type":     "edge_ngram",
-                    "min_gram": 1,
-                    "max_gram": 20
-                },
-                "ngram_filter": {
-                    "type": "nGram",
-                    "min_gram": "3",
-                    "max_gram": "3"
-                },
-                "synonym_filter": {
-                    "type": "synonym",
-                    "synonyms": ["hackwillbereplacedatindexcreation,hackwillbereplacedatindexcreation"]
-                }
-            },
-            "analyzer": {
-                "word": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding" ],
-                    "char_filter" : [ ]
-                },
-                "prefix": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding", "synonym_filter", "prefix_filter" ],
-                    "char_filter" : [ ]
-                },
-                "ngram_with_synonyms": {
-                    "type": "custom",
-                    "tokenizer": "standard",
-                    "filter": [ "lowercase", "asciifolding", "synonym_filter", "ngram_filter" ],
-                    "char_filter" : [ ]
-                },
-                "ngram": {
-                    "tokenizer": "my_ngram_tokenizer",
-                    "filter": [ "lowercase", "asciifolding" ]
-                }
-            },
-            "tokenizer": {
-                "my_ngram_tokenizer": {
-                    "type": "nGram",
-                    "min_gram": "3",
-                    "max_gram": "3",
-                    "token_chars": [ "letter", "digit" ]
-                }
-            }
-        }
-    },
+    "template": "munin_street_*",
+    "settings": null,
     "mappings": {
-        "stop": {
+        "street": {
             "dynamic": "false",
             "properties": {
-                "id": {
-                    "type": "string",
-                    "index": "not_analyzed"
-                },
+                "id": { "type": "string", "index": "not_analyzed" },
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "index_options": "docs",
+                    "analyzer": "word",
+                    "fields": {
+                        "prefix": {
+                            "type": "string",
+                            "index_options": "docs",
+                            "analyzer": "prefix",
+                            "search_analyzer": "word"
+                        }
+                    }
                 },
                 "zip_codes": {
                     "type": "string",
@@ -144,13 +100,7 @@
                         "enabled": false
                     }
                 },
-                "weight": {
-                    "type": "double"
-                },
-                "coverages": {
-                    "type": "string",
-                    "index": "not_analyzed"
-                }
+                "weight": { "type": "double" }
             }
         }
     }


### PR DESCRIPTION
Template settings all share the exact same "settings" field, this can be quite painful when altering the [ES schema for all kind of documents](https://github.com/CanalTP/mimirsbrunn/pull/430).

This PR moves the shared field "settings" into its own file. There is still a lot of redundancies for "mappings" but it might be better to tackle the issue in a separate PR as it would be more tricky.