### PR TITLE
Update docker base to buster

### DIFF
--- a/docker/Dockerfile_bragi
+++ b/docker/Dockerfile_bragi
@@ -1,10 +1,10 @@
-FROM rust:1.44.1-stretch as builder
+FROM rust:1.47-buster as builder
 
 WORKDIR /srv/mimirsbrunn
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
-    && apt-get install -y make libssl1.0-dev git \
+    && apt-get install -y make libssl-dev git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -12,13 +12,13 @@ COPY . ./
 
 RUN cargo build --release
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 WORKDIR /srv
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
-    && apt-get install -y libcurl3 \
+    && apt-get install -y libcurl4 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/Dockerfile_import
+++ b/docker/Dockerfile_import
@@ -1,10 +1,10 @@
-FROM rust:1.44.1-stretch as builder
+FROM rust:1.47-buster as builder
 
 WORKDIR /srv/mimirsbrunn
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
-    && apt-get install -y make libssl1.0-dev git \
+    && apt-get install -y make libssl-dev git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -12,13 +12,13 @@ COPY . ./
 
 RUN cargo build --release --features db-storage
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 WORKDIR /srv
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
-    && apt-get install -y libcurl3 sqlite3 \
+    && apt-get install -y libcurl4 sqlite3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
This PR proposes to update the base for building docker images from *stretch* to *buster*.
I recently used the binaries from `Dockerfile_import` inside another docker image which was based on docker,
and it failed because our Docker image was stretch based.

Now I actually think we should have both leaving side by side. If you have an older Debian you should still be able to use Mimirsbrunn. It seems a way to do that would be to have two images, ie `Dockerfile_stretch_import` and `Dockerfile_buster_import`. What do you think?