### PR TITLE
Primary Ports use model::error

### DIFF
--- a/libs/mimir2/src/domain/model/error.rs
+++ b/libs/mimir2/src/domain/model/error.rs
@@ -1,4 +1,3 @@
-use crate::domain::ports;
 use common::document::ContainerDocument;
 use snafu::Snafu;
 
@@ -11,6 +10,21 @@ pub enum Error {
     },
     #[snafu(display("Document Retrieval Error: {}", source))]
     DocumentRetrievalError { source: Box<dyn std::error::Error> },
+
+    #[snafu(display("Index Creation Error: {}", source))]
+    IndexCreation { source: Box<dyn std::error::Error> },
+
+    #[snafu(display("Index Publication Error: {}", source))]
+    IndexPublication { source: Box<dyn std::error::Error> },
+
+    #[snafu(display("Storage Connection Error: {}", source))]
+    StorageConnection { source: Box<dyn std::error::Error> },
+
+    #[snafu(display("Document Stream Insertion Error: {}", source))]
+    DocumentStreamInsertion { source: Box<dyn std::error::Error> },
+
+    #[snafu(display("Expected Index: {}", index))]
+    ExpectedIndex { index: String },
 }
 
 impl Error {
@@ -18,18 +32,6 @@ impl Error {
         Self::Deserialization {
             target_type: T::static_doc_type(),
             source: err,
-        }
-    }
-}
-
-// Conversion from secondary ports errors
-
-impl From<ports::secondary::list::Error> for Error {
-    fn from(err: ports::secondary::list::Error) -> Self {
-        match err {
-            ports::secondary::list::Error::DocumentRetrievalError { source } => {
-                Self::DocumentRetrievalError { source }
-            }
         }
     }
 }

--- a/libs/mimir2/src/domain/ports/primary/explain_query.rs
+++ b/libs/mimir2/src/domain/ports/primary/explain_query.rs
@@ -1,5 +1,5 @@
-use crate::domain::model::query::Query;
-use crate::domain::ports::secondary::explain::{Error, Explain, Parameters};
+use crate::domain::model::{error::Error as ModelError, query::Query};
+use crate::domain::ports::secondary::explain::{Explain, Parameters};
 use async_trait::async_trait;
 
 #[async_trait]
@@ -11,7 +11,7 @@ pub trait ExplainDocument {
         query: Query,
         id: String,
         doc_type: String,
-    ) -> Result<Self::Document, Error>;
+    ) -> Result<Self::Document, ModelError>;
 }
 
 #[async_trait]
@@ -26,13 +26,15 @@ where
         query: Query,
         id: String,
         doc_type: String,
-    ) -> Result<Self::Document, Error> {
+    ) -> Result<Self::Document, ModelError> {
         let explain_params = Parameters {
             doc_type,
             query,
             id,
         };
 
-        self.explain_document(explain_params).await
+        self.explain_document(explain_params)
+            .await
+            .map_err(|err| ModelError::DocumentRetrievalError { source: err.into() })
     }
 }

--- a/libs/mimir2/src/domain/ports/primary/list_documents.rs
+++ b/libs/mimir2/src/domain/ports/primary/list_documents.rs
@@ -1,4 +1,4 @@
-use crate::domain::model::error::Error;
+use crate::domain::model::error::Error as ModelError;
 use crate::domain::ports::secondary::list::{List, Parameters};
 use async_trait::async_trait;
 use common::document::ContainerDocument;
@@ -10,7 +10,7 @@ type PinnedStream<T> = Pin<Box<dyn Stream<Item = T> + Send + 'static>>;
 
 #[async_trait]
 pub trait ListDocuments<D> {
-    fn list_documents(&self) -> Result<PinnedStream<Result<D, Error>>, Error>;
+    fn list_documents(&self) -> Result<PinnedStream<Result<D, ModelError>>, ModelError>;
 }
 
 impl<D, T> ListDocuments<D> for T
@@ -19,13 +19,13 @@ where
     T: List,
     T::Doc: Into<serde_json::Value>,
 {
-    fn list_documents(&self) -> Result<PinnedStream<Result<D, Error>>, Error> {
+    fn list_documents(&self) -> Result<PinnedStream<Result<D, ModelError>>, ModelError> {
         let doc_type = D::static_doc_type().to_string();
         let raw_documents = self.list_documents(Parameters { doc_type })?;
 
         let documents = raw_documents
             .map(|raw| raw.into())
-            .map(|val| serde_json::from_value(val).map_err(Error::from_deserialization::<D>));
+            .map(|val| serde_json::from_value(val).map_err(ModelError::from_deserialization::<D>));
 
         Ok(Box::pin(documents))
     }

--- a/libs/mimir2/src/domain/ports/primary/search_documents.rs
+++ b/libs/mimir2/src/domain/ports/primary/search_documents.rs
@@ -1,7 +1,8 @@
-use crate::domain::model::query::Query;
-use crate::domain::ports::secondary::search::{Error, Parameters, Search};
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
+
+use crate::domain::model::{error::Error as ModelError, query::Query};
+use crate::domain::ports::secondary::search::{Parameters, Search};
 
 #[async_trait]
 pub trait SearchDocuments {
@@ -11,7 +12,7 @@ pub trait SearchDocuments {
         &self,
         doc_types: Vec<String>,
         query: Query,
-    ) -> Result<Vec<Self::Document>, Error>;
+    ) -> Result<Vec<Self::Document>, ModelError>;
 }
 
 #[async_trait]
@@ -26,7 +27,9 @@ where
         &self,
         doc_types: Vec<String>,
         query: Query,
-    ) -> Result<Vec<Self::Document>, Error> {
-        self.search_documents(Parameters { doc_types, query }).await
+    ) -> Result<Vec<Self::Document>, ModelError> {
+        self.search_documents(Parameters { doc_types, query })
+            .await
+            .map_err(|err| ModelError::DocumentRetrievalError { source: err.into() })
     }
 }

--- a/libs/mimir2/src/domain/ports/secondary/list.rs
+++ b/libs/mimir2/src/domain/ports/secondary/list.rs
@@ -4,6 +4,8 @@ use serde::de::DeserializeOwned;
 use snafu::Snafu;
 use std::pin::Pin;
 
+use crate::domain::model::error::Error as ModelError;
+
 /// This port defines a method to list documents in storage
 #[derive(Debug, Clone)]
 pub struct Parameters {
@@ -24,4 +26,15 @@ pub trait List {
         &self,
         parameters: Parameters,
     ) -> Result<Pin<Box<dyn Stream<Item = Self::Doc> + Send + 'static>>, Error>;
+}
+
+// Conversion from secondary ports errors
+impl From<Error> for ModelError {
+    fn from(err: Error) -> ModelError {
+        match err {
+            Error::DocumentRetrievalError { source } => {
+                ModelError::DocumentRetrievalError { source }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR extends `domain/model/error`, and ensures that all primary ports use this type in their interface. This prevents leaking secondary ports error types to primary interfaces.