### PR TITLE
request-id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,12 +387,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c4ff37a25fb442a1fecfd399be0dde685558bca30fb998420532889a36852d2"
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,17 +500,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
 
 [[package]]
 name = "block-buffer"
@@ -781,12 +764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "copyless"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,7 +817,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "maybe-uninit",
 ]
 
@@ -852,17 +829,6 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.1",
  "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -974,20 +940,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "2.0.2"
+name = "dirs-next"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 0.1.10",
- "dirs-sys",
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.3.5"
+name = "dirs-sys-next"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
@@ -2001,6 +1967,8 @@ dependencies = [
  "slog-async",
  "slog-envlogger",
  "slog-scope",
+ "slog-stdlog",
+ "slog-term",
  "structopt",
  "toml",
  "tools",
@@ -2332,7 +2300,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rustc_version 0.2.3",
  "smallvec 0.6.13",
  "winapi 0.3.9",
@@ -2846,14 +2814,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
-name = "redox_users"
-version = "0.3.5"
+name = "redox_syscall"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
- "getrandom 0.1.15",
- "redox_syscall",
- "rust-argon2",
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.0",
+ "redox_syscall 0.2.5",
 ]
 
 [[package]]
@@ -3040,18 +3016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64 0.13.0",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils 0.8.1",
-]
-
-[[package]]
 name = "rust-ini"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,6 +3054,12 @@ checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
 
 [[package]]
 name = "ryu"
@@ -3390,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "slog-term"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab1d807cf71129b05ce36914e1dbb6fbfbdecaf686301cb457f4fa967f9f5b6"
+checksum = "95c1e7e5aab61ced6006149ea772770b84a0d16ce0f7885def313e4829946d76"
 dependencies = [
  "atty",
  "chrono",
@@ -3434,7 +3404,7 @@ checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
 
@@ -3593,18 +3563,19 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "rand 0.7.3",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "term"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
- "dirs",
+ "dirs-next",
+ "rustversion",
  "winapi 0.3.9",
 ]
 
@@ -3744,7 +3715,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "futures",
 ]
 
@@ -3765,7 +3736,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "futures",
  "lazy_static",
  "log",
@@ -3825,7 +3796,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "futures",
  "slab",
  "tokio-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ slog = { version = "2.5", features = ["max_level_trace", "release_max_level_debu
 slog-scope = "4.3"
 slog-envlogger = "2.2"
 slog-async = "2.5"
