### PR TITLE
Enable synonym filter

### DIFF
--- a/config/elasticsearch/addr/settings.json
+++ b/config/elasticsearch/addr/settings.json
@@ -55,6 +55,7 @@
                         "filter": [
                             "lowercase",
                             "asciifolding",
+                            "synonym_filter",
                             "prefix_filter"
                         ],
                         "char_filter": []
@@ -65,6 +66,7 @@
                             "lowercase",
                             "asciifolding",
                             "elision_filter",
+                            "synonym_filter",
                             "prefix_filter"
                         ],
                         "char_filter": []

--- a/config/elasticsearch/admin/settings.json
+++ b/config/elasticsearch/admin/settings.json
@@ -55,6 +55,7 @@
                         "filter": [
                             "lowercase",
                             "asciifolding",
+                            "synonym_filter",
                             "prefix_filter"
                         ],
                         "char_filter": []
@@ -65,6 +66,7 @@
                             "lowercase",
                             "asciifolding",
                             "elision_filter",
+                            "synonym_filter",
                             "prefix_filter"
                         ],
                         "char_filter": []

--- a/config/elasticsearch/poi/settings.json
+++ b/config/elasticsearch/poi/settings.json
@@ -55,6 +55,7 @@
                         "filter": [
                             "lowercase",
                             "asciifolding",
+                            "synonym_filter",
                             "prefix_filter"
                         ],
                         "char_filter": []
@@ -65,6 +66,7 @@
                             "lowercase",
                             "asciifolding",
                             "elision_filter",
+                            "synonym_filter",
                             "prefix_filter"
                         ],
                         "char_filter": []

--- a/config/elasticsearch/stop/settings.json
+++ b/config/elasticsearch/stop/settings.json
@@ -55,6 +55,7 @@
                         "filter": [
                             "lowercase",
                             "asciifolding",
+                            "synonym_filter",
                             "prefix_filter"
                         ],
                         "char_filter": []
@@ -65,6 +66,7 @@
                             "lowercase",
                             "asciifolding",
                             "elision_filter",
+                            "synonym_filter",
                             "prefix_filter"
                         ],
                         "char_filter": []

--- a/config/elasticsearch/street/settings.json
+++ b/config/elasticsearch/street/settings.json
@@ -55,6 +55,7 @@
                         "filter": [
                             "lowercase",
                             "asciifolding",
+                            "synonym_filter",
                             "prefix_filter"
                         ],
                         "char_filter": []
@@ -65,6 +66,7 @@
                             "lowercase",
                             "asciifolding",
                             "elision_filter",
+                            "synonym_filter",
                             "prefix_filter"
                         ],
                         "char_filter": []

--- a/features/addresses/limousin.feature
+++ b/features/addresses/limousin.feature
@@ -16,7 +16,7 @@ Feature: Addresses
         Examples:
             | query                           | id                            |
             | 14 Place Allègre, Allassac      | addr:1.475761;45.257879:14    |
-            | 1470 Rue du Puy Grasset         | addr:1.938496;45.093038:1470  |
+            | Rue du Puy Grasset 1470         | addr:1.938496;45.093038:1470  |
             | 32BIS Avenue du Limousin 19230  | addr:1.385946;45.399633:32BIS |
 
     # When using aliases, we should still fetch the query at the top of the
@@ -30,3 +30,5 @@ Feature: Addresses
             | 14 p Allègre, Allassac     | addr:1.475761;45.257879:14    |
             | 1470 r du Puy Grasset      | addr:1.938496;45.093038:1470  |
             | 32BIS av du Limousin 19230 | addr:1.385946;45.399633:32BIS |
+            | 2 rte du chastang          | addr:1.944186;45.092028:2     |
+            | rle bridaine 1042          | addr:1.936327;45.091183:1042  |

--- a/tests/data/bano/limousin.csv
+++ b/tests/data/bano/limousin.csv
@@ -1998,3 +1998,4 @@
 190110073V-1,1,Allée des Marronniers,19230,Arnac-Pompadour,C+O,45.396380,1.380611
 190110073V-3,3,Allée des Marronniers,19230,Arnac-Pompadour,C+O,45.396463,1.380809
 190110073V-5,5,Allée des Marronniers,19230,Arnac-Pompadour,C+O,45.396528,1.380804
+DOES_NOT_EXIST,1042,carle bridaine,19400,Argentat,,45.091184,1.936328


### PR DESCRIPTION
~:warning: this is based on #537 which requires to be merged first. It can still be reviewed on looking at f247ae8 alone.~

Enable synonyms filters in mappings. They were already defined in #529 so there is not much to do :smiley: 