### PR TITLE
ES7: add bano2mimir

### DIFF
--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -49,38 +49,6 @@ where
     Ok(())
 }
 
-/* pub async fn import_addresses_from_stream<T, F>(
-    client: ElasticsearchStorage,
-    config: IndexConfiguration,
-    has_headers: bool,
-    nb_threads: usize,
-    streams: impl Iterator<Item = impl AsyncRead + Unpin + Sync + Send + 'static>,
-    into_addr: F,
-) -> Result<(), Error>
-where
-    F: Fn(T) -> Result<Addr, Error> + Send + Sync + Unpin + 'static,
-    T: DeserializeOwned + Send + Sync + 'static,
-{
-
-    let iter = streams
-        .map(|stream| {
-            csv_async::AsyncReaderBuilder::new()
-                .has_headers(has_headers)
-                .create_deserializer(stream)
-                .into_deserialize::<T>()
-        });
-        //.collect::<Vec<_>>();
-
-    let addrs = futures::stream::iter(iter)
-        .flatten()
-        .filter_map(|line| {
-            future::ready(line.map_err(|e| warn!("Impossible to read line, error: {}", e))
-                .ok())
-        });
-
-    import_addresses(client, config, addrs, into_addr).await
-}*/
-
 pub async fn import_addresses_from_reads<T, F>(
     client: ElasticsearchStorage,
     config: Config,

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -209,7 +209,7 @@ async fn run(args: Args) -> Result<(), failure::Error> {
             }
             Err(err) => {
                 warn!("administratives regions not found in es db. {:?}", err);
-                std::iter::empty().collect()
+                Default::default()
             }
         };
         let id_precision = args.id_precision;
@@ -289,10 +289,10 @@ mod tests {
             .expect("elasticsearch docker initialization");
 
         let args = Args {
-            input: Some(PathBuf::from("./tests/fixtures/sample-oa.csv")),
+            input: Some("./tests/fixtures/sample-oa.csv".into()),
             connection_string: elasticsearch_test_url(),
-            mappings: Some(PathBuf::from("./config/addr/mappings.json")),
-            settings: Some(PathBuf::from("./config/addr/settings.json")),
+            mappings: Some("./config/addr/mappings.json".into()),
+            settings: Some("./config/addr/settings.json".into()),
             id_precision: 5,
             nb_threads: 2,
             nb_insert_threads: 2,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,15 +28,19 @@
 // https://groups.google.com/d/forum/navitia
 // www.navitia.io
 
+use crate::logger::logger_init;
 use crate::Error;
 use futures::future::Future;
+use lazy_static::lazy_static;
 use slog_scope::error;
 use std::collections::BTreeMap;
 use std::process::exit;
 use std::sync::Arc;
 use structopt::StructOpt;
 
-use crate::logger::logger_init;
+lazy_static! {
+    pub static ref DEFAULT_NB_THREADS: String = num_cpus::get().to_string();
+}
 
 pub fn get_zip_codes_from_admins(admins: &[Arc<places::admin::Admin>]) -> Vec<String> {
     let level = admins.iter().fold(0, |level, adm| {


### PR DESCRIPTION
This just adds a binary for bano similar to `openaddresses2mimir` which was added in https://github.com/CanalTP/mimirsbrunn/pull/510.

I deduplicated the config loading logic but there is still a lot of similarities between implementations of the importers.