### PR TITLE
Platform

### DIFF
--- a/config/osm2mimir-default.toml
+++ b/config/osm2mimir-default.toml
@@ -23,13 +23,8 @@ dataset = "fr"
   import = false
   [street.exclusion]
     # See [OSM Key Highway](https://wiki.openstreetmap.org/wiki/Key:highway) for background.
-    highways = [
-      "bus_guideway",
-      "bus_stop",
-      "elevator",
-      "escape",
-      "platform"
-    ]
+    highway = [ "bus_guideway", "bus_stop", "elevator", "escape", "platform" ]
+    public_transport = [ "platform", "hub" ]
 
 [poi]
   import = false

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -86,12 +86,13 @@ pub fn streets(
                     .tags
                     .get("highway")
                     .map_or(false, |v| !v.is_empty() && is_valid_highway(v));
-                let has_valid_public_transport_tag = way
+                let has_no_excluded_public_transport_tag = way
                     .tags
                     .get("public_transport")
-                    .map_or(false, |v| !v.is_empty() && is_valid_public_transport(v));
+                    .map_or(true, |v| is_valid_public_transport(v));
                 let has_valid_name_tag = way.tags.get("name").map_or(false, |v| !v.is_empty());
-                has_valid_name_tag && (has_valid_highway_tag || has_valid_public_transport_tag)
+                has_valid_name_tag
+                    && (has_valid_highway_tag || has_no_excluded_public_transport_tag)
             }
             osmpbfreader::OsmObj::Relation(ref rel) => rel
                 .tags

--- a/src/osm_reader/street.rs
+++ b/src/osm_reader/street.rs
@@ -91,8 +91,7 @@ pub fn streets(
                     .get("public_transport")
                     .map_or(true, |v| is_valid_public_transport(v));
                 let has_valid_name_tag = way.tags.get("name").map_or(false, |v| !v.is_empty());
-                has_valid_name_tag
-                    && (has_valid_highway_tag || has_no_excluded_public_transport_tag)
+                has_valid_name_tag && has_valid_highway_tag && has_no_excluded_public_transport_tag
             }
             osmpbfreader::OsmObj::Relation(ref rel) => rel
                 .tags

--- a/src/settings/osm2mimir.rs
+++ b/src/settings/osm2mimir.rs
@@ -12,7 +12,8 @@ use crate::Error;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct StreetExclusion {
-    pub highways: Option<Vec<String>>,
+    pub highway: Option<Vec<String>>,
+    pub public_transport: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
This PR does two little things:
1. It extends street exclusion to public_transport { platform, hub }
2. It changes the key for highways to highway (to match what's done in OSM)