### PR TITLE
[Fixed] loosing Cargo.lock in Dockerfile

### DIFF
--- a/docker/bragi/Dockerfile
+++ b/docker/bragi/Dockerfile
@@ -3,7 +3,7 @@ ARG DEBIAN_VERSION
 
 FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} as builder
 
-WORKDIR /srv/mimirsbrunn
+WORKDIR /home
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -23,11 +23,49 @@ else \
   echo "Unsupported debian version '$DEBIAN_VERSION'"; \
 fi
 
-COPY . ./
+RUN USER=root cargo new mimirsbrunn
 
-RUN rm Cargo.lock
+WORKDIR /home/mimirsbrunn
+
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./Cargo.lock ./Cargo.lock
+
+RUN echo "// dummy file" > src/lib.rs
+RUN echo "fn main () { }" > ./build.rs
+
+RUN mkdir -p libs/bragi/src
+COPY ./libs/bragi/Cargo.toml ./libs/bragi/Cargo.toml
+RUN echo "// dummy file" > ./libs/bragi/src/lib.rs
+
+RUN mkdir -p libs/mimir/src
+COPY ./libs/mimir/Cargo.toml ./libs/mimir/Cargo.toml
+RUN echo "// dummy file" > ./libs/mimir/src/lib.rs
+
+RUN mkdir -p libs/docker_wrapper/src
+COPY ./libs/docker_wrapper/Cargo.toml ./libs/docker_wrapper/Cargo.toml
+RUN echo "// dummy file" > ./libs/docker_wrapper/src/lib.rs
+
+RUN mkdir -p libs/tools/src
+COPY ./libs/tools/Cargo.toml ./libs/tools/Cargo.toml
+RUN echo "// dummy file" > ./libs/tools/src/lib.rs
+
+RUN mkdir -p tests
+RUN echo "// dummy file" > ./tests/tests.rs
 
 RUN cargo build --release
+RUN rm src/*.rs
+
+COPY ./src ./src
+COPY ./libs ./libs
+COPY ./config ./config
+COPY ./docker ./docker
+COPY ./build.rs ./build.rs
+
+RUN rm ./target/release/deps/libmimir*
+RUN rm ./target/release/deps/libbragi*
+RUN rm ./target/release/deps/mimirsbrunn*
+
+RUN cargo build --release --features db-storage
 
 ARG DEBIAN_VERSION
 
@@ -41,22 +79,22 @@ ARG DEBIAN_VERSION
 
 RUN if [ "${DEBIAN_VERSION}" = "buster" ]; then \
   apt-get update \
-    && apt-get install -y libcurl4 \
+    && apt-get install -y libcurl4 sqlite3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
 elif [ "${DEBIAN_VERSION}" = "stretch" ]; then \
   apt-get update \
-    && apt-get install -y libcurl3 \
+    && apt-get install -y libcurl3 sqlite3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
 else \
   echo "Unsupported debian version '$DEBIAN_VERSION'"; \
 fi
 
-COPY --from=builder /srv/mimirsbrunn/target/release/bragi /srv/bragi
+COPY --from=builder /home/mimirsbrunn/target/release/bragi /usr/bin/bragi
 
 EXPOSE 4000
 ENV BRAGI_ES http://localhost:9200/munin
 ENV RUST_LOG=info,hyper=info
 
-CMD ["/srv/bragi", "-b", "0.0.0.0:4000"]
+CMD ["/usr/bin/bragi", "-b", "0.0.0.0:4000"]

--- a/docker/mimirsbrunn/Dockerfile
+++ b/docker/mimirsbrunn/Dockerfile
@@ -3,7 +3,7 @@ ARG DEBIAN_VERSION
 
 FROM rust:${RUST_VERSION}-${DEBIAN_VERSION} as builder
 
-WORKDIR /srv/mimirsbrunn
+WORKDIR /home
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -23,11 +23,51 @@ else \
   echo "Unsupported debian version '$DEBIAN_VERSION'"; \
 fi
 
-COPY . ./
+RUN USER=root cargo new mimirsbrunn
 
-RUN rm Cargo.lock
+WORKDIR /home/mimirsbrunn
+
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./Cargo.lock ./Cargo.lock
+
+RUN echo "// dummy file" > src/lib.rs
+RUN echo "fn main () { }" > ./build.rs
+
+RUN mkdir -p libs/bragi/src
+COPY ./libs/bragi/Cargo.toml ./libs/bragi/Cargo.toml
+RUN echo "// dummy file" > ./libs/bragi/src/lib.rs
+
+RUN mkdir -p libs/mimir/src
+COPY ./libs/mimir/Cargo.toml ./libs/mimir/Cargo.toml
+RUN echo "// dummy file" > ./libs/mimir/src/lib.rs
+
+RUN mkdir -p libs/docker_wrapper/src
+COPY ./libs/docker_wrapper/Cargo.toml ./libs/docker_wrapper/Cargo.toml
+RUN echo "// dummy file" > ./libs/docker_wrapper/src/lib.rs
+
+RUN mkdir -p libs/tools/src
+COPY ./libs/tools/Cargo.toml ./libs/tools/Cargo.toml
+RUN echo "// dummy file" > ./libs/tools/src/lib.rs
+
+RUN mkdir -p tests
+RUN echo "// dummy file" > ./tests/tests.rs
+
+RUN cargo build --release
+RUN rm src/*.rs
+
+COPY ./src ./src
+COPY ./libs ./libs
+COPY ./config ./config
+COPY ./docker ./docker
+COPY ./build.rs ./build.rs
+
+RUN rm ./target/release/deps/libmimir*
+RUN rm ./target/release/deps/libbragi*
+RUN rm ./target/release/deps/mimirsbrunn*
 
 RUN cargo build --release --features db-storage
+
+ARG DEBIAN_VERSION
 
 FROM debian:${DEBIAN_VERSION}-slim
 
@@ -53,8 +93,8 @@ fi
 
 RUN mkdir /etc/mimirsbrunn
 
-COPY --from=builder /srv/mimirsbrunn/target/release/osm2mimir /usr/bin/osm2mimir
-COPY --from=builder /srv/mimirsbrunn/target/release/cosmogony2mimir /usr/bin/cosmogony2mimir
-COPY --from=builder /srv/mimirsbrunn/target/release/bano2mimir /usr/bin/bano2mimir
-COPY --from=builder /srv/mimirsbrunn/target/release/openaddresses2mimir /usr/bin/openaddresses2mimir
-COPY --from=builder /srv/mimirsbrunn/config/* /etc/mimirsbrunn/
+COPY --from=builder /home/mimirsbrunn/target/release/osm2mimir /usr/bin/osm2mimir
+COPY --from=builder /home/mimirsbrunn/target/release/cosmogony2mimir /usr/bin/cosmogony2mimir
+COPY --from=builder /home/mimirsbrunn/target/release/bano2mimir /usr/bin/bano2mimir
+COPY --from=builder /home/mimirsbrunn/target/release/openaddresses2mimir /usr/bin/openaddresses2mimir
+COPY --from=builder /home/mimirsbrunn/config/* /etc/mimirsbrunn/


### PR DESCRIPTION
New version of the Dockerfile. This one uses cache optimization using the two-stage pattern.

Due to the presence of both binaries and libraries, we have to create dummy files.

If this version is ok with you, I'll do the same with `docker/bragi/Dockerfile`