### PR TITLE
Add poi_type to poi's poi_type

### DIFF
--- a/libs/mimir/src/objects.rs
+++ b/libs/mimir/src/objects.rs
@@ -305,7 +305,7 @@ pub struct PoiType {
 impl From<&navitia_poi_model::PoiType> for PoiType {
     fn from(poi_type: &navitia_poi_model::PoiType) -> PoiType {
         PoiType {
-            id: poi_type.id.clone(),
+            id: normalize_id("poi_type", &poi_type.id.clone()),
             name: poi_type.name.clone(),
         }
     }

--- a/tests/poi2mimir_test.rs
+++ b/tests/poi2mimir_test.rs
@@ -157,6 +157,13 @@ pub fn poi2mimir_sample_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         vec!["Livry-sur-Seine"]
     );
 
+    // We test that the poi_type has been normalized (ie its poi_type id has been prefixed by
+    // 'poi_type'
+    match agence_du_four {
+        mimir::Place::Poi(ref poi) => assert_eq!(poi.poi_type.id, "poi_type:TCL:AGE"),
+        _ => panic!("should have been a poi"),
+    }
+
     // If the POI has a city admin, then its weight is that of the city (or at least != 0.0)
     assert_relative_ne!(
         agence_du_four.poi().unwrap().weight,


### PR DESCRIPTION
POI have a field 'poi_type', and the poi_type has in turn two fields,
'id' and 'name'. This change makes sure that poi_type.id is prefixed
with 'poi_type'.