### PR TITLE
remove trimming of insee code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "bragi"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "docker_wrapper"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "mimir",
  "reqwest",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "mimir"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "address-formatter",
  "chrono",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "mimirsbrunn"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "actix-web",
  "address-formatter",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "1.22.0"
+version = "1.23.0"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -222,7 +222,7 @@ pub fn read_zip_codes(tags: &osmpbfreader::Tags) -> Vec<String> {
 }
 
 pub fn read_insee(tags: &osmpbfreader::Tags) -> Option<&str> {
-    tags.get("ref:INSEE").map(|v| v.trim_start_matches('0'))
+    tags.get("ref:INSEE").map(|v| v.as_str())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Code INSEE must be 5 characters. It is not clear why the code was previously trimmed when it started with zeros.