### PR TITLE
default container name for streets should be `street`

### DIFF
--- a/config/osm2mimir/default.toml
+++ b/config/osm2mimir/default.toml
@@ -4,7 +4,7 @@
   visibility = "public"
 
 [container-street]
-  name = "stop"
+  name = "street"
   dataset = "fr"
   visibility = "public"
 


### PR DESCRIPTION
There's just a typo in default configuration, as this is configurable anyway I don't think this requires extending testing.