### PR TITLE
[Added] Multiple docker targets

### DIFF
--- a/.make-release-support
+++ b/.make-release-support
@@ -38,12 +38,6 @@ function getBaseTag() {
   getRelease
 }
 
-# This is the name used to make the base of the docker tag.
-# It is the basename of the directory in which lies the project.
-function getBaseName() {
-  echo ${BASE_NAME}
-}
-
 function getTag() {
   # FIXME Understand what arguments are provided
   if [ -z "$1" ] ; then

--- a/deploy.env
+++ b/deploy.env
@@ -1,5 +1,3 @@
 # The first environment in the following BUILD_ENV variable is the default environment.
 BUILD_ENV=buster:1.47 stretch:1.44.1
 DOCKER_REPO=localhost:5000
-DOCKER_BUILD_CONTEXT=.
-DOCKER_FILE_PATH=docker/Dockerfile


### PR DESCRIPTION
Slight extension to the Makefile to support building multiple images. The image name are the name of the directories found directly under the docker directory. This change iterates through all the directories under the docker directory, and build an image for each of them.
This change is to support building images for both mimir binaries, and bragi.