### PR TITLE
Fix docker connectivity

### DIFF
--- a/libs/mimir2/src/adapters/secondary/elasticsearch/mod.rs
+++ b/libs/mimir2/src/adapters/secondary/elasticsearch/mod.rs
@@ -8,7 +8,7 @@ pub mod remote;
 pub mod storage;
 
 #[derive(Clone)]
-pub struct ElasticsearchStorage(Elasticsearch);
+pub struct ElasticsearchStorage(pub Elasticsearch);
 
 #[cfg(test)]
 pub mod tests {

--- a/libs/mimir2/src/adapters/secondary/elasticsearch/mod.rs
+++ b/libs/mimir2/src/adapters/secondary/elasticsearch/mod.rs
@@ -7,8 +7,11 @@ pub mod query;
 pub mod remote;
 pub mod storage;
 
+// The inner type is visible within the crate so that the
+// docker can access directly the Elasticsearch API to test
+// the elasticsearch connectivity.
 #[derive(Clone)]
-pub struct ElasticsearchStorage(pub Elasticsearch);
+pub struct ElasticsearchStorage(pub(crate) Elasticsearch);
 
 #[cfg(test)]
 pub mod tests {

--- a/libs/mimir2/src/utils/docker.rs
+++ b/libs/mimir2/src/utils/docker.rs
@@ -6,11 +6,9 @@ use bollard::{
     Docker,
 };
 use elasticsearch::{
-    http::transport::{
-        BuildError as TransportBuilderError, SingleNodeConnectionPool, TransportBuilder,
-    },
+    http::transport::BuildError as TransportBuilderError,
     indices::{IndicesDeleteAliasParts, IndicesDeleteIndexTemplateParts, IndicesDeleteParts},
-    Elasticsearch, Error as ElasticsearchError,
+    Error as ElasticsearchError,
 };
 use futures::stream::TryStreamExt;
 use lazy_static::lazy_static;
@@ -18,7 +16,6 @@ use snafu::{ResultExt, Snafu};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 use tokio::time::{sleep, Duration};
-use url::Url;
 
 use crate::adapters::secondary::elasticsearch::remote::{self, Error as ElasticsearchRemoteError};
 use crate::domain::ports::secondary::remote::{Error as RemoteError, Remote};

--- a/libs/mimir2/src/utils/docker.rs
+++ b/libs/mimir2/src/utils/docker.rs
@@ -232,7 +232,7 @@ impl DockerWrapper {
             .await
             .context(DockerEngine)?;
 
-        sleep(Duration::from_secs(15)).await;
+        sleep(Duration::from_secs(30)).await;
 
         Ok(())
     }
@@ -268,7 +268,7 @@ impl DockerWrapper {
             .context(ElasticsearchClient)?;
 
         println!("done with cleanup");
-        sleep(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(5)).await;
         Ok(())
     }
 

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -163,12 +163,6 @@ mod tests {
         std::env::var(elasticsearch::remote::ES_TEST_KEY).expect("env var")
     }
 
-    async fn initialize_elasticsearch_docker() -> std::sync::MutexGuard<'static, ()> {
-        let guard = docker::AVAILABLE.lock().unwrap();
-        docker::initialize().await.expect("initialization");
-        guard
-    }
-
     #[tokio::test]
     async fn should_return_an_error_when_given_an_invalid_es_url() {
         let url = String::from("http://example.com:demo");
@@ -213,7 +207,9 @@ mod tests {
 
     #[tokio::test]
     async fn should_return_an_error_when_given_an_invalid_path_for_mappings() {
-        let guard = initialize_elasticsearch_docker().await;
+        let guard = docker::initialize()
+            .await
+            .expect("elasticsearch docker initialization");
 
         let args = Args {
             input: String::from("foo"),
@@ -238,7 +234,9 @@ mod tests {
 
     #[tokio::test]
     async fn should_return_an_error_when_given_an_invalid_mappings() {
-        let guard = initialize_elasticsearch_docker().await;
+        let guard = docker::initialize()
+            .await
+            .expect("elasticsearch docker initialization");
 
         let args = Args {
             input: String::from("foo"),
@@ -263,7 +261,9 @@ mod tests {
 
     #[tokio::test]
     async fn should_return_an_error_when_given_an_invalid_path_for_input() {
-        let guard = initialize_elasticsearch_docker().await;
+        let guard = docker::initialize()
+            .await
+            .expect("elasticsearch docker initialization");
 
         let args = Args {
             input: String::from("./invalid.jsonl.gz"),


### PR DESCRIPTION
Try to detect early if there is a connection problem when starting an elasticsearch docker. This improves the testing situation since we won't get the mutex guard if elasticsearch is not ready.