### PR TITLE
propagate exit code for docker images

### DIFF
--- a/docker/run_with_default_config.sh
+++ b/docker/run_with_default_config.sh
@@ -9,5 +9,9 @@ CMD=$1
 shift
 ARG=$@
 
-export RUST_LOG="tracing=info,mimir2=info"
+# By default, a pipeline's exit code is the exit code of the last command. This
+# will make this script exit with code 1 if $CMD fails, even if bunyan exits
+# with code 0.
+set -o pipefail
+
 $CMD --config-dir /etc/mimirsbrunn --run-mode docker $@ | bunyan


### PR DESCRIPTION
Currently the docker images always exit with code 0, which is the exit code of bunyan. This means that errors would hardly be programmatically detected, eg. during import pipelines.

To reflect mimir's exit code we have to tweak a bit how the pipe is handled, this can be done with a `set -o pipefail` in bash, according to [the documentation](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html):

```
pipefail

    If set, the return value of a pipeline is the value of the last (rightmost) command
    to exit with a non-zero status, or zero if all commands in the pipeline exit successfully.
    This option is disabled by default.
```
