### PR TITLE
Multiple docker repo

### DIFF
--- a/.make-release-support
+++ b/.make-release-support
@@ -38,12 +38,6 @@ function getBaseTag() {
   getRelease
 }
 
-# This is the name used to make the base of the docker tag.
-# It is the basename of the directory in which lies the project.
-function getBaseName() {
-  echo ${BASE_NAME}
-}
-
 function getTag() {
   # FIXME Understand what arguments are provided
   if [ -z "$1" ] ; then

--- a/.make-release-support
+++ b/.make-release-support
@@ -6,7 +6,6 @@
 
 SCRIPT_SRC="$(dirname "${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}")"
 SCRIPT_DIR="$(cd "${SCRIPT_SRC}" >/dev/null 2>&1 && pwd)"
-BASE_NAME="$(basename ${SCRIPT_DIR})"
 
 # Some constants for SEMVER regexp
 NAT='0|[1-9][0-9]*'
@@ -28,30 +27,17 @@ function hasChanges() {
 	test -n "$(git status -s .)"
 }
 
-# This returns the version contained in Cargo.tom l
+# This returns the version contained in Cargo.toml
 function getRelease() {
   local rel=$(cat Cargo.toml | grep '^version' | cut -d '=' -f 2 | tr -d \")
   rel="${rel#"${rel%%[![:space:]]*}"}"   # remove leading whitespace characters
   echo "$rel"
 }
 
-# The tag can have suffixes, like the commit for when the directory is not equal to
-# the tagged content.... This function return the base part of the tag
-function getBaseTag() {
-	# sed -n -e "s/^tag=\(.*\)$(getRelease)\$/\1/p" .release
-  getRelease
-}
-
-# This is the name used to make the base of the docker tag.
-# It is the basename of the directory in which lies the project.
-function getBaseName() {
-  echo ${BASE_NAME}
-}
-
 function getTag() {
   # FIXME Understand what arguments are provided
 	if [ -z "$1" ] ; then
-    echo "v$(getBaseTag)"
+    echo "v$(getRelease)"
 	else
 		echo "v$1"
 	fi
@@ -66,7 +52,7 @@ function getLastTag() {
 # To do this, we first get the tag of the last rc0.
 # We use this tag to display the commit message,
 # which is expected to be something like
-# [version] new XXX prerelease.
+# [Versioned] new XXX prerelease.
 # So by splitting at spaces, we just extract the third field.
 # (it brittle)
 function getReleaseMessage() {
@@ -100,6 +86,11 @@ function getDockerTags() {
 
 # Updates the version in Cargo.toml
 # $1 Version (must match semver)
+# This function works in 3 steps:
+# 1. validate the argument
+# 2. validate the version
+# 3. set the version. This part, which is very specific to the project this script is embedded in,
+#    has been extracted in the function `setReleaseProject`.
 function setRelease() {
   local VERSION="$1"
   echo "Setting the new release to ${VERSION}"
@@ -118,7 +109,7 @@ function setRelease() {
 }
 
 # This function assumes the version given as argument has been validated.
-# It needs to be customized for each project. It writes the version ($1) to files.
+# It needs to be customized for each project. It writes the version ($1) to file(s).
 function setReleaseProject() {
   local VERSION="$1"
   sed -i -e "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/" Cargo.toml

--- a/.make-release-support
+++ b/.make-release-support
@@ -1,184 +1,387 @@
-#!/bin/bash
-#
-#   Copyright 2015  Xebia Nederland B.V.
-#
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-#
-readonly SCRIPT_SRC="$(dirname "${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}")"
-readonly SCRIPT_DIR="$(cd "${SCRIPT_SRC}" >/dev/null 2>&1 && pwd)"
-readonly BASE_NAME="$(basename ${SCRIPT_DIR})"
-readonly SCRIPT_NAME=$(basename "$0")
+#!/usr/bin/env bash
+
+# Copyright 2015  Xebia Nederland B.V.
+# Copyright (c) 2014-2015 François Saint-Jacques <fsaintjacques@gmail.com>
+# for semver regex (https://github.com/fsaintjacques/semver-tool)
+
+SCRIPT_SRC="$(dirname "${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}")"
+SCRIPT_DIR="$(cd "${SCRIPT_SRC}" >/dev/null 2>&1 && pwd)"
+BASE_NAME="$(basename ${SCRIPT_DIR})"
+
+# Some constants for SEMVER regexp
+NAT='0|[1-9][0-9]*'
+ALPHANUM='[0-9]*[A-Za-z-][0-9A-Za-z-]*'
+IDENT="$NAT|$ALPHANUM"
+FIELD='[0-9A-Za-z-]+'
+
+SEMVER_REGEX="\
+^[vV]?\
+($NAT)\\.($NAT)\\.($NAT)\
+(\\-(${IDENT})(\\.(${IDENT}))*)?\
+(\\+${FIELD}(\\.${FIELD})*)?$"
+
+PRERELEASE_REGEX="^\\-rc(${NAT})$"
 
 # Uses git status in short format to see if there are outstanding files that
 # have not been commited
 function hasChanges() {
-  test -n "$(git status -s .)"
+	test -n "$(git status -s .)"
 }
 
 # This returns the version contained in Cargo.tom l
 function getRelease() {
-  # awk -F= '/^release=/{print $2}' .release
-  cat Cargo.toml | grep '^version' | grep '\([0-9]\+\.\?\)\{3\}' -o
+  local rel=$(cat Cargo.toml | grep '^version' | cut -d '=' -f 2 | tr -d \")
+  rel="${rel#"${rel%%[![:space:]]*}"}"   # remove leading whitespace characters
+  echo "$rel"
 }
 
 # The tag can have suffixes, like the commit for when the directory is not equal to
 # the tagged content.... This function return the base part of the tag
 function getBaseTag() {
-  # sed -n -e "s/^tag=\(.*\)$(getRelease)\$/\1/p" .release
+	# sed -n -e "s/^tag=\(.*\)$(getRelease)\$/\1/p" .release
   getRelease
+}
+
+# This is the name used to make the base of the docker tag.
+# It is the basename of the directory in which lies the project.
+function getBaseName() {
+  echo ${BASE_NAME}
 }
 
 function getTag() {
   # FIXME Understand what arguments are provided
-  if [ -z "$1" ] ; then
+	if [ -z "$1" ] ; then
     echo "v$(getBaseTag)"
+	else
+		echo "v$1"
+	fi
+}
+
+function getLastTag() {
+  # We get the last tag that is not a prerelease (ie does not contain rc)
+  git tag -l --sort=version:refname v* | grep -v rc | tail -n 1
+}
+
+# This function returns the type of release (ie patch, minor, major).
+# To do this, we first get the tag of the last rc0.
+# We use this tag to display the commit message,
+# which is expected to be something like
+# [version] new XXX prerelease.
+# So by splitting at spaces, we just extract the third field.
+# (it brittle)
+function getReleaseMessage() {
+  local rc0=$(git tag -l --sort=version:refname | grep rc0 | tail -n 1)
+  local release_type=$(git log --format=%B -n 1 ${rc0} | cut -d ' ' -f 3)
+  echo "new ${release_type} release"
+}
+
+
+# This function returns the tag(s) for use with Docker.
+# If the version (from getRelease) is a prerelease (finishes with rcN),
+# then we only return this value.
+# If the versios is a release (X.Y.Z), then we return an array of strings,
+# X X.Y X.Y.Z
+function getDockerTags() {
+	local ORIGINAL=$(getRelease)
+  if [[ "$ORIGINAL" =~ $SEMVER_REGEX ]]; then
+    local MAJOR=${BASH_REMATCH[1]}
+    local MINOR=${BASH_REMATCH[2]}
+    local PATCH=${BASH_REMATCH[3]}
+    local PRERE=${BASH_REMATCH[4]}
+    if [ -n "$PRERE" ]; then
+      echo "$ORIGINAL"
+    else
+      echo "${MAJOR} ${MAJOR}.${MINOR} ${MAJOR}.${MINOR}.${PATCH}"
+    fi
   else
-    echo "v$1"
+    echo "$ORIGINAL"
   fi
 }
 
-# This function returns an array of strings,
-# So, if the version returned by getRelease is 1.2.3, it
-# returns "1 1.2 1.2.3"
-function getDockerTags() {
-  local ORIGINAL=$(getRelease)
-  local SEMVER=( ${ORIGINAL//./ } )
-  local MAJOR="${SEMVER[0]}"
-  local MINOR="${SEMVER[1]}"
-  local PATCH="${SEMVER[2]}"
-
-  local VERSION="${MAJOR}.${MINOR}.${PATCH}"
-  echo "${MAJOR} ${MAJOR}.${MINOR} ${MAJOR}.${MINOR}.${PATCH}"
-}
-
 # Updates the version in Cargo.toml
-# $1 Version (must match major.minor.patch)
+# $1 Version (must match semver)
 function setRelease() {
   local VERSION="$1"
   echo "Setting the new release to ${VERSION}"
-  # Check that VERSION is set and non-empty
+	# Check that VERSION is set and non-empty
   [[ -z "${VERSION+xxx}" ]] &&
     { echo "The variable \$VERSION is not set. Make sure it is set before using setRelease."; return 1; }
   [[ -z "${VERSION}" && "${VERSION+xxx}" = "xxx" ]] &&
     { echo "The variable \$VERSION is set but empty. Make sure it is not empty before using setRelease."; return 1; }
 
-  checkSemanticVersion ${VERSION}
+  validate_version ${VERSION}
   [[ $? != 0 ]] &&
     { echo "${VERSION} is not valid semantic version"; return 1; } ||
-    { sed -i -e "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/" Cargo.toml; }
+    { setReleaseProject "${VERSION}"; }
 
   return 0
 }
 
-# Returns 0 if the version has the form major.minor.patch
-# $1 Version
-# This function works by decomposing the version into its
-# parts (major, minor, patch), ensuring they're not empty,
-# reassemble them into a candidate version,
-# and verify that the original version is the same as the candidate.
-function checkSemanticVersion() {
-  local ORIGINAL="$1"
-  # Check that ORIGINAL is set and non-empty
-  [[ -z "${ORIGINAL+xxx}" ]] &&
-    { echo "The variable \$ORIGINAL is not set. Make sure it is set before using checkSemanticVersion."; return 1; }
-  [[ -z "${ORIGINAL}" && "${ORIGINAL+xxx}" = "xxx" ]] &&
-    { echo "The variable \$ORIGINAL is set but empty. Make sure it is not empty before using checkSemanticVersion."; return 1; }
-
-  local SEMVER=( ${ORIGINAL//./ } )
-  local MAJOR="${SEMVER[0]}"
-  [[ -z "${MAJOR}" && "${MAJOR+xxx}" = "xxx" ]] &&
-    { echo "The variable \$MAJOR is empty."; return 1; }
-  local MINOR="${SEMVER[1]}"
-  [[ -z "${MINOR}" && "${MINOR+xxx}" = "xxx" ]] &&
-    { echo "The variable \$MINOR is empty."; return 1; }
-  local PATCH="${SEMVER[2]}"
-  [[ -z "${PATCH}" && "${PATCH+xxx}" = "xxx" ]] &&
-    { echo "The variable \$PATCH is empty."; return 1; }
-  local VERSION="${MAJOR}.${MINOR}.${PATCH}"
-  [[ ${VERSION} == ${ORIGINAL} ]] && { return 0; } || { return 0; }
+# This function assumes the version given as argument has been validated.
+# It needs to be customized for each project. It writes the version ($1) to files.
+function setReleaseProject() {
+  local VERSION="$1"
+  sed -i -e "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/" Cargo.toml
+  sed -i -e "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/" libs/bragi/Cargo.toml
+  sed -i -e "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/" libs/mimir/Cargo.toml
+  sed -i -e "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/" libs/tools/Cargo.toml
+  sed -i -e "s/^version\s*=\s*\".*\"/version = \"$VERSION\"/" libs/docker_wrapper/Cargo.toml
 }
 
 # Not used
 function runPreTagCommand() {
-  if [ -n "$1" ] ; then
-    COMMAND=$(sed -n -e "s/@@RELEASE@@/$1/g" -e 's/^pre_tag_command=\(.*\)/\1/p' .release)
-    if [ -n "$COMMAND" ] ; then
-      if ! OUTPUT=$(bash -c "$COMMAND" 2>&1) ; then echo $OUTPUT >&2 && exit 1 ; fi
-    fi
-  else
-    echo "ERROR: missing release version parameter " >&2
-    return 1
-  fi
+	if [ -n "$1" ] ; then
+		COMMAND=$(sed -n -e "s/@@RELEASE@@/$1/g" -e 's/^pre_tag_command=\(.*\)/\1/p' .release)
+		if [ -n "$COMMAND" ] ; then
+			if ! OUTPUT=$(bash -c "$COMMAND" 2>&1) ; then echo $OUTPUT >&2 && exit 1 ; fi
+		fi
+	else
+		echo "ERROR: missing release version parameter " >&2
+		return 1
+	fi
 }
 
 # This function retrieves the candidate tag from Cargo.toml (with getTag),
 # and make sure it is available with git tag.
 function tagExists() {
-  tag=${1:-$(getTag)}
-  test -n "$tag" && test -n "$(git tag | grep "^$tag\$")"
+	tag=${1:-$(getTag)}
+	test -n "$tag" && test -n "$(git tag | grep "^$tag\$")"
 }
 
 function differsFromRelease() {
-  tag=$(getTag)
-  ! tagExists $tag || test -n "$(git diff --shortstat -r $tag .)"
+	tag=$(getTag)
+	! tagExists $tag || test -n "$(git diff --shortstat -r $tag .)"
 }
 
 # This function retrieves the release, and if the git tag differs from
 # the version in Cargo.toml, add the commit, and also add 'dirty' if the
 # version has outstanding changes.
 function getVersion() {
-  local result=$(getRelease)
+	local result=$(getRelease)
 
-  if differsFromRelease; then
-    result="${result}-$(git log -n 1 --format=%h .)"
-  fi
+	if differsFromRelease; then
+		result="${result}-$(git log -n 1 --format=%h .)"
+	fi
 
-  if hasChanges ; then
-    result="${result}-dirty"
-  fi
+	if hasChanges ; then
+		result="${result}-dirty"
+	fi
   echo "${result}"
 }
 
-# Returns the nextPatchLevel.
-# It reads the current version from Cargo.toml using the getRelease function
-# FIXME We need to return both the incremented version, and also an error if
-# the original version is not a semantic version.
-function nextPatchLevel() {
-  local ORIGINAL=$(getRelease)
-  local SEMVER=( ${ORIGINAL//./ } )
-  local MAJOR="${SEMVER[0]}"
-  local MINOR="${SEMVER[1]}"
-  local PATCH="${SEMVER[2]}"
-  PATCH=$(($PATCH + 1))
-  local VERSION="${MAJOR}.${MINOR}.${PATCH}"
-  echo "${VERSION}"
+# $1 version
+# $2 variable to set
+# Returns 0 and set $2 if $1 follows semver, returns 1 otherwise
+function validate_version() {
+  local version=$1
+  [[ "$version" =~ $SEMVER_REGEX ]] && { return 0; } || { return 1; }
 }
 
-function nextMinorLevel() {
-  local ORIGINAL=$(getRelease)
-  local SEMVER=( ${ORIGINAL//./ } )
-  local MAJOR="${SEMVER[0]}"
-  local MINOR="${SEMVER[1]}"
-  MINOR=$(($MINOR + 1))
-  local VERSION="${MAJOR}.${MINOR}.0"
-  echo "${VERSION}"
+# $1 version
+# $2 variable to set
+# Returns 0 and set $2 if $1 follows semver, returns 1 otherwise
+function decompose_version() {
+  if [ "$#" -ne "2" ]; then
+    echo "You must supply 2 arguments"
+    return 1
+  fi
+  local version=$1
+  if [[ "$version" =~ $SEMVER_REGEX ]]; then
+    local major=${BASH_REMATCH[1]}
+    local minor=${BASH_REMATCH[2]}
+    local patch=${BASH_REMATCH[3]}
+    local prere=${BASH_REMATCH[4]}
+    local build=${BASH_REMATCH[8]}
+    eval "$2=(\"$major\" \"$minor\" \"$patch\" \"$prere\" \"$build\")"
+    return 0
+  else
+    return 1
+  fi
 }
 
-function nextMajorLevel() {
-  local ORIGINAL=$(getRelease)
-  local SEMVER=( ${ORIGINAL//./ } )
-  local MAJOR="${SEMVER[0]}"
-  MAJOR=$(($MAJOR + 1))
-  local VERSION="${MAJOR}.0.0"
-  echo "${VERSION}"
+function validate_prerelease() {
+  if [ "$#" -ne "2" ]; then
+    echo "You must supply 2 arguments"
+    return 1
+  fi
+  local prerelease=$1
+  if [[ "$prerelease" =~ $PRERELEASE_REGEX ]]; then
+    local iter=${BASH_REMATCH[1]}
+    eval "$2=$iter"
+    return 0
+  else
+    echo "prerelease $prerelease does not match the expected scheme '-rcN'. See help for more information."
+    return 1
+  fi
 }
+
+function nextMajorPrerelease() {
+	local ORIGINAL=$(getRelease)
+  decompose_version "$ORIGINAL" SEMVER
+  if [ $? -eq 0 ]; then
+    local MAJOR="${SEMVER[0]}"
+    MAJOR=$(($MAJOR + 1))
+    local VERSION="${MAJOR}.0.0-rc0"
+    echo "${VERSION}"
+  else
+    echo "${ORIGINAL}"
+  fi
+}
+
+function nextMinorPrerelease() {
+	local ORIGINAL=$(getRelease)
+  decompose_version "$ORIGINAL" SEMVER
+  if [ $? -eq 0 ]; then
+    local MAJOR="${SEMVER[0]}"
+    local MINOR="${SEMVER[1]}"
+    MINOR=$(($MINOR + 1))
+    local VERSION="${MAJOR}.${MINOR}.0-rc0"
+    echo "${VERSION}"
+  else
+    echo "${ORIGINAL}"
+  fi
+}
+
+function nextPatchPrerelease() {
+	local ORIGINAL=$(getRelease)
+  decompose_version "$ORIGINAL" SEMVER
+  if [ $? -eq 0 ]; then
+    local MAJOR="${SEMVER[0]}"
+    local MINOR="${SEMVER[1]}"
+    local PATCH="${SEMVER[2]}"
+    PATCH=$(($PATCH + 1))
+    local VERSION="${MAJOR}.${MINOR}.${PATCH}-rc0"
+    echo "${VERSION}"
+  else
+    echo "${ORIGINAL}"
+  fi
+}
+
+function nextPrerelease() {
+	local ORIGINAL=$(getRelease)
+  decompose_version "$ORIGINAL" SEMVER
+  if [ $? -eq 0 ]; then
+    local MAJOR="${SEMVER[0]}"
+    local MINOR="${SEMVER[1]}"
+    local PATCH="${SEMVER[2]}"
+    local PRERE="${SEMVER[3]}"
+    validate_prerelease "$PRERE" i
+    local VERSION="$MAJOR.$MINOR.$PATCH-rc$((i + 1))"
+    echo "${VERSION}"
+  else
+    echo "${ORIGINAL}"
+  fi
+}
+
+function nextRelease() {
+	local ORIGINAL=$(getRelease)
+  decompose_version "$ORIGINAL" SEMVER
+  if [ $? -eq 0 ]; then
+    local MAJOR="${SEMVER[0]}"
+    local MINOR="${SEMVER[1]}"
+    local PATCH="${SEMVER[2]}"
+    local VERSION="$MAJOR.$MINOR.$PATCH"
+    echo "${VERSION}"
+  else
+    echo "${ORIGINAL}"
+  fi
+}
+
+
+# $1 tag.
+# We will returning the changelog from last tag till HEAD
+# We extract the commit msg, followed by a delimiter, followed by the hash
+function changeLog() {
+  git log $1..HEAD --pretty='format:%s -- %h' | sort
+}
+
+# We receive the log as a multiline string, one commit per line, containing the message, followed by the hash
+# We create a dictionary, which contains, for each type of commit, an array of hash
+# But since we can't work with arrays inside a dictionary, it's just a string with -- delimiters between hashes.
+function splitLog() {
+  declare -A assoc
+  str="$1"
+  # FIXME SAVE IFS
+  IFS=$'\n'
+  for line in $(echo "${str}"); do
+    # echo "orig: $line"
+    re="\[([[:alpha:]]+)\] .* -- (.*)"
+    if [[ $line =~ $re ]]; then
+      local commit_type="${BASH_REMATCH[1]}"
+      local commit_hash="${BASH_REMATCH[2]}"
+      local res="${assoc["${commit_type}"]}"
+      if [[ -z "$res" && "${res+xxx}" = "xxx" ]]; then
+        assoc["$commit_type"]="$commit_hash"
+      else
+        assoc["$commit_type"]="$res--$commit_hash"
+      fi
+    fi
+  done
+  # For debug
+  # for i in ${!assoc[@]}; do
+  #   echo "$i ${assoc[$i]}"
+  # done
+  # Now we generate the output. So we iterate through all the commit types,
+  # and for each commit type, we iterate through the list of hashes.
+  # For each hash, we use git show to display the information
+  for commit_type in ${!assoc[@]}; do
+    # We don't want to list all the Version related commits... so skip them.
+    if [ "$commit_type" != "Versioned" ]; then
+      local commits="${assoc["$commit_type"]}"
+      delimiter="--"
+      conCatString=$commits$delimiter
+      splitMultiChar=()
+      while [[ $conCatString ]]; do
+        splitMultiChar+=( "${conCatString%%"$delimiter"*}" )
+        conCatString=${conCatString#*"$delimiter"}
+      done
+      echo "### ${commit_type}:" >> /tmp/changelog.md
+      for commit in "${splitMultiChar[@]}"; do
+        local change=$(git show -s --pretty='format:%s, %an, %as, %h' ${commit})
+        # We remove the [xxx] because its redundant with the section
+        # this syntax means keep everything after first space
+        change="${change#* }"
+        echo "- ${change}" >> /tmp/changelog.md
+      done
+      echo "\n" >> /tmp/changelog.md
+    fi
+  done
+}
+
+# $1 current tag
+# $2 old tag
+function generateChangelog() {
+  # FIXME Use temp file instead
+  rm -f /tmp/changelog.md
+  local day="$(date +%Y-%m-%dT%H:%M:%SZ)"
+  echo "## $1\n" >> /tmp/changelog.md
+  echo "Released $day\n">> /tmp/changelog.md
+  echo "" >> /tmp/changelog.md
+
+  local log=$(changeLog $2)
+  echo "$log"
+  splitLog "$log"
+  # Now to generate the log, we remove the header, prepend
+  # the new changelog on the old one, and put the header back.
+  # In the following line, the +11 matches the height of the header.
+  tail -n +11 CHANGELOG.md > /tmp/old-changelog.md
+  cat /tmp/changelog.md /tmp/old-changelog.md > CHANGELOG.md
+  addChangelogHeader
+}
+
+function addChangelogHeader() {
+  read -r -d '' header <<'EOF'
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file is generated automatically by the release procedure, please do not edit.
+
+EOF
+
+  echo -e "${header}\n\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+}
+

--- a/Makefile
+++ b/Makefile
@@ -57,14 +57,14 @@ docker-build:
 			ARG_DEB="--build-arg DEBIAN_VERSION=$$DEB"; \
 			ARG_RST="--build-arg RUST_VERSION=$$RST"; \
 			for DOCKER_TAG in $(DOCKER_TAGS); do \
-			  TAGS=$$TAGS" --tag $(DOCKER_REPO)/$$DOCKER:$$DOCKER_TAG-$$DEB"; \
+			  TAGS=$$TAGS" --tag $(DOCKER_REPO)$$DOCKER:$$DOCKER_TAG-$$DEB"; \
 			done; \
 			FIRST_ENV=$$(echo $(BUILD_ENV) | awk '{print $$1;}'); \
 			if [ $$FIRST_ENV = $$ENV ]; then \
 				for DOCKER_TAG in $(DOCKER_TAGS); do \
-				  TAGS=$$TAGS" --tag $(DOCKER_REPO)/$$DOCKER:$$DOCKER_TAG"; \
+				  TAGS=$$TAGS" --tag $(DOCKER_REPO)$$DOCKER:$$DOCKER_TAG"; \
 				done; \
-				TAGS=$$TAGS" --tag $(DOCKER_REPO)/$$DOCKER:latest"; \
+				TAGS=$$TAGS" --tag $(DOCKER_REPO)$$DOCKER:latest"; \
 			fi; \
 			echo "docker build $(DOCKER_BUILD_ARGS) $$ARG_DEB $$ARG_RST $$TAGS -f docker/$$DOCKER/Dockerfile ."; \
 			docker build $(DOCKER_BUILD_ARGS) $$ARG_DEB $$ARG_RST $$TAGS -f docker/$$DOCKER/Dockerfile . ; \
@@ -81,18 +81,19 @@ do-push:
 			SPL=$${ENV/:/ }; \
 			DEB=$$(echo $$SPL | awk '{print $$1;}'); \
 			for DOCKER_TAG in $(DOCKER_TAGS); do \
-			  docker push $(DOCKER_REPO)/$$DOCKER:$$DOCKER_TAG-$$DEB; \
+			  docker push $(DOCKER_REPO)$$DOCKER:$$DOCKER_TAG-$$DEB; \
 			done; \
 			FIRST_ENV=$$(echo $(BUILD_ENV) | awk '{print $$1;}'); \
 			if [ $$FIRST_ENV = $$ENV ]; then \
 				for DOCKER_TAG in $(DOCKER_TAGS); do \
-				docker push $(DOCKER_REPO)/$$DOCKER:$$DOCKER_TAG; \
+				docker push $(DOCKER_REPO)$$DOCKER:$$DOCKER_TAG; \
 				done; \
-				docker push $(DOCKER_REPO)/$$DOCKER:latest; \
+				docker push $(DOCKER_REPO)$$DOCKER:latest; \
 			fi; \
 		done; \
 	done
 
+snapshot: DOCKER_REPO := $(SNAPSHOT_REPO)/
 snapshot: build push
 
 tag-new-release: VERSION := $(shell . $(RELEASE_SUPPORT); nextRelease)
@@ -115,23 +116,23 @@ tag-major-prerelease: VERSION := $(shell . $(RELEASE_SUPPORT); nextMajorPrerelea
 tag-major-prerelease: MSG := new major prerelease
 tag-major-prerelease: tag
 
-new-release: DOCKER_REPO := $(RELEASE_REPO)
+new-release: DOCKER_REPO := $(RELEASE_REPO)/
 new-release: tag-new-release release ## Drop the prerelease suffix and release
 	@echo $(VERSION)
 
-new-prerelease: DOCKER_REPO := $(PRERELEASE_REPO)
+new-prerelease: DOCKER_REPO := $(PRERELEASE_REPO)/
 new-prerelease: tag-new-prerelease release ## Increment the prerelease count and release
 	@echo "version $(VERSION) released on $(DOCKER_REPO)"
 
-patch-prerelease: DOCKER_REPO := $(PRERELEASE_REPO)
+patch-prerelease: DOCKER_REPO := $(PRERELEASE_REPO)/
 patch-prerelease: tag-patch-prerelease release ## Increment the patch version number and release
 	@echo "version $(VERSION) released on $(DOCKER_REPO)"
 
-minor-prerelease: DOCKER_REPO := $(PRERELEASE_REPO)
+minor-prerelease: DOCKER_REPO := $(PRERELEASE_REPO)/
 minor-prerelease: tag-minor-prerelease release ## Increment the minor version number and release
 	@echo "version $(VERSION) released on $(DOCKER_REPO)"
 
-major-prerelease: DOCKER_REPO := $(PRERELEASE_REPO)
+major-prerelease: DOCKER_REPO := $(PRERELEASE_REPO)/
 major-prerelease: tag-major-prerelease release ## Increment the major version number and release
 	@echo "version $(VERSION) released on $(DOCKER_REPO)"
 

--- a/deploy.env
+++ b/deploy.env
@@ -1,5 +1,3 @@
 # The first environment in the following BUILD_ENV variable is the default environment.
 BUILD_ENV=buster:1.47 stretch:1.44.1
 DOCKER_REPO=localhost:5000
-DOCKER_BUILD_CONTEXT=.
-DOCKER_FILE_PATH=docker/Dockerfile

--- a/deploy.env
+++ b/deploy.env
@@ -1,3 +1,5 @@
 # The first environment in the following BUILD_ENV variable is the default environment.
 BUILD_ENV=buster:1.47 stretch:1.44.1
-DOCKER_REPO=localhost:5000
+SNAPSHOT_REPO=localhost:5000
+PRERELEASE_REPO=gitlab.brunn.dev:5050/navitia
+RELEASE_REPO=navitia


### PR DESCRIPTION
This is a significant change in the Makefile. It should now support:

* Multiple docker images: Each image is a subdirectory under the docker directory at the root.
* Multiple docker repositories: One for each of the three main target: snapshot, prerelease, and release. These repositories are configured in the deploy.env file, with corresponding variable names: SNAPSHOT_REPO, RELEASE_REPO, ...