### PR TITLE
Restore tests for cosmogony2mimir

### DIFF
--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -363,7 +363,6 @@ mod tests {
             .await
             .expect("Elasticsearch Connection Established");
 
-        // FIXME Maybe should get a Vec<Admin> rather than Vec<AdminDoc>
         let admins: Vec<Admin> = client
             .list_documents()
             .unwrap()


### PR DESCRIPTION
Tests had been commented out while trying to restore Github Actions status. Now that the problem responsible for failing tests has been identified and fixed, we can add those tests.