### PR TITLE
enable `serde` feature for `url` in mimir2

### DIFF
--- a/libs/mimir2/Cargo.toml
+++ b/libs/mimir2/Cargo.toml
@@ -43,7 +43,7 @@ tracing-appender = "0.1.2"
 tracing-futures = "0.2.5"
 tracing-log = "0.1.2"
 tracing-subscriber = "0.2.17"
-url = "2.2"
+url = { version = "2.2", features = [ "serde" ] }
 warp = "0.3.1"
 
 [dependencies.config]


### PR DESCRIPTION
This appears to be what is breaking [the CI](https://github.com/CanalTP/mimirsbrunn/runs/4089978246?check_suite_focus=true) in master. It can also be an issue if some project depends on `mimir2`.