### PR TITLE
[Fixed] Use old toolchains for old platform

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -18,7 +18,7 @@ jobs:
             rust: 1.44.1
           - version: buster
             packages: pkg-config libssl-dev
-            rust: stable
+            rust: 1.48.0
 
     container: debian:${{matrix.version}}
 

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: {{ matrix.rust }}
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
       - name: Build package
         run: ./scripts/build_deb.sh ${{ matrix.version }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -12,10 +12,13 @@ jobs:
         include:
           - version: jessie
             packages: pkg-config libssl-dev
+            rust: 1.44.1
           - version: stretch
             packages: pkg-config libssl1.0-dev
+            rust: 1.44.1
           - version: buster
             packages: pkg-config libssl-dev
+            rust: stable
 
     container: debian:${{matrix.version}}
 
@@ -30,7 +33,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: {{ matrix.rust }}
           components: rustfmt, clippy
       - name: Build package
         run: ./scripts/build_deb.sh ${{ matrix.version }}


### PR DESCRIPTION
This pull request introduces rust toolchain versions adapted to the platform on which the build is ran.