### PR TITLE
Update elasticsearch test with new configuration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,6 @@ lint: ## Check quality of the code
 
 test: ## Launch all tests
 	ELASTICSEARCH_TEST_URL="${ELASTICSEARCH_TEST_URL}" cargo test --all-targets
+	ELASTICSEARCH_TEST_URL="${ELASTICSEARCH_TEST_URL}" cargo test --package mimir2
+	ELASTICSEARCH_TEST_URL="${ELASTICSEARCH_TEST_URL}" cargo test --package common
+	ELASTICSEARCH_TEST_URL="${ELASTICSEARCH_TEST_URL}" cargo test --package places

--- a/libs/common/src/document.rs
+++ b/libs/common/src/document.rs
@@ -15,7 +15,7 @@ pub trait Document: Serialize {
 pub trait ContainerDocument: Document {
     fn static_doc_type() -> &'static str;
 
-    /// Default configuration for an ElasticSearch container containing given type of document.
+    /// Default configuration for an Elasticsearch container containing given type of document.
     ///
     /// Such a configuration is structured as follows:
     ///  - name: index name (string)

--- a/libs/mimir2/src/adapters/secondary/elasticsearch/configuration.rs
+++ b/libs/mimir2/src/adapters/secondary/elasticsearch/configuration.rs
@@ -45,6 +45,12 @@ impl std::fmt::Display for IndexSettings {
     }
 }
 
+impl IndexSettings {
+    pub fn new(value: serde_json::Value) -> IndexSettings {
+        IndexSettings(value)
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct IndexMappings(serde_json::Value);
 
@@ -54,9 +60,15 @@ impl std::fmt::Display for IndexMappings {
     }
 }
 
+impl IndexMappings {
+    pub fn new(value: serde_json::Value) -> IndexMappings {
+        IndexMappings(value)
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename = "snake_case")]
 pub struct IndexParameters {
-    pub timeout: String,
-    pub wait_for_active_shards: String,
+    pub timeout: String,                // TODO How should we set this value
+    pub wait_for_active_shards: String, // TODO How should we set this value
 }

--- a/libs/mimir2/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir2/src/adapters/secondary/elasticsearch/internal.rs
@@ -36,8 +36,11 @@ static CHUNK_SIZE: usize = 100;
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
-    #[snafu(display("Invalid Elasticsearch Index Configuration: {}", details))]
-    InvalidConfiguration { details: String },
+    #[snafu(display("Invalid Elasticsearch Index Configuration: {} [{}]", source, details))]
+    InvalidConfiguration {
+        details: String,
+        source: config::ConfigError,
+    },
 
     /// Elasticsearch Error
     #[snafu(display("Elasticsearch Error: {} [{}]", source, details))]

--- a/libs/mimir2/src/adapters/secondary/elasticsearch/storage.rs
+++ b/libs/mimir2/src/adapters/secondary/elasticsearch/storage.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use config::Config;
 use futures::future::TryFutureExt;
 use futures::stream::Stream;
+use snafu::ResultExt;
 
 use super::configuration::IndexConfiguration;
 use super::internal;
@@ -15,15 +16,54 @@ use crate::domain::model::{
 use crate::domain::ports::secondary::storage::{Error as StorageError, Storage};
 use common::document::Document;
 
-fn build_config_error(err: impl std::error::Error) -> StorageError {
-    StorageError::ContainerCreationError {
-        source: {
-            internal::Error::ElasticsearchInvalidIndexSettings {
-                reason: err.to_string(),
-            }
-            .into()
-        },
-    }
+fn build_index_configuration(config: Config) -> Result<IndexConfiguration, StorageError> {
+    let container_name = config
+        .get_string("container.name")
+        .context(internal::InvalidConfiguration {
+            details: String::from("could not get key 'container.name' from configuration"),
+        })
+        .map_err(|err| StorageError::ContainerCreationError {
+            source: Box::new(err),
+        })?;
+    let container_dataset = config
+        .get_string("container.dataset")
+        .context(internal::InvalidConfiguration {
+            details: String::from("could not get key 'container.dataset' from configuration"),
+        })
+        .map_err(|err| StorageError::ContainerCreationError {
+            source: Box::new(err),
+        })?;
+    let elasticsearch_name = root_doctype_dataset_ts(&container_name, &container_dataset);
+    let builder = Config::builder()
+        .set_default("elasticsearch.name", elasticsearch_name.clone())
+        .context(internal::InvalidConfiguration {
+            details: format!(
+                "could not set key 'elasticsearch.name' to {}",
+                elasticsearch_name
+            ),
+        })
+        .map_err(|err| StorageError::ContainerCreationError {
+            source: Box::new(err),
+        })?;
+
+    let config = builder
+        .add_source(config)
+        .build()
+        .context(internal::InvalidConfiguration {
+            details: String::from("could not build configuration from builder"),
+        })
+        .map_err(|err| StorageError::ContainerCreationError {
+            source: Box::new(err),
+        })?;
+
+    config
+        .get("elasticsearch")
+        .context(internal::InvalidConfiguration {
+            details: String::from("could not get key 'elasticsearch' from configuration"),
+        })
+        .map_err(|err| StorageError::ContainerCreationError {
+            source: Box::new(err),
+        })
 }
 
 #[async_trait]
@@ -31,25 +71,7 @@ impl Storage for ElasticsearchStorage {
     // This function delegates to elasticsearch the creation of the index. But since this
     // function returns nothing, we follow with a find index to return some details to the caller.
     async fn create_container(&self, config: Config) -> Result<Index, StorageError> {
-        let config = Config::builder()
-            .set_default(
-                "elasticsearch.name",
-                root_doctype_dataset_ts(
-                    &config
-                        .get_string("container.name")
-                        .map_err(build_config_error)?,
-                    &config
-                        .get_string("container.dataset")
-                        .map_err(build_config_error)?,
-                ),
-            )
-            .map_err(build_config_error)?
-            .add_source(config)
-            .build()
-            .map_err(build_config_error)?;
-
-        let config: IndexConfiguration = config.get("elasticsearch").map_err(build_config_error)?;
-
+        let config = build_index_configuration(config)?;
         let name = config.name.clone();
         self.create_index(config)
             .and_then(|_| {

--- a/libs/mimir2/src/domain/model/configuration.rs
+++ b/libs/mimir2/src/domain/model/configuration.rs
@@ -2,6 +2,8 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use snafu::Snafu;
 
+// FIXME The code in this module should probably not be in 'configuration.rs'
+//
 /// Prefix used for all indexes that mimir interacts with.
 pub const INDEX_ROOT: &str = "munin";
 


### PR DESCRIPTION
Update the `make check` command so that it takes into account all the workspaces.

Provide a bit more context in some error cases, especially during the creation of the configuration of an elasticsearch index.

Modify elasticsearch adapter tests to make sure they pass.