### PR TITLE
Add no admin check on ntfs index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "transit_model"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61c4f76e7d2256e0497c97448c21753885cdd6e2a999c91492f31fead59a94b"
+checksum = "2aa2252f70b292b39c956fed2331577b4fb192e616d925ec54bd65fd23d5563e"
 dependencies = [
  "chrono",
  "chrono-tz",


### PR DESCRIPTION
Currently indexing stops proceeds even if no admin can be attached.

This PR changes the flow, and if
* admins cannot be listed,
* or if the admin index is empty
then an error is returned