### PR TITLE
insertion stats don't require an `Arc<Mutex<...>>`

### DIFF
--- a/libs/mimir/src/domain/model/stats.rs
+++ b/libs/mimir/src/domain/model/stats.rs
@@ -2,5 +2,4 @@
 pub struct InsertStats {
     pub created: usize,
     pub updated: usize,
-    pub error: usize,
 }


### PR DESCRIPTION
I initially wanted to showcase #625, but it turns out that the stats that we compute in ES internals are very simple (just two integers), so we could just use a `fold` to collect concurrently computed stats instead of using a mutex.