### PR TITLE
Use 'serial_test' to run tests sequentially, remove mutex on docker init

### DIFF
--- a/.github/workflows/create_publish_bragi_docker.yml
+++ b/.github/workflows/create_publish_bragi_docker.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Get branch name
         shell: bash
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
@@ -37,4 +39,5 @@ jobs:
       - name: trig publishing + notifications (the job has successed)
         if: success() && env.BRANCH_NAME == 'release'
         run: |
-          echo '{"text":":information_source: Github Actions: create_publish_bragi_docker for branch ${{ env.BRANCH_NAME }} succeded - New image bragi is available"}' | http --json POST ${{secrets.SLACK_NAVITIA_AUTOCOMPLETE_TEAM_URL}}
+          version=$(make version)
+          echo '{"text":":information_source: Github Actions: create_publish_bragi_docker for branch ${{ env.BRANCH_NAME }} succeded - New image Bragi ' $VERSION 'is available"}' | http --json POST ${{secrets.SLACK_NAVITIA_AUTOCOMPLETE_TEAM_URL}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,12 @@ jobs:
           name: debian-package-release
           path: ./scripts/deb-scratch/*
 
+      - name: Github Release
+        uses: softprops/action-gh-release@v1
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: slack notification (the job has failed)
         if: failure()
         run: |
@@ -56,6 +62,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: package
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - name: install  dependency
         run: |
           sudo apt update
@@ -64,4 +75,5 @@ jobs:
       - name: run publish job & slack notification (the job has successed)
         run: |
           http --ignore-stdin -v -f POST https://${{secrets.JENKINS_TOKEN}}@jenkins-core.canaltp.fr/job/publish_autocomplete_packages/
-          echo '{"text":":information_source: Github Actions: build packages for branch release succeded - New packages mimir are available"}' | http --json POST ${{secrets.SLACK_NAVITIA_AUTOCOMPLETE_TEAM_URL}}
+          version=$(make version)
+          echo '{"text":":information_source: Github Actions: build packages for branch release succeded - New packages mimir ' $VERSION 'is available"}' | http --json POST ${{secrets.SLACK_NAVITIA_AUTOCOMPLETE_TEAM_URL}}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,16 +5,20 @@ on:
   pull_request:
 
 jobs:
-  check:
+  rustfmt:
+    name: Code Validation
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.54.0
-      - name: Validate Code
-        run: make check
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Setup rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.54.0
+    - name: Check formatting
+      run: make format
+    - name: Linting
+      run: make lint
+    - name: Running unit tests and E2E tests
+      run: make test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,252 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-codec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2c11af4b06dc935d8e1b1491dad56bfb32febc49096a91e773f8535c176453"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "log",
- "tokio-codec",
- "tokio-io",
-]
-
-[[package]]
-name = "actix-connect"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fade9bd4bb46bacde89f1e726c7a3dd230536092712f5d94d77ca57c087fca0"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "derive_more",
- "either",
- "futures 0.1.31",
- "http 0.1.21",
- "log",
- "tokio-current-thread",
- "tokio-tcp",
- "trust-dns-resolver",
-]
-
-[[package]]
-name = "actix-http"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb50f77cd28240d344fd54afd205bae8760a3b0ad448b1716a2aa31e24db139"
-dependencies = [
- "actix-codec",
- "actix-connect",
- "actix-server-config",
- "actix-service",
- "actix-threadpool",
- "actix-utils",
- "base64 0.10.1",
- "bitflags",
- "brotli2",
- "bytes 0.4.12",
- "chrono",
- "copyless",
- "derive_more",
- "either",
- "encoding_rs",
- "failure",
- "flate2",
- "futures 0.1.31",
- "h2 0.1.26",
- "hashbrown 0.6.3",
- "http 0.1.21",
- "httparse",
- "indexmap",
- "language-tags",
- "lazy_static",
- "log",
- "mime",
- "percent-encoding 2.1.0",
- "rand 0.7.3",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded 0.6.1",
- "sha1",
- "slab",
- "time",
- "tokio-current-thread",
- "tokio-tcp",
- "tokio-timer",
- "trust-dns-resolver",
-]
-
-[[package]]
-name = "actix-router"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23224bb527e204261d0291102cb9b52713084def67d94f7874923baefe04ccf7"
-dependencies = [
- "bytes 0.4.12",
- "http 0.1.21",
- "log",
- "regex",
- "serde",
- "string",
-]
-
-[[package]]
-name = "actix-rt"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c9da1d06603d82ec2b6690fc5b80eb626cd2d6b573f3d9a71d5252e06d098e"
-dependencies = [
- "actix-threadpool",
- "copyless",
- "futures 0.1.31",
- "tokio-current-thread",
- "tokio-executor",
- "tokio-reactor",
- "tokio-timer",
-]
-
-[[package]]
-name = "actix-server"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd626534af8d0a738e5f74901fe603af0445708f91b86a7d763d80df10d562a5"
-dependencies = [
- "actix-rt",
- "actix-server-config",
- "actix-service",
- "futures 0.1.31",
- "log",
- "mio 0.6.23",
- "net2",
- "num_cpus",
- "slab",
- "tokio-io",
- "tokio-reactor",
- "tokio-signal",
- "tokio-tcp",
- "tokio-timer",
-]
-
-[[package]]
-name = "actix-server-config"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483a34989c682d93142bacad6300375bb6ad8002d2e0bb249dbad86128b9ff30"
-dependencies = [
- "futures 0.1.31",
- "tokio-io",
- "tokio-tcp",
-]
-
-[[package]]
-name = "actix-service"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca5b48e928841ff7e7dce1fdb5b0d4582f6b1b976e08f4bac3f640643e0773f"
-dependencies = [
- "futures 0.1.31",
-]
-
-[[package]]
-name = "actix-testing"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af001e97ac6750994824d400a1b7087055aab14317aa012f528d0b2b363f37f1"
-dependencies = [
- "actix-rt",
- "actix-server",
- "actix-server-config",
- "actix-service",
- "futures 0.1.31",
- "log",
- "net2",
- "tokio-reactor",
- "tokio-tcp",
-]
-
-[[package]]
-name = "actix-threadpool"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5ae85d13da7e6fb86b1b7bc83185e0e3bd4cc5f421c887e1803796c034d35d"
-dependencies = [
- "derive_more",
- "futures 0.1.31",
- "lazy_static",
- "log",
- "num_cpus",
- "parking_lot",
- "threadpool",
-]
-
-[[package]]
-name = "actix-utils"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908c3109948f5c37a8b57fd343a37dcad5bb1d90bfd06300ac96b17bbe017b95"
-dependencies = [
- "actix-codec",
- "actix-service",
- "bytes 0.4.12",
- "either",
- "futures 0.1.31",
- "log",
- "tokio-current-thread",
- "tokio-timer",
-]
-
-[[package]]
-name = "actix-web"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a1b967cdbacb903c4b9ae71257a7f098d881b25eb483d0c468b7dac579b03"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-router",
- "actix-rt",
- "actix-server",
- "actix-server-config",
- "actix-service",
- "actix-testing",
- "actix-threadpool",
- "actix-utils",
- "actix-web-codegen",
- "awc",
- "bytes 0.4.12",
- "derive_more",
- "encoding_rs",
- "futures 0.1.31",
- "hashbrown 0.6.3",
- "log",
- "mime",
- "net2",
- "parking_lot",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded 0.6.1",
- "time",
- "url 2.2.2",
-]
-
-[[package]]
-name = "actix-web-codegen"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068a33520e21c1eea89726be4d6b3ce2e6b81046904367e1677287695a043abb"
-dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.77",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,7 +28,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f72bd5c4ebc7f5e8eedd8533311cafd6456c47ce69904e11f9c389573d2a80f"
 dependencies = [
  "enum-map",
- "env_logger 0.6.2",
+ "env_logger",
  "failure",
  "handlebars",
  "include_dir",
@@ -295,15 +49,6 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "ahash"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29661b60bec623f0586702976ff4d0c9942dcb6723161c2df0eea78455cfedfb"
-dependencies = [
- "const-random",
-]
 
 [[package]]
 name = "aho-corasick"
@@ -416,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "2.10.1"
+version = "2.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b2e3ae5916a72f724593dfef3a35cd7b46845730be06f6444acdb9aa693730"
+checksum = "c8a5bb9cdc45035df039132dd466621e6459f9ac378dc2874ded5254f539c616"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -429,7 +174,7 @@ dependencies = [
  "chrono",
  "fnv",
  "futures-util",
- "http 0.2.5",
+ "http",
  "indexmap",
  "mime",
  "multer",
@@ -447,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "2.10.1"
+version = "2.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c25a9c8271c44fab115a6aab82646f3c6748e08a7a5acdcece3fcb93a858467"
+checksum = "99941fdd3b5745f4bd34a3e6b539f6604badd07c15a6a2e915e0e041a09c002e"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -463,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "2.10.1"
+version = "2.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718f05c9b8ad72003014e0b419aeb08ed782b701ac621733a40c526ebf8b9b76"
+checksum = "aee8226c393b6c834665ebaae398fa9936f7c1af48055f55ce7138af6dfc66e3"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -476,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "2.10.1"
+version = "2.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48b298918bb0b642778d3432307d15237e4f1386cecdb2aa5719d84030007c8"
+checksum = "568d658bca34d74d4bd3101ee44a0cfb343337534b1ce8de5e2776f74b999f27"
 dependencies = [
  "bytes 1.1.0",
  "serde",
@@ -487,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-warp"
-version = "2.10.1"
+version = "2.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4c716db291a3736f61e203475f872743b5558fe94121253481edf1242efdc1"
+checksum = "35a03ae24bd2f58ada146d0befc782f037e94c951bb81451a01085f0bba58ac9"
 dependencies = [
  "async-graphql",
  "futures-util",
@@ -542,38 +287,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "awc"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e995283278dd3bf0449e7534e77184adb1570c0de8b6a50bf7c9d01ad8db8c4"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-service",
- "base64 0.10.1",
- "bytes 0.4.12",
- "derive_more",
- "futures 0.1.31",
- "log",
- "mime",
- "percent-encoding 2.1.0",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_urlencoded 0.6.1",
- "tokio-timer",
-]
 
 [[package]]
 name = "backtrace"
@@ -588,15 +304,6 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
-]
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -683,7 +390,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 0.2.5",
+ "http",
  "hyper 0.14.13",
  "hyper-unix-connector",
  "log",
@@ -691,11 +398,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_urlencoded 0.7.0",
+ "serde_urlencoded",
  "thiserror",
  "tokio 1.12.0",
  "tokio-util 0.6.8",
- "url 2.2.2",
+ "url",
  "winapi 0.3.9",
 ]
 
@@ -708,26 +415,6 @@ dependencies = [
  "chrono",
  "serde",
  "serde_with",
-]
-
-[[package]]
-name = "brotli-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "brotli2"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
-dependencies = [
- "brotli-sys",
- "libc",
 ]
 
 [[package]]
@@ -884,15 +571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "common"
 version = "0.1.0"
 dependencies = [
@@ -912,34 +590,6 @@ dependencies = [
  "serde_json",
  "toml",
 ]
-
-[[package]]
-name = "const-random"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f590d95d011aa80b063ffe3253422ed5aa462af4e9867d43ce8337562bac77c4"
-dependencies = [
- "const-random-macro",
- "proc-macro-hack 0.5.19",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
-dependencies = [
- "getrandom 0.2.3",
- "lazy_static",
- "proc-macro-hack 0.5.19",
- "tiny-keccak",
-]
-
-[[package]]
-name = "copyless"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
 
 [[package]]
 name = "core-foundation"
@@ -1037,7 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1048,7 +698,7 @@ checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1058,21 +708,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "lazy_static",
 ]
 
 [[package]]
@@ -1084,12 +723,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "csv"
@@ -1276,20 +909,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
-dependencies = [
- "lazy_static",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "regex",
- "rustc_version 0.2.3",
- "syn 0.15.44",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,13 +999,13 @@ dependencies = [
  "bytes 1.1.0",
  "dyn-clone",
  "lazy_static",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "reqwest 0.11.4",
  "rustc_version 0.2.3",
  "serde",
  "serde_json",
  "serde_with",
- "url 2.2.2",
+ "url",
  "void",
 ]
 
@@ -1397,17 +1016,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d58266c97445680766be408285e798d3401c6d4c378ec5552e78737e681e37d"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
 ]
 
 [[package]]
@@ -1448,20 +1056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime 2.1.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -1527,7 +1122,6 @@ dependencies = [
  "crc32fast",
  "futures 0.1.31",
  "libc",
- "miniz-sys",
  "miniz_oxide",
  "tokio-io",
 ]
@@ -1569,7 +1163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -1577,12 +1171,6 @@ name = "fragile"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -1676,7 +1264,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "proc-macro-hack 0.5.19",
  "proc-macro2 1.0.29",
  "quote 1.0.9",
@@ -1707,7 +1295,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1940,24 +1528,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
-dependencies = [
- "byteorder",
- "bytes 0.4.12",
- "fnv",
- "futures 0.1.31",
- "http 0.1.21",
- "indexmap",
- "log",
- "slab",
- "string",
- "tokio-io",
-]
-
-[[package]]
-name = "h2"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
@@ -1967,7 +1537,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.5",
+ "http",
  "indexmap",
  "slab",
  "tokio 0.2.25",
@@ -1978,16 +1548,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
+checksum = "3b21b78895ff1ade3f8df6a9a77917f20dc8b46d0069dd5a3837cf1f507a70ee"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.5",
+ "http",
  "indexmap",
  "slab",
  "tokio 1.12.0",
@@ -2037,16 +1607,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
-dependencies = [
- "ahash",
- "autocfg 0.1.7",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -2061,7 +1621,7 @@ dependencies = [
  "bitflags",
  "bytes 1.1.0",
  "headers-core",
- "http 0.2.5",
+ "http",
  "mime",
  "sha-1 0.9.8",
  "time",
@@ -2073,7 +1633,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http 0.2.5",
+ "http",
 ]
 
 [[package]]
@@ -2113,28 +1673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "http"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
-dependencies = [
- "bytes 0.4.12",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,7 +1690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
  "bytes 0.5.6",
- "http 0.2.5",
+ "http",
 ]
 
 [[package]]
@@ -2162,7 +1700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes 1.1.0",
- "http 0.2.5",
+ "http",
  "pin-project-lite 0.2.7",
 ]
 
@@ -2200,12 +1738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,7 +1748,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.2.7",
- "http 0.2.5",
+ "http",
  "http-body 0.3.1",
  "httparse",
  "httpdate 0.3.2",
@@ -2239,8 +1771,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.4",
- "http 0.2.5",
+ "h2 0.3.5",
+ "http",
  "http-body 0.4.3",
  "httparse",
  "httpdate 1.0.1",
@@ -2300,17 +1832,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
@@ -2326,7 +1847,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
 dependencies = [
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
  "globset",
  "lazy_static",
  "log",
@@ -2368,7 +1889,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "hashbrown 0.11.2",
 ]
 
@@ -2382,24 +1903,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "ipconfig"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
-dependencies = [
- "socket2 0.3.19",
- "widestring",
- "winapi 0.3.9",
- "winreg 0.6.2",
 ]
 
 [[package]]
@@ -2473,12 +1991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2521,9 +2033,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -2553,12 +2065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,12 +2078,6 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "md5"
@@ -2597,7 +2097,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -2632,7 +2132,7 @@ dependencies = [
  "elasticsearch",
  "futures 0.3.17",
  "geojson 0.19.0",
- "http 0.2.5",
+ "http",
  "lazy_static",
  "mockall",
  "places",
@@ -2642,6 +2142,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
+ "serial_test",
  "snafu",
  "tokio 1.12.0",
  "toml",
@@ -2650,7 +2151,7 @@ dependencies = [
  "tracing-futures",
  "tracing-log",
  "tracing-subscriber",
- "url 2.2.2",
+ "url",
  "uuid",
  "warp",
 ]
@@ -2659,7 +2160,6 @@ dependencies = [
 name = "mimirsbrunn"
 version = "1.24.0-alpha"
 dependencies = [
- "actix-web",
  "address-formatter",
  "approx 0.5.0",
  "assert_float_eq",
@@ -2676,13 +2176,12 @@ dependencies = [
  "csv-async",
  "cucumber_rust",
  "elasticsearch",
- "env_logger 0.9.0",
  "failure",
  "flate2",
  "futures 0.3.17",
  "geo 0.18.0",
  "geo-types 0.7.2",
- "http 0.2.5",
+ "http",
  "human-sort",
  "itertools 0.9.0",
  "json",
@@ -2702,6 +2201,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serial_test",
  "slog",
  "slog-async",
  "slog-envlogger",
@@ -2721,7 +2221,7 @@ dependencies = [
  "tracing-subscriber",
  "transit_model",
  "typed_index_collection",
- "url 2.2.2",
+ "url",
  "walkdir",
  "warp",
 ]
@@ -2758,23 +2258,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz-sys"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -2807,17 +2297,6 @@ dependencies = [
  "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
 ]
 
 [[package]]
@@ -2877,7 +2356,7 @@ dependencies = [
  "bytes 1.1.0",
  "encoding_rs",
  "futures-util",
- "http 0.2.5",
+ "http",
  "httparse",
  "log",
  "mime",
@@ -2981,7 +2460,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-traits",
 ]
 
@@ -2991,7 +2470,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -3063,7 +2542,7 @@ version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -3124,27 +2603,26 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
+ "instant",
  "lock_api",
  "parking_lot_core",
- "rustc_version 0.2.3",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.6.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
+ "cfg-if 1.0.0",
+ "instant",
  "libc",
- "redox_syscall 0.1.57",
- "rustc_version 0.2.3",
- "smallvec 0.6.14",
+ "redox_syscall",
+ "smallvec",
  "winapi 0.3.9",
 ]
 
@@ -3159,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "pathdiff"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pdqselect"
@@ -3195,12 +2673,6 @@ name = "peg-runtime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -3572,25 +3044,6 @@ checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -3616,16 +3069,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
@@ -3643,21 +3086,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3679,15 +3107,6 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
@@ -3705,65 +3124,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "rayon"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -3777,25 +3143,10 @@ checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -3813,7 +3164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.3",
- "redox_syscall 0.2.10",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3884,7 +3235,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http 0.2.5",
+ "http",
  "http-body 0.3.1",
  "hyper 0.13.10",
  "hyper-tls 0.4.3",
@@ -3895,17 +3246,17 @@ dependencies = [
  "mime",
  "mime_guess",
  "native-tls",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite 0.2.7",
  "serde",
- "serde_urlencoded 0.7.0",
+ "serde_urlencoded",
  "tokio 0.2.25",
  "tokio-tls",
- "url 2.2.2",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.7.0",
+ "winreg",
 ]
 
 [[package]]
@@ -3920,7 +3271,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http 0.2.5",
+ "http",
  "http-body 0.4.3",
  "hyper 0.14.13",
  "hyper-tls 0.5.0",
@@ -3930,29 +3281,19 @@ dependencies = [
  "log",
  "mime",
  "native-tls",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite 0.2.7",
  "serde",
  "serde_json",
- "serde_urlencoded 0.7.0",
+ "serde_urlencoded",
  "tokio 1.12.0",
  "tokio-native-tls",
  "tokio-util 0.6.8",
- "url 2.2.2",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.7.0",
-]
-
-[[package]]
-name = "resolv-conf"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
-dependencies = [
- "hostname",
- "quick-error",
+ "winreg",
 ]
 
 [[package]]
@@ -3987,7 +3328,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -3999,7 +3340,7 @@ dependencies = [
  "heapless",
  "num-traits",
  "pdqselect",
- "smallvec 1.6.1",
+ "smallvec",
 ]
 
 [[package]]
@@ -4014,7 +3355,7 @@ dependencies = [
  "libsqlite3-sys",
  "lru-cache",
  "memchr",
- "smallvec 1.6.1",
+ "smallvec",
  "time",
 ]
 
@@ -4209,21 +3550,9 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a72808528a89fa9eca23bbb6a1eb92cb639b881357269b6510f11e50c0f8a9"
 dependencies = [
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
-dependencies = [
- "dtoa",
- "itoa",
- "serde",
- "url 2.2.2",
 ]
 
 [[package]]
@@ -4274,6 +3603,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+dependencies = [
+ "proc-macro2 1.0.29",
+ "quote 1.0.9",
+ "syn 1.0.77",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4297,12 +3648,6 @@ dependencies = [
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
-
-[[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sharded-slab"
@@ -4429,18 +3774,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.14"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "smartstring"
@@ -4519,15 +3855,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "string"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
-dependencies = [
- "bytes 0.4.12",
-]
 
 [[package]]
 name = "strsim"
@@ -4669,7 +3996,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.4",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -4753,15 +4080,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4769,15 +4087,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -4829,7 +4138,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "bytes 1.1.0",
  "libc",
  "memchr",
@@ -4840,37 +4149,6 @@ dependencies = [
  "signal-hook-registry",
  "tokio-macros",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio-codec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "tokio-io",
-]
-
-[[package]]
-name = "tokio-current-thread"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
-dependencies = [
- "futures 0.1.31",
- "tokio-executor",
-]
-
-[[package]]
-name = "tokio-executor"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
 ]
 
 [[package]]
@@ -4886,9 +4164,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
 dependencies = [
  "proc-macro2 1.0.29",
  "quote 1.0.9",
@@ -4906,42 +4184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-reactor"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
- "lazy_static",
- "log",
- "mio 0.6.23",
- "num_cpus",
- "parking_lot",
- "slab",
- "tokio-executor",
- "tokio-io",
- "tokio-sync",
-]
-
-[[package]]
-name = "tokio-signal"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c34c6e548f101053321cba3da7cbb87a610b85555884c41b07da2eb91aff12"
-dependencies = [
- "futures 0.1.31",
- "libc",
- "mio 0.6.23",
- "mio-uds",
- "signal-hook-registry",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4950,42 +4192,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.7",
  "tokio 1.12.0",
-]
-
-[[package]]
-name = "tokio-sync"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
-dependencies = [
- "fnv",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-tcp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "iovec",
- "mio 0.6.23",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-timer"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
- "slab",
- "tokio-executor",
 ]
 
 [[package]]
@@ -5009,21 +4215,6 @@ dependencies = [
  "pin-project 1.0.8",
  "tokio 1.12.0",
  "tungstenite",
-]
-
-[[package]]
-name = "tokio-udp"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "log",
- "mio 0.6.23",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
 ]
 
 [[package]]
@@ -5177,7 +4368,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.6.1",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -5228,50 +4419,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5559ebdf6c2368ddd11e20b11d6bbaf9e46deb803acd7815e93f5a7b4a6d2901"
-dependencies = [
- "byteorder",
- "enum-as-inner",
- "failure",
- "futures 0.1.31",
- "idna 0.1.5",
- "lazy_static",
- "log",
- "rand 0.6.5",
- "smallvec 0.6.14",
- "socket2 0.3.19",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "tokio-tcp",
- "tokio-timer",
- "tokio-udp",
- "url 1.7.2",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9992e58dba365798803c0b91018ff6c8d3fc77e06977c4539af2a6bfe0a039"
-dependencies = [
- "cfg-if 0.1.10",
- "failure",
- "futures 0.1.31",
- "ipconfig",
- "lazy_static",
- "log",
- "lru-cache",
- "resolv-conf",
- "smallvec 0.6.14",
- "tokio-executor",
- "trust-dns-proto",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5286,13 +4433,13 @@ dependencies = [
  "base64 0.13.0",
  "byteorder",
  "bytes 1.1.0",
- "http 0.2.5",
+ "http",
  "httparse",
  "input_buffer",
  "log",
  "rand 0.8.4",
  "sha-1 0.9.8",
- "url 2.2.2",
+ "url",
  "utf-8",
 ]
 
@@ -5418,25 +4565,14 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.3",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -5509,18 +4645,18 @@ dependencies = [
  "bytes 1.1.0",
  "futures 0.3.17",
  "headers",
- "http 0.2.5",
+ "http",
  "hyper 0.14.13",
  "log",
  "mime",
  "mime_guess",
  "multipart",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project 1.0.8",
  "scoped-tls",
  "serde",
  "serde_json",
- "serde_urlencoded 0.7.0",
+ "serde_urlencoded",
  "tokio 1.12.0",
  "tokio-stream",
  "tokio-tungstenite",
@@ -5620,12 +4756,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
-
-[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5667,15 +4797,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winreg"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
-dependencies = [
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,6 +1873,28 @@ name = "gimli"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+
+[[package]]
+name = "git-version"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack 0.5.19",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
+dependencies = [
+ "proc-macro-hack 0.5.19",
+ "proc-macro2 1.0.29",
+ "quote 1.0.9",
+ "syn 1.0.77",
+]
 
 [[package]]
 name = "glob"
@@ -2459,9 +2487,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2614,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "mimirsbrunn"
-version = "1.21.0"
+version = "1.24.0-alpha"
 dependencies = [
  "actix-web",
  "address-formatter",
@@ -3353,13 +3381,13 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "0.6.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term 0.12.1",
  "ctor",
- "difference",
+ "diff",
  "output_vt100",
 ]
 
@@ -3490,9 +3518,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.18.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc440ee4802a86e357165021e3e255a9143724da31db1e2ea540214c96a0f82"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
 dependencies = [
  "memchr",
 ]
@@ -3801,9 +3829,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "relational_types"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f42a0be51124aebb7e902f9008b65f97e9c9725c046e1b8ec5ce10040b1176f"
+checksum = "55826fbb774caf0f5c7d295c3af2b964243a8350982b4794d9ab3872784d455f"
 dependencies = [
  "derivative 1.0.4",
  "relational_types_procmacro",
@@ -3813,9 +3841,9 @@ dependencies = [
 
 [[package]]
 name = "relational_types_procmacro"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23fd701d2ac20a49020ebe475714e9828d1e10aabb7f7efbe43b982f209b91b"
+checksum = "d01be4cee22c1c7f209f5a0e0959c5ca25f609e94baa69fd4ed311096f88128e"
 dependencies = [
  "quote 0.3.15",
  "syn 0.11.11",
@@ -5133,16 +5161,17 @@ dependencies = [
 
 [[package]]
 name = "transit_model"
-version = "0.31.4"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f6c4c427a6d15197144edff4cfc9a19b03152778a2b93068f8e27a1e23e918"
+checksum = "785121862e0aac9559fb25b79a8b1e50f59b3db09c686f11a825823242fdff65"
 dependencies = [
  "chrono",
  "chrono-tz",
  "csv",
  "derivative 2.2.0",
  "failure",
- "geo 0.14.2",
+ "geo 0.18.0",
+ "git-version",
  "iso4217",
  "lazy_static",
  "log",
@@ -5152,13 +5181,14 @@ dependencies = [
  "minidom_writer",
  "num-traits",
  "pretty_assertions",
- "quick-xml 0.18.1",
+ "quick-xml 0.22.0",
  "relational_types",
  "rust_decimal",
  "serde",
  "serde_json",
  "skip_error",
  "tempfile",
+ "thiserror",
  "typed_index_collection",
  "walkdir",
  "wkt",
@@ -5272,9 +5302,9 @@ dependencies = [
 
 [[package]]
 name = "typed_index_collection"
-version = "1.2.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee45ec878881768c4133c4ced0bb9be705a6eb502152de326ecf7de9c78504d"
+checksum = "d5582dddcdd96aa61797b2c85da0244f4e4d9974ed0f5fe846e1c81be1127b3e"
 dependencies = [
  "derivative 2.2.0",
  "log",
@@ -5632,12 +5662,13 @@ dependencies = [
 
 [[package]]
 name = "wkt"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5f08ce23c6e6a296762b8f4d8beadeae1f58e8184226197818db8885d458e6"
+checksum = "a3cb4f61f748cb9de30eef5508a212c6edf9c0926847247fcad7ec969907112a"
 dependencies = [
- "geo-types 0.6.2",
+ "geo-types 0.7.2",
  "num-traits",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
  "failure",
  "flate2",
  "geo-types 0.7.2",
- "geojson",
+ "geojson 0.22.2",
  "log",
  "osmpbfreader",
  "serde",
@@ -1809,6 +1809,18 @@ dependencies = [
 
 [[package]]
 name = "geojson"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da98686bca3298df46f3957c78166cfbf0fa399e9efcdac0cb7ff2cfed1fd2ab"
+dependencies = [
+ "geo-types 0.6.2",
+ "num-traits",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "geojson"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c209e446d28d9142fb23127808bef2a1485924e7b42cd8c9407ea7cbfe09ccc"
@@ -2615,9 +2627,11 @@ dependencies = [
  "chrono",
  "common",
  "config",
+ "cosmogony",
  "criterion",
  "elasticsearch",
  "futures 0.3.17",
+ "geojson 0.19.0",
  "http 0.2.5",
  "lazy_static",
  "mockall",
@@ -2627,6 +2641,7 @@ dependencies = [
  "semver 1.0.4",
  "serde",
  "serde_json",
+ "serde_qs",
  "snafu",
  "tokio 1.12.0",
  "toml",
@@ -3308,7 +3323,7 @@ dependencies = [
  "config",
  "cosmogony",
  "geo-types 0.7.2",
- "geojson",
+ "geojson 0.22.2",
  "navitia-poi-model",
  "serde",
  "tracing",
@@ -3966,7 +3981,7 @@ name = "rs-es"
 version = "0.12.3"
 source = "git+https://github.com/canaltp/rs-es#d379033daa600b51c0f91bcf23f2c5fefdb5dddb"
 dependencies = [
- "geojson",
+ "geojson 0.22.2",
  "log",
  "reqwest 0.10.10",
  "serde",
@@ -4186,6 +4201,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a72808528a89fa9eca23bbb6a1eb92cb639b881357269b6510f11e50c0f8a9"
+dependencies = [
+ "percent-encoding 2.1.0",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mimirsbrunn"
-version = "1.21.0"
+version = "1.24.0-alpha"
 authors = ["Kisio Digital <team.core@kisio.com>", "Qwant", "Guillaume Pinot <texitoi@texitio.eu>"]
 build = "build.rs"
 autotests = false
@@ -48,8 +48,8 @@ geo = "0.18"
 geo-types = { version = "0.7", features = [ "rstar" ] }
 rstar = "0.8"
 itertools = "0.9"
-transit_model = "0.31.4"
-typed_index_collection = "1.1"
+transit_model = "0.39"
+typed_index_collection = "2.0"
 failure = "0.1"
 cosmogony = "0.10.3"
 par-map = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,13 +93,12 @@ path = "src/lib.rs"
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = [ "blocking", "json" ] }
-env_logger = "*"
 url = "2.2.2"
 approx = "0.5"
-actix-web = "1"
 cucumber = { package = "cucumber_rust", version = "0.9" }
 tokio = { version = "1.6.0", features = [ "rt-multi-thread", "macros", "process" ] }
 elasticsearch = "7.12.0-alpha.1"
+serial_test = "0.5.1"
 
 [build-dependencies]
 json = "0.12"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL=/bin/bash
 # Configuration
 .PHONY: check docker-build-bragi-release docker-build-bragi-master dockerhub-login push-bragi-image-master push-bragi-image-release wipe-useless-images help
 .DEFAULT_GOAL := help
+ELASTICSEARCH_TEST_URL=http://localhost:9201
 
 check: pre-build ## Runs several tests (alias for pre-build)
 pre-build: fmt lint test

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ SHELL=/bin/bash
 # Configuration
 .PHONY: check docker-build-bragi-release docker-build-bragi-master dockerhub-login push-bragi-image-master push-bragi-image-release wipe-useless-images help
 .DEFAULT_GOAL := help
-ELASTICSEARCH_TEST_URL=http://localhost:9201
 
 check: pre-build ## Runs several tests (alias for pre-build)
 pre-build: fmt lint test
@@ -55,3 +54,7 @@ test: ## Launch all tests
 	ELASTICSEARCH_TEST_URL="${ELASTICSEARCH_TEST_URL}" cargo test --package mimir2
 	ELASTICSEARCH_TEST_URL="${ELASTICSEARCH_TEST_URL}" cargo test --package common
 	ELASTICSEARCH_TEST_URL="${ELASTICSEARCH_TEST_URL}" cargo test --package places
+
+.PHONY: version
+version: ## display version of bragi
+	@echo $(BRAGI_VERSION)

--- a/config/bragi/default.toml
+++ b/config/bragi/default.toml
@@ -10,3 +10,4 @@ version_req = ">=7.13.0"
 [service]
 host = "0.0.0.0"
 port = "5000"
+content_length_limit = 32768 # 32 x 1024

--- a/docs/bragi.md
+++ b/docs/bragi.md
@@ -104,41 +104,63 @@ TODO How to specify negative long lat ?
 
 <table>
 <colgroup>
-<col style="width: 17%" />
-<col style="width: 29%" />
-<col style="width: 28%" />
-<col style="width: 25%" />
+<col style="width: 12%" />
+<col style="width: 18%" />
+<col style="width: 41%" />
+<col style="width: 27%" />
 </colgroup>
+<thead>
+<tr class="header">
+<th>name</th>
+<th>type</th>
+<th>description</th>
+<th>example</th>
+</tr>
+</thead>
 <tbody>
 <tr class="odd">
-<td>name</td>
-<td>type</td>
-<td>description</td>
-<td>example</td>
-</tr>
-<tr class="even">
 <td>q</td>
 <td>string</td>
 <td>query string</td>
-<td>lond</td>
+<td><code>q=lond</code></td>
 </tr>
-<tr class="odd">
+<tr class="even">
 <td>lat</td>
 <td>double (optional)</td>
 <td>latitude. Used to boost results in the vicinity</td>
-<td>45.3456</td>
-</tr>
-<tr class="even">
-<td>lon</td>
-<td>double (optional)</td>
-<td>longitude.</td>
-<td>2.4554</td>
+<td><code>lat=45.3456</code></td>
 </tr>
 <tr class="odd">
+<td>lon</td>
+<td>double (optional)</td>
+<td>longitude. Note that if you specify lat or lon, you must specify the converse.</td>
+<td><code>lon=2.4554</code></td>
+</tr>
+<tr class="even">
 <td>datasets</td>
-<td>strings, comma separated (optional)</td>
-<td>restrics the search to the given datasets. (1)</td>
-<td></td>
+<td>list of strings (optional)</td>
+<td><p>restrics the search to the given datasets.</p>
+<p>Valid datasets values are specified at index time</p>
+<p>See <a href="/docs/concepts.md">dataset</a> for an explanation of datasets.</p></td>
+<td><code>datatasets[]=fr&amp;</code> <code>datasets[]=be</code></td>
+</tr>
+<tr class="odd">
+<td>type</td>
+<td>list of strings (optional)</td>
+<td>restrics the search to the given place types. (2)</td>
+<td><code>type[]=streets&amp;</code> <code>type[]=zone</code></td>
+</tr>
+<tr class="even">
+<td>zone_type</td>
+<td>list of strings (optional)</td>
+<td>restrics the search to the given zone types. (1)</td>
+<td><code>zone_type[]=city&amp;</code> <code>zone_type[]=city_district</code></td>
+</tr>
+<tr class="odd">
+<td>shape_scope</td>
+<td>list of strings</td>
+<td>restrics the shape filter to the types listed in shape_scope.</td>
+<td><code>shape_scope[]=street&amp;</code> <code>shape_scope[]=zone</code></td>
 </tr>
 </tbody>
 </table>

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,52 @@
+*Alphabetical Order*
+
+# Dataset
+
+Dataset are a way to partition the data stored in Elasticsearch
+
+(TODO)
+
+# Poi and Poi Type
+
+# Type
+
+Such a loaded word in computer...
+
+For bragi, the *type* refers to the type of places the user can query. This is
+the list (exhaustive) of valid types:
+
+* **house**: This is an address, that is something like a street number and a street name.
+    Use `type[]=house` for query parameter.
+* **poi**: A point of interest. Use `type[]=poi`.
+* **stop_area**: A public transportation stop, like a bus stop, a train station, ...
+    Use `type[]=public_transportation:stop_area`.
+* **street**: A public way. Note that note all public ways may be indexed (TODO).
+    Use `type[]=street`
+* **zone**: A region, or more precisely an administrative region. Sometimes refered to as *admin*.
+
+For the autocomplete REST endpoint, the user can specify the type of place he is interested in:
+
+`[...]/autocomplete?q=chatelet&type[]=public_transport:stop_area`
+
+will enable the user to only search for stops that are related to `chatelet`. 
+
+Related to [zone and zone types](#zone_and_zone_types) and [poi and poi_types](#poi_and_poi_types)
+
+# Zone and Zone Types
+
+TODO Check validity
+
+Zone and Zone Types are concepts inherited from *cosmogony*. cosmogony is the
+tool used to extract a hierarchy of administrative regions from OSM files. Zone
+is just another word for administrative region. And each zone has a zone type.
+which must be one of
+* suburb,
+* city_district,
+* city,
+* state_district,
+* state,
+* country_region,
+* country,
+* non_administrative,
+
+Note that if you specify `type[]=zone`, then you must specify also the `zone_type[]` list.

--- a/docs/tbl/autocomplete-query-param.md
+++ b/docs/tbl/autocomplete-query-param.md
@@ -1,0 +1,31 @@
++-------------+-------------------+--------------------------------------------+-----------------------------+
+| name        | type              | description                                | example                     |
++=============+===================+============================================+=============================+
+| q           | string            | query string                               | `q=lond`                    |
++-------------+-------------------+--------------------------------------------+-----------------------------+
+| lat         | double (optional) | latitude. Used to boost                    | `lat=45.3456`               |
+|             |                   | results in the vicinity                    |                             |
++-------------+-------------------+--------------------------------------------+-----------------------------+
+| lon         | double (optional) | longitude. Note that if you specify        |                             |
+|             |                   | lat or lon, you must specify the converse. | `lon=2.4554`                |
++-------------+-------------------+--------------------------------------------+-----------------------------+
+| datasets    | list of strings   | restrics the search to                     | `datatasets[]=fr&`          |
+|             | (optional)        | the given datasets.                        | `datasets[]=be`             |
+|             |                   |                                            |                             |
+|             |                   | Valid datasets values are specified        |                             |
+|             |                   | at index time                              |                             |
+|             |                   |                                            |                             |
+|             |                   | See [dataset](/docs/concepts.md) for       |                             |
+|             |                   | an explanation of datasets.                |                             |
++-------------+-------------------+--------------------------------------------+-----------------------------+
+| type        | list of strings   | restrics the search to                     | `type[]=streets&`           |
+|             | (optional)        | the given place types.    (2)              | `type[]=zone`               |
++-------------+-------------------+--------------------------------------------+-----------------------------+
+| zone_type   | list of strings   | restrics the search to                     | `zone_type[]=city&`         |
+|             | (optional)        | the given zone types. (1)                  | `zone_type[]=city_district` |
++-------------+-------------------+--------------------------------------------+-----------------------------+
+| shape_scope | list of strings   | restrics the shape filter to the types     | `shape_scope[]=street&`     |
+|             |                   | listed in shape_scope.                     | `shape_scope[]=zone`        |
++-------------+-------------------+--------------------------------------------+-----------------------------+
+
+

--- a/libs/mimir2/Cargo.toml
+++ b/libs/mimir2/Cargo.toml
@@ -55,6 +55,7 @@ mockall = "0.9.1"
 criterion = { version = "0.3", features = [ "async_tokio" ] }
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
 rand = "0.8"
+serial_test = "0.5.1"
 
 [lib]
 name = "mimir2"

--- a/libs/mimir2/Cargo.toml
+++ b/libs/mimir2/Cargo.toml
@@ -21,8 +21,10 @@ async-trait = "0.1.50"
 bollard = "0.10.1"
 chrono = { version = "0.4", features = [ "serde" ] }
 common = { path = "../common" }
+cosmogony = "0.10.3"
 elasticsearch = "7.12.0-alpha.1"
 futures = "0.3"
+geojson = { version = "0.19", features = ["geo-types"] }
 http = "0.2"
 lazy_static = "1.4"
 places = { path = "../places" }
@@ -30,6 +32,7 @@ regex = "1.5.4"
 semver = "1.0.0"
 serde = { version = "1.0", features = [ "derive", "rc" ] }
 serde_json = "1.0"
+serde_qs = "0.8"
 snafu = { version = "0.6.10", features = [ "futures" ] }
 tokio = { version = "1.6.0", features = [ "sync", "rt-multi-thread", "macros", "process" ] }
 toml = "0.5"

--- a/libs/mimir2/src/adapters/primary/bragi/api/mod.rs
+++ b/libs/mimir2/src/adapters/primary/bragi/api/mod.rs
@@ -1,3 +1,5 @@
+use cosmogony::ZoneType;
+use geojson::{GeoJson, Geometry};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -10,39 +12,32 @@ pub struct ForwardGeocoderQuery {
     pub q: String,
     pub lat: Option<f32>,
     pub lon: Option<f32>,
-    pub shape: Option<String>,
-    pub shape_scope: Option<Vec<String>>, // Here I merge shape and shape_scope together, (and I use str)
+    pub shape_scope: Option<Vec<Type>>,
     pub datasets: Option<Vec<String>>,
-    pub zone_types: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
+    pub types: Option<Vec<Type>>,
+    #[serde(default, rename = "zone_type")]
+    pub zone_types: Option<Vec<ZoneType>>,
     pub poi_types: Option<Vec<String>>,
 }
 
-impl From<ForwardGeocoderQuery> for Filters {
-    fn from(query: ForwardGeocoderQuery) -> Self {
+impl From<(ForwardGeocoderQuery, Option<Geometry>)> for Filters {
+    fn from(query: (ForwardGeocoderQuery, Option<Geometry>)) -> Self {
         Filters {
             // When option_zip_option becomes available: coord: input.lat.zip_with(input.lon, Coord::new),
-            coord: match (query.lat, query.lon) {
+            coord: match (query.0.lat, query.0.lon) {
                 (Some(lat), Some(lon)) => Some(Coord::new(lat, lon)),
                 _ => None,
             },
-            shape: match (query.shape, query.shape_scope) {
-                (Some(shape), Some(shape_scope)) => Some((shape, shape_scope)),
-                _ => None,
-            },
-            datasets: query.datasets,
-            zone_types: query.zone_types,
-            poi_types: query.poi_types,
+            shape: None, // Not implemented yet.... soon!
+            datasets: query.0.datasets,
+            zone_types: query.0.zone_types.map(|zts| {
+                zts.iter()
+                    .map(|zt| serde_json::to_string(zt).unwrap())
+                    .collect()
+            }),
+            poi_types: query.0.poi_types,
         }
-    }
-}
-
-// For the purpose of testing, we want to be able to test a filter which
-// validates input query. In order to do that, ForwardGeocoderQuery must implement
-// warp::Reply
-#[cfg(test)]
-impl warp::Reply for ForwardGeocoderQuery {
-    fn into_response(self) -> warp::reply::Response {
-        warp::reply::Response::new(serde_json::to_string(&self).unwrap().into())
     }
 }
 
@@ -53,14 +48,9 @@ pub struct ReverseGeocoderQuery {
     pub lon: f64,
 }
 
-// For the purpose of testing, we want to be able to test a filter which
-// validates input query. In order to do that, ReverseGeocoderQuery must implement
-// warp::Reply
-#[cfg(test)]
-impl warp::Reply for ReverseGeocoderQuery {
-    fn into_response(self) -> warp::reply::Response {
-        warp::reply::Response::new(serde_json::to_string(&self).unwrap().into())
-    }
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct JsonParam {
+    pub shape: GeoJson,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -115,7 +105,9 @@ pub struct StatusResponseBody {
 #[macro_export]
 macro_rules! forward_geocoder {
     ($cl:expr, $st:expr) => {
-        routes::forward_geocoder()
+        routes::forward_geocoder_get()
+            .or(routes::forward_geocoder_post())
+            .unify()
             .and(routes::with_client($cl))
             .and(routes::with_settings($st))
             .and_then(handlers::forward_geocoder)
@@ -144,3 +136,29 @@ macro_rules! status {
     };
 }
 pub use status;
+
+#[derive(PartialEq, Copy, Clone, Debug, Deserialize, Serialize)]
+pub enum Type {
+    #[serde(rename = "house")]
+    House,
+    #[serde(rename = "poi")]
+    Poi,
+    #[serde(rename = "public_transport:stop_area")]
+    StopArea,
+    #[serde(rename = "street")]
+    Street,
+    #[serde(rename = "zone")]
+    Zone,
+}
+
+impl Type {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Type::House => "house",
+            Type::Poi => "poi",
+            Type::StopArea => "public_transport:stop_area",
+            Type::Street => "street",
+            Type::Zone => "zone",
+        }
+    }
+}

--- a/libs/mimir2/src/adapters/primary/bragi/handlers/mod.rs
+++ b/libs/mimir2/src/adapters/primary/bragi/handlers/mod.rs
@@ -1,3 +1,4 @@
+use geojson::Geometry;
 use serde::Serialize;
 use warp::http::StatusCode;
 use warp::reply::{json, with_status};
@@ -19,6 +20,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub async fn forward_geocoder<S>(
     params: ForwardGeocoderQuery,
+    geometry: Option<Geometry>,
     client: S,
     settings: settings::QuerySettings,
 ) -> Result<impl warp::Reply, warp::Rejection>
@@ -27,7 +29,7 @@ where
     S::Document: Serialize,
 {
     let q = params.q.clone();
-    let filters = filters::Filters::from(params);
+    let filters = filters::Filters::from((params, geometry));
 
     let dsl = dsl::build_query(&q, filters, &["fr"], &settings);
 

--- a/libs/mimir2/src/adapters/primary/bragi/routes/mod.rs
+++ b/libs/mimir2/src/adapters/primary/bragi/routes/mod.rs
@@ -204,8 +204,8 @@ pub async fn validate_geojson_shape(json: JsonParam) -> Result<Option<Geometry>,
     match json.shape {
         GeoJson::Feature(f) => f
             .geometry
-            .ok_or(warp::reject::custom(InvalidPostBody))
-            .map(|g| Some(g)),
+            .ok_or_else(|| warp::reject::custom(InvalidPostBody))
+            .map(Some),
         _ => Err(warp::reject::custom(InvalidPostBody)),
     }
 }
@@ -218,7 +218,7 @@ pub fn reverse_geocoder_query(
 pub async fn report_invalid(rejection: Rejection) -> Result<impl Reply, Infallible> {
     let reply = warp::reply::reply();
 
-    if let Some(_) = rejection.find::<warp::reject::InvalidQuery>() {
+    if rejection.find::<warp::reject::InvalidQuery>().is_some() {
         Ok(warp::reply::with_status(reply, StatusCode::BAD_REQUEST))
     } else if let Some(_invalid_request) = rejection.find::<InvalidRequest>() {
         Ok(warp::reply::with_status(reply, StatusCode::BAD_REQUEST))

--- a/libs/mimir2/src/adapters/primary/bragi/routes/mod.rs
+++ b/libs/mimir2/src/adapters/primary/bragi/routes/mod.rs
@@ -1,7 +1,10 @@
+use geojson::{GeoJson, Geometry};
 use std::convert::Infallible;
 use warp::{http::StatusCode, path, reject::Reject, Filter, Rejection, Reply};
 
-use crate::adapters::primary::bragi::api::{ForwardGeocoderQuery, ReverseGeocoderQuery};
+use crate::adapters::primary::bragi::api::{
+    ForwardGeocoderQuery, JsonParam, ReverseGeocoderQuery, Type,
+};
 use crate::adapters::primary::common::settings::QuerySettings;
 use crate::domain::ports::primary::search_documents::SearchDocuments;
 
@@ -10,14 +13,43 @@ fn path_prefix() -> impl Filter<Extract = (), Error = Rejection> + Clone {
     path!("api" / "v1" / ..).boxed()
 }
 
-/// This function reads the input parameters on a get request, makes a summary validation
-/// of the parameters, and returns them.
-pub fn forward_geocoder(
-) -> impl Filter<Extract = (ForwardGeocoderQuery,), Error = Rejection> + Clone {
+/// This is the entry warp filter for the GET autocomplete endpoint
+///
+/// It validates:
+/// * It is a GET HTTP request
+/// * The path is <prefix> / autocomplete
+/// * It has valid query parameters
+///
+/// If any of these steps fails, this filter rejects the request
+///
+/// If all succeed, it returns
+/// * a `ForwardGeocoderQuery` structure representing input parameters,
+/// * None for the Geometry, since the Geometry can only be obtained from a POST request
+///
+pub fn forward_geocoder_get(
+) -> impl Filter<Extract = (ForwardGeocoderQuery, Option<Geometry>), Error = Rejection> + Clone {
     warp::get()
         .and(path_prefix())
         .and(warp::path("autocomplete"))
         .and(forward_geocoder_query())
+        .and(warp::path::end())
+        .and(warp::any().map(move || None))
+}
+
+/// This is the entry warp filter for the POST autocomplete endpoint
+/// It validates:
+/// * It is a POST HTTP request
+/// * The path is prefix / autocomplete
+/// * It has valid query parameters and the body of the request is a valid shape.
+///
+/// If any of these steps fails, this filter rejects the request
+pub fn forward_geocoder_post(
+) -> impl Filter<Extract = (ForwardGeocoderQuery, Option<Geometry>), Error = Rejection> + Clone {
+    warp::post()
+        .and(path_prefix())
+        .and(warp::path("autocomplete"))
+        .and(forward_geocoder_query())
+        .and(forward_geocoder_body())
 }
 
 /// This function reads the input parameters on a get request, makes a summary validation
@@ -49,20 +81,133 @@ pub fn with_elasticsearch(
     warp::any().map(move || url.clone())
 }
 
+#[derive(Debug, PartialEq)]
+pub enum InvalidRequestReason {
+    CannotDeserialize,
+    EmptyQueryString,
+    InconsistentPoiRequest,
+    InconsistentZoneRequest,
+    InconsistentLatLonRequest,
+}
+
 #[derive(Debug)]
-struct InvalidRequest;
+struct InvalidRequest {
+    pub reason: InvalidRequestReason,
+}
+
 impl Reject for InvalidRequest {}
 
+#[derive(Debug)]
+struct InvalidPostBody;
+impl Reject for InvalidPostBody {}
+
+/// Extract and Validate input parameters from the query
 pub fn forward_geocoder_query(
 ) -> impl Filter<Extract = (ForwardGeocoderQuery,), Error = Rejection> + Copy {
-    warp::filters::query::query().and_then(|query: ForwardGeocoderQuery| async move {
-        // TODO Write actual code to validate the request.
-        if query.q.is_empty() {
-            Err(warp::reject::custom(InvalidRequest))
-        } else {
-            Ok(query)
-        }
-    })
+    // warp::query cannot parse array parameters correctly, so we use serde_qs for that:
+    warp::filters::query::raw()
+        .and_then(|param: String| async move {
+            serde_qs::from_str::<ForwardGeocoderQuery>(&param).map_err(|_| {
+                warp::reject::custom(InvalidRequest {
+                    reason: InvalidRequestReason::CannotDeserialize,
+                })
+            })
+        })
+        .and_then(ensure_query_string_not_empty)
+        .and_then(ensure_poi_type_consistent)
+        .and_then(ensure_zone_type_consistent)
+        .and_then(ensure_lat_lon_consistent)
+}
+
+pub async fn ensure_query_string_not_empty(
+    params: ForwardGeocoderQuery,
+) -> Result<ForwardGeocoderQuery, Rejection> {
+    if params.q.is_empty() {
+        Err(warp::reject::custom(InvalidRequest {
+            reason: InvalidRequestReason::EmptyQueryString,
+        }))
+    } else {
+        Ok(params)
+    }
+}
+
+/// This filter ensures that if the user requests 'poi', then he must specify the list
+/// of poi_types.
+pub async fn ensure_poi_type_consistent(
+    params: ForwardGeocoderQuery,
+) -> Result<ForwardGeocoderQuery, Rejection> {
+    if params
+        .types
+        .as_ref()
+        .map(|types| types.iter().any(|s| *s == Type::Poi))
+        .unwrap_or(false)
+        && params
+            .poi_types
+            .as_ref()
+            .map(|poi_types| poi_types.is_empty())
+            .unwrap_or(true)
+    {
+        Err(warp::reject::custom(InvalidRequest {
+            reason: InvalidRequestReason::InconsistentPoiRequest,
+        }))
+    } else {
+        Ok(params)
+    }
+}
+
+/// This filter ensures that if the user specifies lat or lon,
+/// then he must specify also lon or lat.
+pub async fn ensure_lat_lon_consistent(
+    params: ForwardGeocoderQuery,
+) -> Result<ForwardGeocoderQuery, Rejection> {
+    if params.lat.is_some() ^ params.lon.is_some() {
+        Err(warp::reject::custom(InvalidRequest {
+            reason: InvalidRequestReason::InconsistentLatLonRequest,
+        }))
+    } else {
+        Ok(params)
+    }
+}
+
+/// This filter ensures that if the user requests 'zone', then he must specify the list
+/// of zone_types.
+pub async fn ensure_zone_type_consistent(
+    params: ForwardGeocoderQuery,
+) -> Result<ForwardGeocoderQuery, Rejection> {
+    if params
+        .types
+        .as_ref()
+        .map(|types| types.iter().any(|s| *s == Type::Zone))
+        .unwrap_or(false)
+        && params
+            .zone_types
+            .as_ref()
+            .map(|zone_types| zone_types.is_empty())
+            .unwrap_or(true)
+    {
+        Err(warp::reject::custom(InvalidRequest {
+            reason: InvalidRequestReason::InconsistentZoneRequest,
+        }))
+    } else {
+        Ok(params)
+    }
+}
+
+pub fn forward_geocoder_body(
+) -> impl Filter<Extract = (Option<Geometry>,), Error = Rejection> + Copy {
+    warp::body::content_length_limit(1024 * 32)
+        .and(warp::body::json())
+        .and_then(validate_geojson_shape)
+}
+
+pub async fn validate_geojson_shape(json: JsonParam) -> Result<Option<Geometry>, Rejection> {
+    match json.shape {
+        GeoJson::Feature(f) => f
+            .geometry
+            .ok_or(warp::reject::custom(InvalidPostBody))
+            .map(|g| Some(g)),
+        _ => Err(warp::reject::custom(InvalidPostBody)),
+    }
 }
 
 pub fn reverse_geocoder_query(
@@ -73,7 +218,9 @@ pub fn reverse_geocoder_query(
 pub async fn report_invalid(rejection: Rejection) -> Result<impl Reply, Infallible> {
     let reply = warp::reply::reply();
 
-    if let Some(InvalidRequest) = rejection.find() {
+    if let Some(_) = rejection.find::<warp::reject::InvalidQuery>() {
+        Ok(warp::reply::with_status(reply, StatusCode::BAD_REQUEST))
+    } else if let Some(_invalid_request) = rejection.find::<InvalidRequest>() {
         Ok(warp::reply::with_status(reply, StatusCode::BAD_REQUEST))
     } else {
         // Do better error handling here
@@ -93,60 +240,140 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn should_report_invalid_request_with_empty_query() {
-        let filter = forward_geocoder();
+    async fn should_report_invalid_query_with_no_query() {
+        let filter = forward_geocoder_get();
         let resp = warp::test::request()
             .path("/api/v1/autocomplete")
-            .reply(&filter);
-        assert_eq!(
-            resp.await.status(),
-            warp::http::status::StatusCode::BAD_REQUEST,
+            .filter(&filter)
+            .await;
+        assert!(
+            resp.unwrap_err()
+                .find::<warp::reject::InvalidQuery>()
+                .is_some(),
             "Empty query parameter not allowed"
         );
     }
 
     #[tokio::test]
+    async fn should_report_invalid_request_with_empty_query_string() {
+        let filter = forward_geocoder_get();
+        let resp = warp::test::request()
+            .path("/api/v1/autocomplete?q=")
+            .filter(&filter)
+            .await;
+        assert_eq!(
+            resp.unwrap_err().find::<InvalidRequest>().unwrap().reason,
+            InvalidRequestReason::EmptyQueryString,
+            "Empty query string not allowed"
+        );
+    }
+
+    #[tokio::test]
     async fn should_report_invalid_request_with_invalid_query() {
-        let filter = forward_geocoder();
+        let filter = forward_geocoder_get();
         let resp = warp::test::request()
             .path("/api/v1/autocomplete?place=paris") // place is an unknown key
-            .reply(&filter);
+            .filter(&filter)
+            .await;
         assert_eq!(
-            resp.await.status(),
-            warp::http::status::StatusCode::BAD_REQUEST,
-            "Invalid query parameter not allowed"
+            resp.unwrap_err().find::<InvalidRequest>().unwrap().reason,
+            InvalidRequestReason::CannotDeserialize,
+            "Unknown parameter, cannot deserialize"
         );
     }
 
     #[tokio::test]
-    async fn should_report_valid_request_with_just_query_string() {
-        let filter = forward_geocoder();
+    async fn should_report_invalid_request_with_invalid_type() {
+        let filter = forward_geocoder_get();
+        let resp = warp::test::request()
+            .path("/api/v1/autocomplete?place=paris&type[]=country") // place is an unknown key
+            .filter(&filter)
+            .await;
+        assert_eq!(
+            resp.unwrap_err().find::<InvalidRequest>().unwrap().reason,
+            InvalidRequestReason::CannotDeserialize,
+            "Unknown type, cannot deserialize"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_correctly_extract_query_string() {
+        let filter = forward_geocoder_get();
         let resp = warp::test::request()
             .path("/api/v1/autocomplete?q=paris")
-            .reply(&filter)
+            .filter(&filter)
             .await;
-        assert_eq!(
-            resp.status(),
-            warp::http::status::StatusCode::OK,
-            "Expected Status::OK, Got {}: Error Message: {}",
-            resp.status(),
-            String::from_utf8(resp.body().to_vec()).unwrap()
-        );
+        assert_eq!(resp.unwrap().0.q, String::from("paris"));
     }
 
     #[tokio::test]
-    async fn should_report_valid_reverse() {
-        let filter = reverse_geocoder();
+    async fn should_correctly_extract_types() {
+        let filter = forward_geocoder_get();
         let resp = warp::test::request()
-            .path("/api/v1/reverse?lat=48.85406&lon=2.33027")
-            .reply(&filter)
+            .path("/api/v1/autocomplete?q=paris&type[]=street&type[]=zone&zone_type[]=city")
+            .filter(&filter)
             .await;
-        assert_eq!(
-            resp.status(),
-            warp::http::status::StatusCode::OK,
-            "Expected Status::OK, Got {}: Error Message: {}",
-            resp.status(),
-            String::from_utf8(resp.body().to_vec()).unwrap()
+        assert_eq!(resp.as_ref().unwrap().0.types.as_ref().unwrap().len(), 2);
+        assert!(resp
+            .unwrap()
+            .0
+            .types
+            .unwrap()
+            .iter()
+            .zip([Type::Street, Type::Zone].iter())
+            .all(|(a, b)| *a == *b));
+    }
+
+    // TODO The shape_scope parameter can only be used with a POST request (since that's the only
+    // way of specifying the shape). But to write a test for that case, we'd need to have access
+    // to both the query parameters (ForwardGeocoderQuery) and the body (Option<Geometry>) which
+    // is possible at the handler level...
+
+    #[tokio::test]
+    async fn should_correctly_extract_geojson_shape() {
+        let filter = forward_geocoder_post();
+        let resp = warp::test::request()
+            .method("POST")
+            .path("/api/v1/autocomplete?q=paris")
+            .body(r#"{"shape":{"type":"Feature","properties":{},"geometry":{"type":"Polygon", "coordinates":[[[2.376488, 48.846431],
+        [2.376306, 48.846430],[2.376309, 48.846606],[2.376486, 48.846603], [2.376488, 48.846431]]]}}}"#)
+            .filter(&filter)
+            .await;
+        assert!(resp.unwrap().1.is_some());
+    }
+
+    #[tokio::test]
+    async fn should_report_invalid_shape() {
+        let filter = forward_geocoder_post();
+        let resp = warp::test::request()
+            .method("POST")
+            .path("/api/v1/autocomplete?q=paris")
+            .body(r#"{"shape":{"type":"Feature","properties":{}}}"#)
+            .filter(&filter)
+            .await;
+        assert!(
+            resp.unwrap_err()
+                .find::<warp::filters::body::BodyDeserializeError>()
+                .unwrap()
+                .to_string()
+                .contains("Expected GeoJSON property 'geometry'"),
+            "Invalid GeoJSON shape (missing geometry). cannot deserialize body"
         );
     }
+
+    // #[tokio::test]
+    // async fn should_report_valid_reverse() {
+    //     let filter = reverse_geocoder();
+    //     let resp = warp::test::request()
+    //         .path("/api/v1/reverse?lat=48.85406&lon=2.33027")
+    //         .reply(&filter)
+    //         .await;
+    //     assert_eq!(
+    //         resp.status(),
+    //         warp::http::status::StatusCode::OK,
+    //         "Expected Status::OK, Got {}: Error Message: {}",
+    //         resp.status(),
+    //         String::from_utf8(resp.body().to_vec()).unwrap()
+    //     );
+    // }
 }

--- a/libs/mimir2/src/adapters/secondary/elasticsearch/mod.rs
+++ b/libs/mimir2/src/adapters/secondary/elasticsearch/mod.rs
@@ -27,6 +27,7 @@ pub mod tests {
 
     use config::Config;
     use serde::Serialize;
+    use serial_test::serial;
 
     use super::*;
 
@@ -38,8 +39,9 @@ pub mod tests {
     // In this test we present an invalid configuration (its actually empty) to the
     // create_container function, and expect the error message to be meaningful
     #[tokio::test]
+    #[serial]
     async fn should_return_invalid_configuration() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -54,8 +56,6 @@ pub mod tests {
         let config = Config::builder().build().expect("build empty config");
 
         let res = client.create_container(config).await;
-
-        drop(guard);
 
         assert!(res
             .unwrap_err()
@@ -73,8 +73,9 @@ pub mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_connect_to_elasticsearch() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -85,12 +86,12 @@ pub mod tests {
             .conn(ES_DEFAULT_TIMEOUT, ES_DEFAULT_VERSION_REQ)
             .await
             .expect("Elasticsearch Connection Established");
-        drop(guard);
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_create_index_with_valid_configuration() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
         let pool = remote::connection_test_pool()
@@ -132,13 +133,13 @@ pub mod tests {
             .build()
             .expect("valid configuration");
         let res = client.create_container(config).await;
-        drop(guard);
         assert!(res.is_ok());
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_correctly_report_invalid_configuration() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -181,7 +182,6 @@ pub mod tests {
             .build()
             .expect("valid configuration");
         let res = client.create_container(config).await;
-        drop(guard);
         assert!(res
             .unwrap_err()
             .to_string()
@@ -227,8 +227,9 @@ pub mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_correctly_insert_multiple_documents() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -273,14 +274,14 @@ pub mod tests {
                 documents,
             )
             .await;
-        drop(guard);
 
         assert_eq!(res.expect("insertion stats").created, 6);
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_detect_invalid_elasticsearch_version() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -288,8 +289,6 @@ pub mod tests {
             .await
             .expect("Elasticsearch Connection Pool");
         let client = pool.conn(ES_DEFAULT_TIMEOUT, ">=9.99.99").await;
-
-        drop(guard);
 
         assert!(client
             .unwrap_err()

--- a/libs/places/Cargo.toml
+++ b/libs/places/Cargo.toml
@@ -16,8 +16,8 @@ serde = { version = "1", features = ["rc"]}
 geo-types = "0.7"
 geojson = { version = "0.22", features = ["geo-types"] }
 cosmogony = "0.10"
-transit_model = "0.31.4"
-typed_index_collection = "1.1"
+transit_model = "0.39"
+typed_index_collection = "2.0"
 navitia-poi-model = "0.3"
 common = { path = "../common" }
 

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -155,14 +155,16 @@ mod tests {
     use mimir2::domain::ports::primary::list_documents::ListDocuments;
     use mimir2::{adapters::secondary::elasticsearch::remote, utils::docker};
     use places::addr::Addr;
+    use serial_test::serial;
 
     fn elasticsearch_test_url() -> String {
         std::env::var(elasticsearch::remote::ES_TEST_KEY).expect("env var")
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_correctly_index_bano_file() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -197,8 +199,6 @@ mod tests {
             .try_collect()
             .await
             .unwrap();
-
-        drop(guard);
 
         assert_eq!(addresses.len(), 35);
 

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -90,6 +90,7 @@ async fn index_cosmogony(args: Args) -> Result<(), Error> {
 mod tests {
     use approx::assert_relative_eq;
     use futures::TryStreamExt;
+    use serial_test::serial;
 
     use super::*;
     use common::document::ContainerDocument;
@@ -143,8 +144,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_return_an_error_when_given_an_invalid_path_for_config() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -159,8 +161,6 @@ mod tests {
 
         let res = mimirsbrunn::utils::launch_async_args(index_cosmogony, args).await;
 
-        drop(guard);
-
         assert!(res
             .unwrap_err()
             .to_string()
@@ -168,8 +168,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_return_an_error_when_given_an_invalid_mappings() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -184,14 +185,13 @@ mod tests {
 
         let res = mimirsbrunn::utils::launch_async_args(index_cosmogony, args).await;
 
-        drop(guard);
-
         assert!(dbg!(res.unwrap_err().to_string()).contains("expected value at line 1 column 1"));
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_return_an_error_when_given_an_invalid_path_for_input() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -206,8 +206,6 @@ mod tests {
 
         let res = mimirsbrunn::utils::launch_async_args(index_cosmogony, args).await;
 
-        drop(guard);
-
         assert!(res
             .unwrap_err()
             .to_string()
@@ -215,8 +213,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_return_an_error_when_given_an_invalid_setting_override() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -231,8 +230,6 @@ mod tests {
 
         let res = mimirsbrunn::utils::launch_async_args(index_cosmogony, args).await;
 
-        drop(guard);
-
         assert!(res
             .unwrap_err()
             .to_string()
@@ -240,8 +237,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_correctly_index_a_small_cosmogony_file() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -275,15 +273,14 @@ mod tests {
             .await
             .unwrap();
 
-        drop(guard);
-
         assert!(admins.iter().all(|admin| admin.boundary.is_some()));
         assert!(admins.iter().all(|admin| admin.coord.is_valid()));
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_correctly_index_cosmogony_with_langs() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -314,8 +311,6 @@ mod tests {
             .await
             .unwrap();
 
-        drop(guard);
-
         let brittany = admins.iter().find(|a| a.name == "Bretagne").unwrap();
         assert_eq!(brittany.names.get("fr"), Some("Bretagne"));
         assert_eq!(brittany.names.get("en"), Some("Brittany"));
@@ -323,8 +318,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_index_cosmogony_with_correct_values() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -363,8 +359,6 @@ mod tests {
                 _ => panic!("should only have admins"),
             })
             .collect();
-
-        drop(guard);
 
         let brittany = admins.iter().find(|a| a.name == "Bretagne").unwrap();
         assert_eq!(brittany.id, "admin:osm:relation:102740");

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -280,14 +280,16 @@ mod tests {
     use mimir2::domain::ports::primary::search_documents::SearchDocuments;
     use mimir2::{adapters::secondary::elasticsearch::remote, utils::docker};
     use places::{addr::Addr, Place};
+    use serial_test::serial;
 
     fn elasticsearch_test_url() -> String {
         std::env::var(elasticsearch::remote::ES_TEST_KEY).expect("env var")
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_correctly_index_oa_file() {
-        let guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 
@@ -343,8 +345,6 @@ mod tests {
             .try_collect()
             .await
             .unwrap();
-
-        drop(guard);
 
         assert_eq!(addresses.len(), 11);
 

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -192,6 +192,7 @@ mod tests {
     use mimir2::{adapters::secondary::elasticsearch::remote, utils::docker};
     use mimirsbrunn::admin::index_cosmogony;
     use places::{admin::Admin, street::Street, Place};
+    use serial_test::serial;
     use structopt::StructOpt;
 
     fn elasticsearch_test_url() -> String {
@@ -215,8 +216,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn should_correctly_index_osm_streets_and_pois() {
-        let _guard = docker::initialize()
+        docker::initialize()
             .await
             .expect("elasticsearch docker initialization");
 

--- a/src/bragi/settings.rs
+++ b/src/bragi/settings.rs
@@ -57,8 +57,12 @@ pub struct Elasticsearch {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Service {
+    /// Host on which we expose bragi. Example: 'http://localhost', '0.0.0.0'
     pub host: String,
+    /// Port on which we expose bragi.
     pub port: u16,
+    /// Used on POST request to set an upper limit on the size of the body (in bytes)
+    pub content_length_limit: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/osm_reader/admin.rs
+++ b/src/osm_reader/admin.rs
@@ -222,7 +222,7 @@ pub fn read_zip_codes(tags: &osmpbfreader::Tags) -> Vec<String> {
 }
 
 pub fn read_insee(tags: &osmpbfreader::Tags) -> Option<&str> {
-    tags.get("ref:INSEE").map(|v| v.trim_start_matches('0'))
+    tags.get("ref:INSEE").map(|v| v.as_str())
 }
 
 #[cfg(test)]

--- a/tests/admin.rs
+++ b/tests/admin.rs
@@ -5,6 +5,7 @@ use mimir2::adapters::secondary::elasticsearch::remote::connection_test_pool;
 use mimir2::adapters::secondary::elasticsearch::{ES_DEFAULT_TIMEOUT, ES_DEFAULT_VERSION_REQ};
 use mimir2::domain::ports::secondary::remote::Remote;
 use mimir2::utils::docker;
+use serial_test::serial;
 use std::convert::Infallible;
 
 mod steps;
@@ -31,8 +32,9 @@ impl World for MyWorld {
 }
 
 #[tokio::main]
+#[serial]
 async fn main() {
-    let _guard = docker::initialize()
+    docker::initialize()
         .await
         .expect("elasticsearch docker initialization");
     let pool = connection_test_pool().await.unwrap();

--- a/tests/poi2mimir_test.rs
+++ b/tests/poi2mimir_test.rs
@@ -157,6 +157,13 @@ pub fn poi2mimir_sample_test(es_wrapper: crate::ElasticSearchWrapper<'_>) {
         vec!["Livry-sur-Seine"]
     );
 
+    // We test that the poi_type has been normalized (ie its poi_type id has been prefixed by
+    // 'poi_type'
+    match agence_du_four {
+        mimir::Place::Poi(ref poi) => assert_eq!(poi.poi_type.id, "poi_type:TCL:AGE"),
+        _ => panic!("should have been a poi"),
+    }
+
     // If the POI has a city admin, then its weight is that of the city (or at least != 0.0)
     assert_relative_ne!(
         agence_du_four.poi().unwrap().weight,


### PR DESCRIPTION
`serial-test` is a light-weight dependency that will take in charge the mutex and avoid poisoning on failure.

Tests with `#[serial]` will run sequentially.

It's also possible to use `#[serial(something)]` to define independent sequences:
https://docs.rs/serial_test/0.5.1/serial_test/attr.serial.html
