### PR TITLE
use pub(crate) for elasticsearch internal

### DIFF
--- a/libs/mimir2/src/adapters/secondary/elasticsearch/configuration.rs
+++ b/libs/mimir2/src/adapters/secondary/elasticsearch/configuration.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use snafu::{ResultExt, Snafu};
+// use std::collections::BTreeMap;
+use std::convert::TryFrom;
+// use std::pin::Pin;
+// use std::sync::{Arc, Mutex};
+// use tracing::{info, warn};
+
+use super::ElasticsearchStorage;
+use crate::domain::model::configuration::{self, Configuration};
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum Error {
+    #[snafu(display("Invalid Elasticsearch Index Configuration: {}", details))]
+    InvalidConfiguration { details: String },
+}
+
+/// The indices create index API has 4 components, which are
+/// reproduced below:
+/// - Path parameter: The index name
+/// - Query parameters: Things like timeout, wait for active shards, ...
+/// - Request body, including
+///   - Aliases (not implemented here)
+///   - Mappings
+///   - Settings
+///   See https://www.elastic.co/guide/en/elasticsearch/reference/7.12/indices-create-index.html
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexConfiguration {
+    pub name: String,
+    pub parameters: IndexParameters,
+    pub settings: IndexSettings,
+    pub mappings: IndexMappings,
+}
+
+// FIXME A lot of work needs to go in there to type everything
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct IndexSettings {
+    pub value: serde_json::Value,
+}
+
+// FIXME A lot of work needs to go in there to type everything
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct IndexMappings {
+    pub value: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename = "snake_case")]
+pub struct IndexParameters {
+    pub timeout: String,
+    pub wait_for_active_shards: String,
+}
+
+impl TryFrom<Configuration> for IndexConfiguration {
+    type Error = Error;
+
+    // FIXME Parameters not handled
+    fn try_from(configuration: Configuration) -> Result<Self, Self::Error> {
+        let Configuration { value, .. } = configuration;
+        serde_json::from_str(&value).map_err(|err| Error::InvalidConfiguration {
+            details: format!(
+                "could not deserialize index configuration: {} / {}",
+                err.to_string(),
+                value
+            ),
+        })
+    }
+}

--- a/libs/mimir2/src/adapters/secondary/elasticsearch/mod.rs
+++ b/libs/mimir2/src/adapters/secondary/elasticsearch/mod.rs
@@ -1,7 +1,8 @@
 use elasticsearch::Elasticsearch;
 
+pub mod configuration;
 pub mod explain;
-pub mod internal;
+pub(crate) mod internal;
 pub mod list;
 pub mod query;
 pub mod remote;

--- a/libs/mimir2/src/adapters/secondary/elasticsearch/storage.rs
+++ b/libs/mimir2/src/adapters/secondary/elasticsearch/storage.rs
@@ -3,6 +3,7 @@ use futures::future::TryFutureExt;
 use futures::stream::Stream;
 use std::convert::TryFrom;
 
+use super::configuration::IndexConfiguration;
 use super::internal;
 use super::ElasticsearchStorage;
 use crate::domain::model::{
@@ -18,7 +19,7 @@ impl Storage for ElasticsearchStorage {
     // This function delegates to elasticsearch the creation of the index. But since this
     // function returns nothing, we follow with a find index to return some details to the caller.
     async fn create_container(&self, config: Configuration) -> Result<Index, StorageError> {
-        let config = internal::IndexConfiguration::try_from(config).map_err(|err| {
+        let config = IndexConfiguration::try_from(config).map_err(|err| {
             StorageError::ContainerCreationError {
                 source: Box::new(err),
             }

--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -4,7 +4,7 @@ use flate2::read::GzDecoder;
 use futures::future;
 use futures::stream::{self, Stream, StreamExt};
 use mimir2::{
-    adapters::secondary::elasticsearch::{internal::IndexConfiguration, ElasticsearchStorage},
+    adapters::secondary::elasticsearch::{configuration::IndexConfiguration, ElasticsearchStorage},
     domain::{
         model::{configuration::Configuration, document::Document, index::IndexVisibility},
         ports::primary::generate_index::GenerateIndex,

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -36,7 +36,7 @@ use cosmogony::{Zone, ZoneIndex};
 use failure::{format_err, Error};
 use futures::stream::{Stream, StreamExt};
 use mimir2::{
-    adapters::secondary::elasticsearch::{internal::IndexConfiguration, ElasticsearchStorage},
+    adapters::secondary::elasticsearch::{configuration::IndexConfiguration, ElasticsearchStorage},
     domain::{
         model::{
             configuration::Configuration,

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -32,7 +32,7 @@ use failure::{format_err, Error};
 use mimir2::{
     adapters::secondary::elasticsearch::{
         self,
-        internal::{IndexConfiguration, IndexMappings, IndexParameters, IndexSettings},
+        configuration::{IndexConfiguration, IndexMappings, IndexParameters, IndexSettings},
     },
     domain::ports::secondary::remote::Remote,
 };
@@ -290,7 +290,9 @@ mod tests {
 
     #[tokio::test]
     async fn should_correctly_index_a_small_cosmogony_file() {
-        let _guard = docker::initialize().await.unwrap();
+        let guard = docker::initialize()
+            .await
+            .expect("elasticsearch docker initialization");
 
         let args = Args {
             input: String::from("./tests/fixtures/cosmogony/bretagne.small.jsonl.gz"),
@@ -322,6 +324,8 @@ mod tests {
             .try_collect()
             .await
             .unwrap();
+
+        drop(guard);
 
         assert!(admins.iter().all(|admin| admin.0.boundary.is_some()));
         assert!(admins.iter().all(|admin| admin.0.coord.is_valid()));

--- a/tests/steps/admin.rs
+++ b/tests/steps/admin.rs
@@ -3,7 +3,7 @@ use mimir2::{
     adapters::primary::bragi::autocomplete::{build_query, Filters},
     adapters::secondary::elasticsearch,
     adapters::secondary::elasticsearch::{
-        internal::{IndexConfiguration, IndexMappings, IndexParameters, IndexSettings},
+        configuration::{IndexConfiguration, IndexMappings, IndexParameters, IndexSettings},
         remote::{connection_test_pool, Error as PoolError},
     },
     domain::model::query::Query,


### PR DESCRIPTION
and spin out the configuration in a different file so that it is
accessible from the client.