### PR TITLE
wrap buffers arround file readers

### DIFF
--- a/libs/mimir/src/adapters/primary/common/settings.rs
+++ b/libs/mimir/src/adapters/primary/common/settings.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::path::Path;
-use tokio::io::AsyncReadExt;
+use tokio::fs::File;
+use tokio::io::{AsyncReadExt, BufReader};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -113,11 +114,17 @@ impl QuerySettings {
         P: AsRef<Path>,
     {
         let mut settings_content = String::new();
-        let mut settings_file = tokio::fs::File::open(path).await.context(InvalidFileOpen)?;
+
+        let mut settings_file = File::open(path)
+            .await
+            .map(BufReader::new)
+            .context(InvalidFileOpen)?;
+
         settings_file
             .read_to_string(&mut settings_content)
             .await
             .context(InvalidFileOpen)?;
+
         QuerySettings::new(&settings_content)
     }
 }

--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -28,6 +28,9 @@ pub enum Error {
     InvalidExtention,
 }
 
+/// Size of the IO buffer over input CSV file
+const CSV_BUFFER_SIZE: usize = 1024 * 1024; // 1MB
+
 /// Import the addresses found in path, using the given (Elastiscsearch) configuration and client.
 /// The function `into_addr` is used to transform the item read in the file (Bano) into an actual
 /// address.
@@ -115,10 +118,8 @@ async fn records_from_file<T>(
 where
     T: DeserializeOwned + Send + Sync + 'static,
 {
-    let file_read = File::open(file)
-        .await
-        .context(InvalidIO)
-        .map(BufReader::new)?;
+    let file_read =
+        BufReader::with_capacity(CSV_BUFFER_SIZE, File::open(file).await.context(InvalidIO)?);
 
     let data_read = {
         if file.extension().and_then(OsStr::to_str) == Some("csv") {


### PR DESCRIPTION
Rust's [`File`](https://doc.rust-lang.org/std/fs/struct.File.html) doesn't have any buffer by default, this is generally more efficient and good practice to use some, 