### PR TITLE
ListDocuments: take document type as parameter and use public error type

### DIFF
--- a/libs/mimir2/src/domain/model/document.rs
+++ b/libs/mimir2/src/domain/model/document.rs
@@ -7,6 +7,11 @@ pub trait Document: serde::Serialize {
     fn id(&self) -> String;
 }
 
+/// A type of document with a schema known at compile time and which can be used to generate an index.
+pub trait ContainerDocument: Document {
+    fn static_doc_type() -> &'static str;
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::Document;

--- a/libs/mimir2/src/domain/model/error.rs
+++ b/libs/mimir2/src/domain/model/error.rs
@@ -1,0 +1,35 @@
+use super::document::ContainerDocument;
+use crate::domain::ports;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to parse {} document: {}", target_type, source))]
+    Deserialization {
+        target_type: &'static str,
+        source: serde_json::Error,
+    },
+    #[snafu(display("Document Retrieval Error: {}", source))]
+    DocumentRetrievalError { source: Box<dyn std::error::Error> },
+}
+
+impl Error {
+    pub fn from_deserialization<T: ContainerDocument>(err: serde_json::Error) -> Self {
+        Self::Deserialization {
+            target_type: T::static_doc_type(),
+            source: err,
+        }
+    }
+}
+
+// Conversion from secondary ports errors
+
+impl From<ports::secondary::list::Error> for Error {
+    fn from(err: ports::secondary::list::Error) -> Self {
+        match err {
+            ports::secondary::list::Error::DocumentRetrievalError { source } => {
+                Self::DocumentRetrievalError { source }
+            }
+        }
+    }
+}

--- a/libs/mimir2/src/domain/model/mod.rs
+++ b/libs/mimir2/src/domain/model/mod.rs
@@ -1,5 +1,6 @@
 pub mod configuration;
 pub mod document;
+pub mod error;
 pub mod explanation;
 pub mod index;
 pub mod query;


### PR DESCRIPTION
* `ListDocuments` becomes `ListDocuments<D>` which returns a `Stream` on the entry type.
* The type parameter `D` must implement `ContainerDocument`
* `list_documents` use a new `domain::model::error::Error` which will be common to all primary ports