### PR TITLE
address importers rationalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
  "async-graphql-value",
  "async-stream",
  "async-trait",
- "bytes 1.1.0",
+ "bytes",
  "chrono",
  "fnv",
  "futures-util",
@@ -213,7 +213,7 @@ version = "2.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce4f659edaf5ee21fcd21f00aa1f498abd99c2f6cb2fdb972eb9ee07ce204a7"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "serde",
  "serde_json",
 ]
@@ -371,7 +371,7 @@ checksum = "a4a3f238d4b66f33d9162893ade03cd8a485320f591b244ea5b7f236d3494e98"
 dependencies = [
  "base64 0.13.0",
  "bollard-stubs",
- "bytes 1.1.0",
+ "bytes",
  "chrono",
  "dirs-next",
  "futures-core",
@@ -443,16 +443,6 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
 
 [[package]]
 name = "bytes"
@@ -969,7 +959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d853e1c104dbad916425c88e72ac5b73db65bbc22d3b8ab945174e68df91e6f0"
 dependencies = [
  "base64 0.11.0",
- "bytes 1.1.0",
+ "bytes",
  "dyn-clone",
  "lazy_static",
  "percent-encoding",
@@ -1093,10 +1083,8 @@ checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
  "cfg-if",
  "crc32fast",
- "futures 0.1.31",
  "libc",
  "miniz_oxide",
- "tokio-io",
 ]
 
 [[package]]
@@ -1477,7 +1465,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1544,7 +1532,7 @@ checksum = "a4c4eb0471fcb85846d8b0690695ef354f9afb11cb03cac2e1d7c9253351afb0"
 dependencies = [
  "base64 0.13.0",
  "bitflags",
- "bytes 1.1.0",
+ "bytes",
  "headers-core",
  "http",
  "httpdate",
@@ -1603,7 +1591,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -1614,7 +1602,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "http",
  "pin-project-lite",
 ]
@@ -1652,7 +1640,7 @@ version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1676,7 +1664,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "hyper",
  "native-tls",
  "tokio",
@@ -1771,7 +1759,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
 ]
 
 [[package]]
@@ -1781,15 +1769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2027,6 +2006,7 @@ version = "2.0.0-rc1"
 dependencies = [
  "address-formatter",
  "approx 0.5.0",
+ "async-compression",
  "async-trait",
  "bincode",
  "chrono",
@@ -2041,7 +2021,6 @@ dependencies = [
  "cucumber_rust",
  "elasticsearch",
  "failure",
- "flate2",
  "futures 0.3.17",
  "geo 0.18.0",
  "geo-types 0.7.2",
@@ -2181,7 +2160,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "408327e2999b839cd1af003fc01b2019a6c10a1361769542203f6fedc5179680"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "encoding_rs",
  "futures-util",
  "http",
@@ -3045,7 +3024,7 @@ checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
  "async-compression",
  "base64 0.13.0",
- "bytes 1.1.0",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -3778,7 +3757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg",
- "bytes 1.1.0",
+ "bytes",
  "libc",
  "memchr",
  "mio",
@@ -3788,17 +3767,6 @@ dependencies = [
  "signal-hook-registry",
  "tokio-macros",
  "winapi",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "log",
 ]
 
 [[package]]
@@ -3852,7 +3820,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
@@ -4042,7 +4010,7 @@ checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
- "bytes 1.1.0",
+ "bytes",
  "http",
  "httparse",
  "input_buffer",
@@ -4247,7 +4215,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures 0.3.17",
  "headers",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ db-storage = [ "rusqlite" ]
 
 [dependencies]
 address-formatter = "0.2.1"
+async-compression = { version = "0.3.8", features = [ "gzip", "tokio" ] }
 bincode = "1.3.3"
 chrono = "0.4"
 chrono-tz = "0.5"
@@ -33,7 +34,6 @@ cosmogony = "0.10.3"
 csv = "1.1"
 csv-async = {version = "1.2", features = ["tokio", "with_serde"]}
 failure = "0.1"
-flate2 = { version = "1.0", features = [ "tokio" ] }
 futures = "0.3"
 geo = "0.18"
 geo-types = { version = "0.7", features = [ "rstar" ] }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,0 +1,32 @@
+use futures::stream::{Stream, TryStreamExt};
+use std::path::{Path, PathBuf};
+use tokio::fs;
+use tokio::io::Error;
+use tokio_stream::wrappers::ReadDirStream;
+
+/// Walk over all files of an input path. If it is a directory all files from
+/// this directory or subdirectory are yielded, if it is a file, it will be the
+/// only yielded value.
+pub fn walk_files_recursive(
+    path: &Path,
+) -> impl Stream<Item = Result<PathBuf, Error>> + Send + Sync + 'static {
+    let heap = vec![path.to_path_buf()];
+
+    futures::stream::try_unfold(heap, |mut heap| async move {
+        while let Some(curr) = heap.pop() {
+            if curr.is_file() {
+                return Ok(Some((curr, heap)));
+            }
+
+            let sub_dirs: Vec<_> = fs::read_dir(&curr)
+                .await
+                .map(ReadDirStream::new)?
+                .try_collect()
+                .await?;
+
+            heap.extend(sub_dirs.into_iter().map(|dir| dir.path()))
+        }
+
+        Ok(None)
+    })
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,3 @@
+pub mod fs;
 pub mod launch;
 pub mod logger;


### PR DESCRIPTION
I initially just wanted to add extra logs in the address importers which was failing silently, eg. when using an invalid file path, but I think there was a few other issues we wanted to handle.

Here is what changed:

 - added a tracing instrument for each input file, log when there is an issue with deserializing the CSV into a "record" (before calling `into_addr`), log when there is an issue with opening a file
 - de-duplicated addr parsers: there was two separate co-existing implementations, one for bano (close to what was there before async) and one for openaddresses
 - one of the implementations didn't support gzip files, I re-implemented the decoder using `async-compression` (which still uses `flate2` as a back-end)
 - when specifying a directory as input, we will walk recursively instead of just file directly in the input