### PR TITLE
increase default mimir log level

### DIFF
--- a/src/bragi/server.rs
+++ b/src/bragi/server.rs
@@ -46,8 +46,7 @@ pub async fn run(opts: &Opts) -> Result<(), Error> {
 
     // Filter traces based on the RUST_LOG env var, or, if it's not set,
     // default to show the output of the example.
-    let filter =
-        std::env::var("RUST_LOG").unwrap_or_else(|_| "tracing=info,mimir=debug".to_owned());
+    let filter = std::env::var("RUST_LOG").unwrap_or_else(|_| "tracing=info,mimir=info".to_owned());
 
     // following code mostly from https://betterprogramming.pub/production-grade-logging-in-rust-applications-2c7fffd108a6
     let app_name = concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION")).to_string();

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -20,8 +20,7 @@ pub fn logger_init<P: AsRef<Path>>(
     let path = path.as_ref();
     // Filter traces based on the RUST_LOG env var, or, if it's not set,
     // default to show the output of the example.
-    let filter =
-        std::env::var("RUST_LOG").unwrap_or_else(|_| "tracing=info,mimir=debug".to_owned());
+    let filter = std::env::var("RUST_LOG").unwrap_or_else(|_| "tracing=info,mimir=info".to_owned());
 
     // following code mostly from https://betterprogramming.pub/production-grade-logging-in-rust-applications-2c7fffd108a6
     let app_name = concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION")).to_string();


### PR DESCRIPTION
Currently we have a default RUST_LOG string which includes `mimir=debug`. This is not necessary, and this PR changes that to `mimir=default`