### PR TITLE
[FEAT]: Add Makefile and parametric dockerfiles

### DIFF
--- a/.make-release-support
+++ b/.make-release-support
@@ -22,19 +22,19 @@ readonly SCRIPT_NAME=$(basename "$0")
 # Uses git status in short format to see if there are outstanding files that
 # have not been commited
 function hasChanges() {
-	test -n "$(git status -s .)"
+  test -n "$(git status -s .)"
 }
 
 # This returns the version contained in Cargo.tom l
 function getRelease() {
-	# awk -F= '/^release=/{print $2}' .release
+  # awk -F= '/^release=/{print $2}' .release
   cat Cargo.toml | grep '^version' | grep '\([0-9]\+\.\?\)\{3\}' -o
 }
 
 # The tag can have suffixes, like the commit for when the directory is not equal to
 # the tagged content.... This function return the base part of the tag
 function getBaseTag() {
-	# sed -n -e "s/^tag=\(.*\)$(getRelease)\$/\1/p" .release
+  # sed -n -e "s/^tag=\(.*\)$(getRelease)\$/\1/p" .release
   getRelease
 }
 
@@ -46,18 +46,18 @@ function getBaseName() {
 
 function getTag() {
   # FIXME Understand what arguments are provided
-	if [ -z "$1" ] ; then
+  if [ -z "$1" ] ; then
     echo "v$(getBaseTag)"
-	else
-		echo "v$1"
-	fi
+  else
+    echo "v$1"
+  fi
 }
 
 # This function returns an array of strings,
 # So, if the version returned by getRelease is 1.2.3, it
 # returns "1 1.2 1.2.3"
 function getDockerTags() {
-	local ORIGINAL=$(getRelease)
+  local ORIGINAL=$(getRelease)
   local SEMVER=( ${ORIGINAL//./ } )
   local MAJOR="${SEMVER[0]}"
   local MINOR="${SEMVER[1]}"
@@ -72,7 +72,7 @@ function getDockerTags() {
 function setRelease() {
   local VERSION="$1"
   echo "Setting the new release to ${VERSION}"
-	# Check that VERSION is set and non-empty
+  # Check that VERSION is set and non-empty
   [[ -z "${VERSION+xxx}" ]] &&
     { echo "The variable \$VERSION is not set. Make sure it is set before using setRelease."; return 1; }
   [[ -z "${VERSION}" && "${VERSION+xxx}" = "xxx" ]] &&
@@ -94,7 +94,7 @@ function setRelease() {
 # and verify that the original version is the same as the candidate.
 function checkSemanticVersion() {
   local ORIGINAL="$1"
-	# Check that ORIGINAL is set and non-empty
+  # Check that ORIGINAL is set and non-empty
   [[ -z "${ORIGINAL+xxx}" ]] &&
     { echo "The variable \$ORIGINAL is not set. Make sure it is set before using checkSemanticVersion."; return 1; }
   [[ -z "${ORIGINAL}" && "${ORIGINAL+xxx}" = "xxx" ]] &&
@@ -116,42 +116,42 @@ function checkSemanticVersion() {
 
 # Not used
 function runPreTagCommand() {
-	if [ -n "$1" ] ; then
-		COMMAND=$(sed -n -e "s/@@RELEASE@@/$1/g" -e 's/^pre_tag_command=\(.*\)/\1/p' .release)
-		if [ -n "$COMMAND" ] ; then
-			if ! OUTPUT=$(bash -c "$COMMAND" 2>&1) ; then echo $OUTPUT >&2 && exit 1 ; fi
-		fi
-	else
-		echo "ERROR: missing release version parameter " >&2
-		return 1
-	fi
+  if [ -n "$1" ] ; then
+    COMMAND=$(sed -n -e "s/@@RELEASE@@/$1/g" -e 's/^pre_tag_command=\(.*\)/\1/p' .release)
+    if [ -n "$COMMAND" ] ; then
+      if ! OUTPUT=$(bash -c "$COMMAND" 2>&1) ; then echo $OUTPUT >&2 && exit 1 ; fi
+    fi
+  else
+    echo "ERROR: missing release version parameter " >&2
+    return 1
+  fi
 }
 
 # This function retrieves the candidate tag from Cargo.toml (with getTag),
 # and make sure it is available with git tag.
 function tagExists() {
-	tag=${1:-$(getTag)}
-	test -n "$tag" && test -n "$(git tag | grep "^$tag\$")"
+  tag=${1:-$(getTag)}
+  test -n "$tag" && test -n "$(git tag | grep "^$tag\$")"
 }
 
 function differsFromRelease() {
-	tag=$(getTag)
-	! tagExists $tag || test -n "$(git diff --shortstat -r $tag .)"
+  tag=$(getTag)
+  ! tagExists $tag || test -n "$(git diff --shortstat -r $tag .)"
 }
 
 # This function retrieves the release, and if the git tag differs from
 # the version in Cargo.toml, add the commit, and also add 'dirty' if the
 # version has outstanding changes.
 function getVersion() {
-	local result=$(getRelease)
+  local result=$(getRelease)
 
-	if differsFromRelease; then
-		result="${result}-$(git log -n 1 --format=%h .)"
-	fi
+  if differsFromRelease; then
+    result="${result}-$(git log -n 1 --format=%h .)"
+  fi
 
-	if hasChanges ; then
-		result="${result}-dirty"
-	fi
+  if hasChanges ; then
+    result="${result}-dirty"
+  fi
   echo "${result}"
 }
 
@@ -160,7 +160,7 @@ function getVersion() {
 # FIXME We need to return both the incremented version, and also an error if
 # the original version is not a semantic version.
 function nextPatchLevel() {
-	local ORIGINAL=$(getRelease)
+  local ORIGINAL=$(getRelease)
   local SEMVER=( ${ORIGINAL//./ } )
   local MAJOR="${SEMVER[0]}"
   local MINOR="${SEMVER[1]}"
@@ -171,7 +171,7 @@ function nextPatchLevel() {
 }
 
 function nextMinorLevel() {
-	local ORIGINAL=$(getRelease)
+  local ORIGINAL=$(getRelease)
   local SEMVER=( ${ORIGINAL//./ } )
   local MAJOR="${SEMVER[0]}"
   local MINOR="${SEMVER[1]}"
@@ -181,7 +181,7 @@ function nextMinorLevel() {
 }
 
 function nextMajorLevel() {
-	local ORIGINAL=$(getRelease)
+  local ORIGINAL=$(getRelease)
   local SEMVER=( ${ORIGINAL//./ } )
   local MAJOR="${SEMVER[0]}"
   MAJOR=$(($MAJOR + 1))

--- a/.make-release-support
+++ b/.make-release-support
@@ -1,0 +1,190 @@
+#!/bin/bash
+#
+#   Copyright 2015  Xebia Nederland B.V.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+readonly SCRIPT_SRC="$(dirname "${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}")"
+readonly SCRIPT_DIR="$(cd "${SCRIPT_SRC}" >/dev/null 2>&1 && pwd)"
+readonly BASE_NAME="$(basename ${SCRIPT_DIR})"
+readonly SCRIPT_NAME=$(basename "$0")
+
+# Uses git status in short format to see if there are outstanding files that
+# have not been commited
+function hasChanges() {
+	test -n "$(git status -s .)"
+}
+
+# This returns the version contained in Cargo.tom l
+function getRelease() {
+	# awk -F= '/^release=/{print $2}' .release
+  cat Cargo.toml | grep '^version' | grep '\([0-9]\+\.\?\)\{3\}' -o
+}
+
+# The tag can have suffixes, like the commit for when the directory is not equal to
+# the tagged content.... This function return the base part of the tag
+function getBaseTag() {
+	# sed -n -e "s/^tag=\(.*\)$(getRelease)\$/\1/p" .release
+  getRelease
+}
+
+# This is the name used to make the base of the docker tag.
+# It is the basename of the directory in which lies the project.
+function getBaseName() {
+  echo ${BASE_NAME}
+}
+
+function getTag() {
+  # FIXME Understand what arguments are provided
+	if [ -z "$1" ] ; then
+    echo "v$(getBaseTag)"
+	else
+		echo "v$1"
+	fi
+}
+
+# This function returns an array of strings,
+# So, if the version returned by getRelease is 1.2.3, it
+# returns "1 1.2 1.2.3"
+function getDockerTags() {
+	local ORIGINAL=$(getRelease)
+  local SEMVER=( ${ORIGINAL//./ } )
+  local MAJOR="${SEMVER[0]}"
+  local MINOR="${SEMVER[1]}"
+  local PATCH="${SEMVER[2]}"
+
+  local VERSION="${MAJOR}.${MINOR}.${PATCH}"
+  echo "${MAJOR} ${MAJOR}.${MINOR} ${MAJOR}.${MINOR}.${PATCH}"
+}
+
+# Updates the version in Cargo.toml
+# $1 Version (must match major.minor.patch)
+function setRelease() {
+  local VERSION="$1"
+  echo "Setting the new release to ${VERSION}"
+	# Check that VERSION is set and non-empty
+  [[ -z "${VERSION+xxx}" ]] &&
+    { echo "The variable \$VERSION is not set. Make sure it is set before using setRelease."; return 1; }
+  [[ -z "${VERSION}" && "${VERSION+xxx}" = "xxx" ]] &&
+    { echo "The variable \$VERSION is set but empty. Make sure it is not empty before using setRelease."; return 1; }
+
+  checkSemanticVersion ${VERSION}
+  [[ $? != 0 ]] &&
+    { echo "${VERSION} is not valid semantic version"; return 1; } ||
+    { sed -i -e "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/" Cargo.toml; }
+
+  return 0
+}
+
+# Returns 0 if the version has the form major.minor.patch
+# $1 Version
+# This function works by decomposing the version into its
+# parts (major, minor, patch), ensuring they're not empty,
+# reassemble them into a candidate version,
+# and verify that the original version is the same as the candidate.
+function checkSemanticVersion() {
+  local ORIGINAL="$1"
+	# Check that ORIGINAL is set and non-empty
+  [[ -z "${ORIGINAL+xxx}" ]] &&
+    { echo "The variable \$ORIGINAL is not set. Make sure it is set before using checkSemanticVersion."; return 1; }
+  [[ -z "${ORIGINAL}" && "${ORIGINAL+xxx}" = "xxx" ]] &&
+    { echo "The variable \$ORIGINAL is set but empty. Make sure it is not empty before using checkSemanticVersion."; return 1; }
+
+  local SEMVER=( ${ORIGINAL//./ } )
+  local MAJOR="${SEMVER[0]}"
+  [[ -z "${MAJOR}" && "${MAJOR+xxx}" = "xxx" ]] &&
+    { echo "The variable \$MAJOR is empty."; return 1; }
+  local MINOR="${SEMVER[1]}"
+  [[ -z "${MINOR}" && "${MINOR+xxx}" = "xxx" ]] &&
+    { echo "The variable \$MINOR is empty."; return 1; }
+  local PATCH="${SEMVER[2]}"
+  [[ -z "${PATCH}" && "${PATCH+xxx}" = "xxx" ]] &&
+    { echo "The variable \$PATCH is empty."; return 1; }
+  local VERSION="${MAJOR}.${MINOR}.${PATCH}"
+  [[ ${VERSION} == ${ORIGINAL} ]] && { return 0; } || { return 0; }
+}
+
+# Not used
+function runPreTagCommand() {
+	if [ -n "$1" ] ; then
+		COMMAND=$(sed -n -e "s/@@RELEASE@@/$1/g" -e 's/^pre_tag_command=\(.*\)/\1/p' .release)
+		if [ -n "$COMMAND" ] ; then
+			if ! OUTPUT=$(bash -c "$COMMAND" 2>&1) ; then echo $OUTPUT >&2 && exit 1 ; fi
+		fi
+	else
+		echo "ERROR: missing release version parameter " >&2
+		return 1
+	fi
+}
+
+# This function retrieves the candidate tag from Cargo.toml (with getTag),
+# and make sure it is available with git tag.
+function tagExists() {
+	tag=${1:-$(getTag)}
+	test -n "$tag" && test -n "$(git tag | grep "^$tag\$")"
+}
+
+function differsFromRelease() {
+	tag=$(getTag)
+	! tagExists $tag || test -n "$(git diff --shortstat -r $tag .)"
+}
+
+# This function retrieves the release, and if the git tag differs from
+# the version in Cargo.toml, add the commit, and also add 'dirty' if the
+# version has outstanding changes.
+function getVersion() {
+	local result=$(getRelease)
+
+	if differsFromRelease; then
+		result="${result}-$(git log -n 1 --format=%h .)"
+	fi
+
+	if hasChanges ; then
+		result="${result}-dirty"
+	fi
+  echo "${result}"
+}
+
+# Returns the nextPatchLevel.
+# It reads the current version from Cargo.toml using the getRelease function
+# FIXME We need to return both the incremented version, and also an error if
+# the original version is not a semantic version.
+function nextPatchLevel() {
+	local ORIGINAL=$(getRelease)
+  local SEMVER=( ${ORIGINAL//./ } )
+  local MAJOR="${SEMVER[0]}"
+  local MINOR="${SEMVER[1]}"
+  local PATCH="${SEMVER[2]}"
+  PATCH=$(($PATCH + 1))
+  local VERSION="${MAJOR}.${MINOR}.${PATCH}"
+  echo "${VERSION}"
+}
+
+function nextMinorLevel() {
+	local ORIGINAL=$(getRelease)
+  local SEMVER=( ${ORIGINAL//./ } )
+  local MAJOR="${SEMVER[0]}"
+  local MINOR="${SEMVER[1]}"
+  MINOR=$(($MINOR + 1))
+  local VERSION="${MAJOR}.${MINOR}.0"
+  echo "${VERSION}"
+}
+
+function nextMajorLevel() {
+	local ORIGINAL=$(getRelease)
+  local SEMVER=( ${ORIGINAL//./ } )
+  local MAJOR="${SEMVER[0]}"
+  MAJOR=$(($MAJOR + 1))
+  local VERSION="${MAJOR}.0.0"
+  echo "${VERSION}"
+}

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ SHELL=/bin/bash
 	release patch-release minor-release major-release tag check-status check-release \
 	push pre-push do-push post-push
 
-build: pre-build docker-build post-build
+build: pre-build docker-build post-build ## Build one or more docker images
 
 pre-build: fmt lint test
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,160 @@
+#
+#   Based on Makefile from https://github.com/mvanholsteijn/docker-makefile
+#
+#
+#   Based on https://gist.github.com/mpneuried/0594963ad38e68917ef189b4e6a269db
+#
+#
+# import config.
+# You can change the default config with `make cnf="config_special.env" build`
+cnf ?= config.env
+include $(cnf)
+export $(shell sed 's/=.*//' $(cnf))
+
+# import deploy config
+# You can change the default deploy config with `make cnf="deploy_special.env" release`
+dpl ?= deploy.env
+include $(dpl)
+export $(shell sed 's/=.*//' $(dpl))
+
+# HELP
+# This will output the help for each task
+# thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+
+help: ## This help.
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+RELEASE_SUPPORT := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))/.make-release-support
+
+NAME=$(shell . $(RELEASE_SUPPORT) ; getBaseName)
+VERSION=$(shell . $(RELEASE_SUPPORT) ; getVersion)
+DOCKER_TAGS=$(addprefix $(DOCKER_REPO)/$(NAME):,$(shell . $(RELEASE_SUPPORT) ; getDockerTags))
+TAG=$(shell . $(RELEASE_SUPPORT); getTag)
+
+SHELL=/bin/bash
+
+.PHONY: \
+	pre-build docker-build post-build build \
+	release patch-release minor-release major-release tag check-status check-release \
+	push pre-push do-push post-push
+
+build: pre-build docker-build post-build
+
+pre-build: fmt lint test
+
+post-build:
+
+pre-push:
+
+post-push:
+
+docker-build:
+	@for ENV in $(BUILD_ENV); do \
+		TAGS=""; \
+		SPL=$${ENV/:/ }; \
+		DEB=$$(echo $$SPL | awk '{print $$1;}'); \
+		RST=$$(echo $$SPL | awk '{print $$2;}'); \
+		ARG_DEB="--build-arg DEBIAN_VERSION=$$DEB"; \
+		ARG_RST="--build-arg RUST_VERSION=$$RST"; \
+		for DOCKER_TAG in $(DOCKER_TAGS); do \
+			TAGS=$$TAGS" --tag $$DOCKER_TAG-$$DEB"; \
+		done; \
+		FIRST_ENV=$$(echo $(BUILD_ENV) | awk '{print $$1;}'); \
+		if [ $$FIRST_ENV = $$ENV ]; then \
+			for DOCKER_TAG in $(DOCKER_TAGS); do \
+				TAGS=$$TAGS" --tag $$DOCKER_TAG"; \
+			done; \
+			TAGS=$$TAGS" --tag $(DOCKER_REPO)/$(NAME):latest"; \
+		fi; \
+		echo "docker build $(DOCKER_BUILD_ARGS) $$ARG_DEB $$ARG_RST $$TAGS -f $(DOCKER_FILE_PATH) $(DOCKER_BUILD_CONTEXT)"; \
+		docker build $(DOCKER_BUILD_ARGS) $$ARG_DEB $$ARG_RST $$TAGS -f $(DOCKER_FILE_PATH) $(DOCKER_BUILD_CONTEXT); \
+	done
+
+release: check-status check-release build push
+
+push: pre-push do-push post-push
+
+do-push:
+	@for ENV in $(BUILD_ENV); do \
+		SPL=$${ENV/:/ }; \
+		DEB=$$(echo $$SPL | awk '{print $$1;}'); \
+		for DOCKER_TAG in $(DOCKER_TAGS); do \
+			docker push $$DOCKER_TAG-$$DEB; \
+		done; \
+		FIRST_ENV=$$(echo $(BUILD_ENV) | awk '{print $$1;}'); \
+		if [ $$FIRST_ENV = $$ENV ]; then \
+			for DOCKER_TAG in $(DOCKER_TAGS); do \
+			  docker push $$DOCKER_TAG; \
+			done; \
+			docker push $(DOCKER_REPO)/$(NAME):latest; \
+		fi; \
+	done
+
+snapshot: build push
+
+tag-patch-release: VERSION := $(shell . $(RELEASE_SUPPORT); nextPatchLevel)
+tag-patch-release: tag
+
+tag-minor-release: VERSION := $(shell . $(RELEASE_SUPPORT); nextMinorLevel)
+tag-minor-release: tag
+
+tag-major-release: VERSION := $(shell . $(RELEASE_SUPPORT); nextMajorLevel)
+tag-major-release: tag
+
+patch-release: tag-patch-release release ## Increment the patch version number and release
+	@echo $(VERSION)
+
+minor-release: tag-minor-release release ## Increment the minor version number and release
+	@echo $(VERSION)
+
+major-release: tag-major-release release ## Increment the major version number and release
+	@echo $(VERSION)
+
+tag: TAG=$(shell . $(RELEASE_SUPPORT); getTag $(VERSION))
+
+tag: check-status ## Check that the tag does not already exist, changes the version in Cargo.toml, commit, and tag.
+	@. $(RELEASE_SUPPORT) ; ! tagExists $(TAG) || (echo "ERROR: tag $(TAG) for version $(VERSION) already tagged in git" >&2 && exit 1) ;
+	@. $(RELEASE_SUPPORT) ; setRelease $(VERSION)
+	cargo check # We need to add this cargo check which will update Cargo.lock. Otherwise Cargo.lock will be modified after,
+	            # and the release will seem dirty.
+	git add .
+	git commit -m "[VER] new version $(VERSION)" ;
+	git tag $(TAG) ;
+	@ if [ -n "$(shell git remote -v)" ] ; then git push --tags ; else echo 'no remote to push tags to' ; fi
+
+check-status: ## Check that there are no outstanding changes. (uses git status)
+	@. $(RELEASE_SUPPORT) ; ! hasChanges \
+		|| (echo "Status ERROR: there are outstanding changes" >&2 && exit 1) \
+		&& (echo "Status OK" >&2 ) ;
+
+check-release: ## Check that the current git tag matches the one in Cargo.toml and there are no outstanding changes.
+	@. $(RELEASE_SUPPORT) ; tagExists $(TAG) || (echo "ERROR: version not yet tagged in git. make [minor,major,patch]-release." >&2 && exit 1) ;
+	@. $(RELEASE_SUPPORT) ; ! differsFromRelease $(TAG) || (echo "ERROR: current directory differs from tagged $(TAG). make [minor,major,patch]-release." ; exit 1)
+
+
+######### Debug
+
+check-name:
+	@echo $(NAME)
+
+check-tag:
+	@echo $(TAG)
+
+check-version:
+	@echo $(VERSION)
+
+### RUST related rules
+
+fmt: format ## Check formatting of the code (alias for 'format')
+format: ## Check formatting of the code
+	cargo fmt --all -- --check
+
+clippy: lint ## Check quality of the code (alias for 'lint')
+lint: ## Check quality of the code
+	cargo clippy --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings
+
+test: ## Launch all tests
+	cargo test --all-targets                 # `--all-targets` but no doctests
+
+

--- a/README.md
+++ b/README.md
@@ -80,9 +80,13 @@ For more detail about the different ways to import those data sources, check the
 
 ## debian packages
 
-[Kisio Digital](http://www.kisiodigital.com/), the company behind [navitia](https://www.navitia.io/) has some available debian 8 [packages](https://ci.navitia.io/view/mimir/job/mimirsbrunn_release_package/lastSuccessfulBuild/artifact/mimirsbrunn_1.8.0_amd64.deb).
+[Kisio Digital](http://www.kisiodigital.com/), the company behind
+[navitia](https://www.navitia.io/) has some available debian
+8 [packages](https://ci.navitia.io/view/mimir/job/mimirsbrunn_release_package/lastSuccessfulBuild/artifact/mimirsbrunn_1.8.0_amd64.deb).
 
-If you need some packages for a different target, you can use CanalTP's [script](https://github.com/CanalTP/mimirsbrunn/blob/master/build_packages.sh) or [cargo-deb](https://github.com/mmstick/cargo-deb)
+If you need some packages for a different target, you can use CanalTP's
+[script](https://github.com/CanalTP/mimirsbrunn/blob/master/build_packages.sh) or
+[cargo-deb](https://github.com/mmstick/cargo-deb)
 
 ## manually
 
@@ -96,27 +100,52 @@ For a disposable ES, you can run:
 
 ### build
 
-`cargo build --release`
+#### Binaries
+
+If you want to build local binaries, use `cargo build --release`. You may need to adjust the
+version of the rust compiler prior to executing this command (eg `rustup update`).
+
+#### Docker
+
+If you want to build a docker image, you can use the `docker` command, with the following caveat:
+You need to specify the version of debian it will be based on, as well as the version of rust.
+You also want to verify that the version of Debian you specify is supported! Check the content of
+`docker/Dockerfile_bragi` for that. Your `docker` command will look like:
+
+```
+docker build --build-arg DEBIAN_VERSION=buster --build-arg RUST_VERSION=1.47 ...
+```
+
+Alternatively, there is a Makefile that can assist you with several tasks. See `make help` for
+details. For example `make snapshot` will build an image and push it to a repository. The
+repository, as well as the build environments are specified in `deploy.env`.
 
 ### test
 
 `cargo test`
 
-Integration tests are spawning one ElasticSearch docker, so you'll need a recent docker version. Only one docker is spawn, so the ES db is cleaned before each test.
+Integration tests are spawning one ElasticSearch docker, so you'll need a recent docker version.
+Only one docker is spawn, so the ES db is cleaned before each test.
 
 # More documentation
 
-For more precise documentation on use, troubleshooting, development please check the [documentation directory](documentation/readme.md).
+For more precise documentation on use, troubleshooting, development please check the [documentation
+directory](documentation/readme.md).
 
 # Contributing
 
 The project is [Licensed as AGPL 3](https://github.com/CanalTP/mimirsbrunn/blob/master/LICENSE).
 
-We'll be happy to review all you [pull requests](https://help.github.com/en/articles/about-pull-requests).
+We'll be happy to review all you [pull
+requests](https://help.github.com/en/articles/about-pull-requests).
 
-You can also open some issues if you find some bugs, or if you find the geocoder results not to your liking.
+You can also open some issues if you find some bugs, or if you find the geocoder results not to
+your liking.
 
-Another way to contribute to this project (and to lots of others geocoders) is to add some geocoder test on [geocoder-tester](https://github.com/geocoders/geocoder-tester), a great non regression tool used by many geocoder. It's quite easy, you just add some new test cases with some searches and the results that you expect.
+Another way to contribute to this project (and to lots of others geocoders) is to add some geocoder
+test on [geocoder-tester](https://github.com/geocoders/geocoder-tester), a great non regression
+tool used by many geocoder. It's quite easy, you just add some new test cases with some searches
+and the results that you expect.
 
 # presentation of the other alternatives
 * [pelias](https://github.com/pelias/pelias)
@@ -125,6 +154,7 @@ Another way to contribute to this project (and to lots of others geocoders) is t
 
 TODO: add a bit more detail on all the projects
 
-All those projects use quite the same APIs, and you can compare their results using [geocoder-tester](https://github.com/geocoders/geocoder-tester).
+All those projects use quite the same APIs, and you can compare their results using
+[geocoder-tester](https://github.com/geocoders/geocoder-tester).
 
 For a more visual comparison, you can also use [a comparator](https://github.com/CanalTP/autocomplete-comparator).

--- a/config.env
+++ b/config.env
@@ -1,0 +1,4 @@
+# Port to run the container
+PORT=4000
+
+# Until here you can define all the individual configurations for your app

--- a/deploy.env
+++ b/deploy.env
@@ -1,4 +1,4 @@
-# The first environment in the following is the default environment.
+# The first environment in the following BUILD_ENV variable is the default environment.
 BUILD_ENV=buster:1.47 stretch:1.44.1
 DOCKER_REPO=localhost:5000
 DOCKER_BUILD_CONTEXT=.

--- a/deploy.env
+++ b/deploy.env
@@ -1,0 +1,5 @@
+# The first environment in the following is the default environment.
+BUILD_ENV=buster:1.47 stretch:1.44.1
+DOCKER_REPO=localhost:5000
+DOCKER_BUILD_CONTEXT=.
+DOCKER_FILE_PATH=docker/Dockerfile

--- a/docker/Dockerfile_bragi
+++ b/docker/Dockerfile_bragi
@@ -1,27 +1,55 @@
-FROM rust:1.44.1-stretch as builder
+ARG RUST_VERSION
+ARG DEBIAN_VERSION
+
+FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} as builder
 
 WORKDIR /srv/mimirsbrunn
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update \
+
+ARG DEBIAN_VERSION
+
+RUN if [ "${DEBIAN_VERSION}" = "buster" ]; then \
+  apt-get update \
+    && apt-get install -y make libssl-dev git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ "${DEBIAN_VERSION}" = "stretch" ]; then \
+  apt-get update \
     && apt-get install -y make libssl1.0-dev git \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+else \
+  echo "Unsupported debian version '$DEBIAN_VERSION'"; \
+fi
 
 COPY . ./
 
 RUN cargo build --release
 
-FROM debian:stretch-slim
+ARG DEBIAN_VERSION
+
+FROM debian:${DEBIAN_VERSION}-slim
 
 WORKDIR /srv
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update \
+
+ARG DEBIAN_VERSION
+
+RUN if [ "${DEBIAN_VERSION}" = "buster" ]; then \
+  apt-get update \
+    && apt-get install -y libcurl4 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ "${DEBIAN_VERSION}" = "stretch" ]; then \
+  apt-get update \
     && apt-get install -y libcurl3 \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+else \
+  echo "Unsupported debian version '$DEBIAN_VERSION'"; \
+fi
 
 COPY --from=builder /srv/mimirsbrunn/target/release/bragi /srv/bragi
 

--- a/docker/Dockerfile_import
+++ b/docker/Dockerfile_import
@@ -1,26 +1,53 @@
-FROM rust:1.44.1-stretch as builder
+ARG RUST_VERSION
+ARG DEBIAN_VERSION
+
+FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} as builder
 
 WORKDIR /srv/mimirsbrunn
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update \
+
+ARG DEBIAN_VERSION
+
+RUN if [ "${DEBIAN_VERSION}" = "buster" ]; then \
+  apt-get update \
+    && apt-get install -y make libssl-dev git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ "${DEBIAN_VERSION}" = "stretch" ]; then \
+  apt-get update \
     && apt-get install -y make libssl1.0-dev git \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+else \
+  echo "Unsupported debian version '$DEBIAN_VERSION'"; \
+fi
 
 COPY . ./
 
 RUN cargo build --release --features db-storage
 
-FROM debian:stretch-slim
+FROM debian:${DEBIAN_VERSION}-slim
 
 WORKDIR /srv
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update \
+
+ARG DEBIAN_VERSION
+
+RUN if [ "${DEBIAN_VERSION}" = "buster" ]; then \
+  apt-get update \
+    && apt-get install -y libcurl4 sqlite3 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+elif [ "${DEBIAN_VERSION}" = "stretch" ]; then \
+  apt-get update \
     && apt-get install -y libcurl3 sqlite3 \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+else \
+  echo "Unsupported debian version '$DEBIAN_VERSION'"; \
+fi
 
 RUN mkdir /etc/mimirsbrunn
 


### PR DESCRIPTION
To support multiple platforms (like debian buster and stretch), we
introduce build arguments (`--build-arg`) when calling Dockerfile, such
that one Dockerfile can be used to generate one image per debian
platform.

In addition we introduce a Makefile and support script to facilitate
releases.

Building a docker image, you now have to use a line like:

docker build --build-arg DEBIAN_VERSION=buster --build-arg RUST_VERSION=1.47 ...

Plus de details sur le Makefile [ici](https://github.com/crocme10/test-makefile)