+slog-term = "2.8"
+slog-stdlog = "4.1"
 structopt = "0.3"
 csv = "1.1"
 rs-es = { git = "https://github.com/canaltp/rs-es", features = ["geo"], version = "0.12.3"}

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -622,9 +622,7 @@ pub fn autocomplete(
     query_settings: &QuerySettings,
     request_id: Option<&str>,
 ) -> Result<Vec<mimir::Place>, BragiError> {
-    info!("Info id: {:?}", request_id);
-    debug!("Debug id: {:?}", request_id);
-    trace!("Trace id: {:?}", request_id);
+    info!("Request Id: {:?}", request_id);
     // Perform parameters validation.
     if !zone_types.is_empty() && !types.iter().any(|s| *s == "zone") {
         return Err(BragiError::InvalidParam(

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -39,7 +39,7 @@ use rs_es::query::compound::BoostMode;
 use rs_es::query::functions::{DecayOptions, FilteredFunction, Function, Modifier};
 use rs_es::query::Query;
 use rs_es::units as rs_u;
-use slog_scope::{debug, error, info, trace, warn};
+use slog_scope::{debug, error, info, warn};
 use std::{fmt, iter};
 
 lazy_static::lazy_static! {

--- a/libs/bragi/src/query.rs
+++ b/libs/bragi/src/query.rs
@@ -622,7 +622,6 @@ pub fn autocomplete(
     query_settings: &QuerySettings,
     request_id: Option<&str>,
 ) -> Result<Vec<mimir::Place>, BragiError> {
-    info!("Request Id: {:?}", request_id);
     // Perform parameters validation.
     if !zone_types.is_empty() && !types.iter().any(|s| *s == "zone") {
         return Err(BragiError::InvalidParam(

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -853,9 +853,9 @@ impl serde::Serialize for Coord {
     }
 }
 
-impl Into<Geometry> for Coord {
-    fn into(self) -> Geometry {
-        Geometry::new(geojson::Value::Point(vec![self.lon(), self.lat()]))
+impl From<Coord> for Geometry {
+    fn from(coord: Coord) -> Geometry {
+        Geometry::new(geojson::Value::Point(vec![coord.lon(), coord.lat()]))
     }
 }
 
@@ -869,7 +869,7 @@ impl<'de> Deserialize<'de> for Coord {
         enum Field {
             Lon,
             Lat,
-        }
+        };
 
         struct CoordVisitor;
 

--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -869,7 +869,7 @@ impl<'de> Deserialize<'de> for Coord {
         enum Field {
             Lon,
             Lat,
-        };
+        }
 
         struct CoordVisitor;
 

--- a/scripts/autocomplete.sh
+++ b/scripts/autocomplete.sh
@@ -11,6 +11,7 @@ curl_cmd="curl -s --data-urlencode \"q=${query}\""
   [[ ! -z "${input_type}" ]] && curl_cmd="${curl_cmd} --data-urlencode type[]=${input_type}"
 curl_cmd="${curl_cmd} --data-urlencode limit=${limit}"
 curl_cmd="${curl_cmd} --data-urlencode _debug=true"
+curl_cmd="${curl_cmd} --data-urlencode request_id=test"
 curl_cmd="${curl_cmd} --get ${bragi_endpoint}"
 
 #

--- a/src/bin/poi2mimir.rs
+++ b/src/bin/poi2mimir.rs
@@ -38,7 +38,7 @@ use mimirsbrunn::{admin_geofinder::AdminGeoFinder, labels, utils};
 use navitia_poi_model::{Model as NavitiaModel, Poi as NavitiaPoi, PoiType as NavitiaPoiType};
 use std::collections::HashMap;
 use std::ops::Deref;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
 lazy_static! {
@@ -113,7 +113,7 @@ fn import_pois(
     rubber: &mut Rubber,
     index: &TypedIndex<Poi>,
     admins_geofinder: AdminGeoFinder,
-    file: &PathBuf,
+    file: &Path,
 ) -> Result<(), mimirsbrunn::Error>
 where
 {
@@ -147,7 +147,7 @@ where
 fn index_poi(
     cnx_string: &str,
     dataset: &str,
-    file: &PathBuf,
+    file: &Path,
     visibility: IndexVisibility,
     nb_shards: usize,
     nb_replicas: usize,

--- a/src/osm_reader/osm_store.rs
+++ b/src/osm_reader/osm_store.rs
@@ -48,7 +48,7 @@ use slog_scope::error;
 use std::fs;
 
 #[cfg(feature = "db-storage")]
-use std::path::PathBuf;
+use std::path::Path;
 
 #[cfg(feature = "db-storage")]
 use std::collections::HashMap;
@@ -110,14 +110,14 @@ impl Getter for BTreeMap<OsmId, OsmObj> {
 #[cfg(feature = "db-storage")]
 pub struct Db<'a> {
     conn: Connection,
-    db_file: &'a PathBuf,
+    db_file: &'a Path,
     buffer: HashMap<OsmId, OsmObj>,
     db_buffer_size: usize,
 }
 
 #[cfg(feature = "db-storage")]
 impl<'a> Db<'a> {
-    fn new(db_file: &'a PathBuf, db_buffer_size: usize) -> Result<Db<'a>, String> {
+    fn new(db_file: &'a Path, db_buffer_size: usize) -> Result<Db<'a>, String> {
         let _ = fs::remove_file(db_file); // we ignore any potential error
         let conn = Connection::open(&db_file)
             .map_err(|e| format!("failed to open SQLITE connection: {}", e))?;


### PR DESCRIPTION
This PR fixes some lints (clippy), and adds an optional `request_id` parameter, which can be used to trace requests. This probably is a moot issue if we overhaul tracing in a distributed environment with more efficient tools (eg jaeger, ....)