### PR TITLE
allow to index from streams of any lifetime

### DIFF
--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -516,7 +516,7 @@ impl ElasticsearchStorage {
     ) -> Result<InsertStats, Error>
     where
         D: Document + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 'static,
+        S: Stream<Item = D> + Send + Sync,
     {
         let stats = Arc::new(Mutex::new(InsertStats::default()));
 

--- a/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
@@ -58,7 +58,7 @@ impl Storage for ElasticsearchStorage {
     ) -> Result<InsertStats, StorageError>
     where
         D: Document + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 'static,
+        S: Stream<Item = D> + Send + Sync,
     {
         self.add_pipeline(
             String::from(include_str!(

--- a/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
@@ -14,7 +14,7 @@ use crate::domain::ports::secondary::storage::{Error as StorageError, Storage};
 use common::document::Document;
 
 #[async_trait]
-impl Storage for ElasticsearchStorage {
+impl<'s> Storage<'s> for ElasticsearchStorage {
     // This function delegates to elasticsearch the creation of the index. But since this
     // function returns nothing, we follow with a find index to return some details to the caller.
     async fn create_container(&self, config: &ContainerConfig) -> Result<Index, StorageError> {
@@ -58,7 +58,7 @@ impl Storage for ElasticsearchStorage {
     ) -> Result<InsertStats, StorageError>
     where
         D: Document + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync,
+        S: Stream<Item = D> + Send + Sync + 's,
     {
         self.add_pipeline(
             String::from(include_str!(

--- a/libs/mimir/src/domain/ports/primary/configure_backend.rs
+++ b/libs/mimir/src/domain/ports/primary/configure_backend.rs
@@ -11,7 +11,7 @@ pub trait ConfigureBackend {
 #[async_trait]
 impl<T> ConfigureBackend for T
 where
-    T: Storage + Send + Sync + 'static,
+    T: Storage<'static> + Send + Sync + 'static,
 {
     async fn configure(&self, directive: String, config: Config) -> Result<(), ModelError> {
         self.configure(directive, config)

--- a/libs/mimir/src/domain/ports/primary/generate_index.rs
+++ b/libs/mimir/src/domain/ports/primary/generate_index.rs
@@ -10,11 +10,14 @@ use tracing_futures::Instrument;
 
 #[async_trait]
 pub trait GenerateIndex {
-    async fn generate_index<D: ContainerDocument + Send + Sync + 'static>(
+    async fn generate_index<D, S>(
         &self,
         config: &ContainerConfig,
-        documents: impl Stream<Item = D> + Send + Sync + 'static,
-    ) -> Result<Index, ModelError>;
+        documents: S,
+    ) -> Result<Index, ModelError>
+    where
+        D: ContainerDocument + Send + Sync + 'static,
+        S: Stream<Item = D> + Send + Sync;
 }
 
 #[async_trait]
@@ -23,11 +26,15 @@ where
     T: Storage + Send + Sync + 'static,
 {
     #[tracing::instrument(skip(self, config, documents))]
-    async fn generate_index<D: ContainerDocument + Send + Sync + 'static>(
+    async fn generate_index<D, S>(
         &self,
         config: &ContainerConfig,
-        documents: impl Stream<Item = D> + Send + Sync + 'static,
-    ) -> Result<Index, ModelError> {
+        documents: S,
+    ) -> Result<Index, ModelError>
+    where
+        D: ContainerDocument + Send + Sync + 'static,
+        S: Stream<Item = D> + Send + Sync,
+    {
         // 1. We create the index
         // 2. We insert the document stream in that newly created index
         // 3. We publish the index

--- a/libs/mimir/src/domain/ports/primary/generate_index.rs
+++ b/libs/mimir/src/domain/ports/primary/generate_index.rs
@@ -9,7 +9,7 @@ use tracing::{info, info_span};
 use tracing_futures::Instrument;
 
 #[async_trait]
-pub trait GenerateIndex {
+pub trait GenerateIndex<'s> {
     async fn generate_index<D, S>(
         &self,
         config: &ContainerConfig,
@@ -17,13 +17,13 @@ pub trait GenerateIndex {
     ) -> Result<Index, ModelError>
     where
         D: ContainerDocument + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync;
+        S: Stream<Item = D> + Send + Sync + 's;
 }
 
 #[async_trait]
-impl<T> GenerateIndex for T
+impl<'s, T> GenerateIndex<'s> for T
 where
-    T: Storage + Send + Sync + 'static,
+    T: Storage<'s> + Send + Sync + 'static,
 {
     #[tracing::instrument(skip(self, config, documents))]
     async fn generate_index<D, S>(
@@ -33,7 +33,7 @@ where
     ) -> Result<Index, ModelError>
     where
         D: ContainerDocument + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync,
+        S: Stream<Item = D> + Send + Sync + 's,
     {
         // 1. We create the index
         // 2. We insert the document stream in that newly created index

--- a/libs/mimir/src/domain/ports/secondary/storage.rs
+++ b/libs/mimir/src/domain/ports/secondary/storage.rs
@@ -56,7 +56,7 @@ pub trait Storage {
     ) -> Result<InsertStats, Error>
     where
         D: Document + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 'static;
+        S: Stream<Item = D> + Send + Sync;
 
     async fn publish_index(
         &self,
@@ -91,7 +91,7 @@ where
     ) -> Result<InsertStats, Error>
     where
         D: Document + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 'static,
+        S: Stream<Item = D> + Send + Sync,
     {
         (**self).insert_documents(index, documents).await
     }


### PR DESCRIPTION
The constraint was previously enforced by automock, but this is finally not the direction we took for tests.

This relaxing will allow to attach some context to the input stream, an application of this that lead me to this suggestion was the collection of statistics:

```rust
    let mut count_errors = HashMap::new();

    let pois = read_pois(raw_xml, admin_geofinder).filter_map(|poi| {
        future::ready({
            poi.map_err(|err| *count_errors.entry(err).or_insert(0) += 1)
                .ok()
        })
    });

    create_index(
        &mimir_es,
        &raw_config,
        &settings.container_tripadvisor.dataset,
        IndexVisibility::Private,
        pois,
    )
    .await
    .expect("error while indexing POIs");
```

In this example, the stream `pois` only lives as long as `count_errors`, which is not static.