### PR TITLE
ctlmimir: use config/logging for logging.path definition

### DIFF
--- a/config/ctlmimir/default.toml
+++ b/config/ctlmimir/default.toml
@@ -1,2 +1,0 @@
-[logging]
-  path = "./logs"

--- a/config/ctlmimir/testing.toml
+++ b/config/ctlmimir/testing.toml
@@ -1,2 +1,0 @@
-mode = "testing"
-

--- a/src/settings/ctlmimir.rs
+++ b/src/settings/ctlmimir.rs
@@ -83,7 +83,7 @@ impl Settings {
         builder = builder.add_source(
             common::config::config_from(
                 opts.config_dir.as_ref(),
-                &["ctlmimir", "elasticsearch"],
+                &["elasticsearch", "logging"],
                 opts.run_mode.as_deref(),
                 "CTLMIMIR",
                 opts.settings.clone(),
@@ -92,11 +92,11 @@ impl Settings {
         );
 
         let config = builder.build().context(ConfigMerge {
-            msg: String::from("Cannot build the configuration from sources"),
+            msg: "Cannot build the configuration from sources",
         })?;
 
         config.try_into().context(ConfigMerge {
-            msg: String::from("Cannot convert configuration into ctlmimir settings"),
+            msg: "Cannot convert configuration into ctlmimir settings",
         })
     }
 }


### PR DESCRIPTION
`config/ctlmimir` seems redundant with `config/logging`, so I'm not sure we should maintain both.