### PR TITLE
Add port to update documents before publishing

### DIFF
--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -17,12 +17,15 @@ use snafu::{ResultExt, Snafu};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::pin::Pin;
+use std::sync::Arc;
 use tracing::info;
 
 use super::configuration::{
     ComponentTemplateConfiguration, Error as ConfigurationError, IndexTemplateConfiguration,
 };
-use super::models::{ElasticsearchBulkResponse, ElasticsearchSearchResponse};
+use super::models::{
+    ElasticsearchBulkError, ElasticsearchBulkResponse, ElasticsearchSearchResponse,
+};
 use super::ElasticsearchStorage;
 use crate::adapters::secondary::elasticsearch::models::ElasticsearchBulkResult;
 use crate::domain::model::{
@@ -521,6 +524,7 @@ impl ElasticsearchStorage {
                 let doc_id = doc.id();
                 BulkOperation::index(doc).id(doc_id).into()
             }),
+            |_| false,
         )
         .await
     }
@@ -537,23 +541,33 @@ impl ElasticsearchStorage {
         self.bulk(
             index,
             updates.map(|(doc_id, operation)| BulkOperation::update(doc_id, operation).into()),
+            |err| err.err_type == "document_missing_exception",
         )
         .await
     }
 
-    async fn bulk<D, S>(&self, index: String, documents: S) -> Result<InsertStats, Error>
+    async fn bulk<D, S, F>(
+        &self,
+        index: String,
+        documents: S,
+        allow_errors: F,
+    ) -> Result<InsertStats, Error>
     where
         D: Serialize + Send + Sync + 'static,
         S: Stream<Item = BulkOperation<D>> + Send + Sync,
+        F: Fn(&ElasticsearchBulkError) -> bool + Sync + Send + 'static,
     {
+        let allow_errors = Arc::new(allow_errors);
+
         let stats = documents
             .chunks(self.config.insertion_chunk_size)
             .map(|chunk| {
                 let index = index.clone();
                 let client = self.clone();
+                let filter_errors = allow_errors.clone();
 
                 async move {
-                    tokio::spawn(client.bulk_block(index, chunk))
+                    tokio::spawn(client.bulk_block(index, chunk, move |err| filter_errors(err)))
                         .await
                         .expect("tokio task panicked")
                         .unwrap_or_else(|err| panic!("Error inserting chunk: {}", err))
@@ -570,6 +584,7 @@ impl ElasticsearchStorage {
         self,
         index: String,
         chunk: Vec<BulkOperation<D>>,
+        allow_errors: impl Fn(&ElasticsearchBulkError) -> bool,
     ) -> Result<InsertStats, Error>
     where
         D: Serialize + Send + Sync + 'static,
@@ -598,17 +613,22 @@ impl ElasticsearchStorage {
             let es_response: ElasticsearchBulkResponse =
                 resp.json().await.context(ElasticsearchDeserialization)?;
 
-            es_response.items.iter().try_for_each(|item| {
-                (item.index.result)
-                    .as_ref()
-                    .map_err(|err| Error::NotCreated {
-                        details: err.reason.to_string(),
-                    })
-                    .map(|result| match result {
+            es_response.items.into_iter().try_for_each(|item| {
+                match item.inner().result {
+                    Ok(result) => match result {
                         ElasticsearchBulkResult::Created => stats.created += 1,
                         ElasticsearchBulkResult::Updated => stats.updated += 1,
                         _ => unreachable!("no port implements document deletion"),
-                    })
+                    },
+                    Err(err) if allow_errors(&err) => {}
+                    Err(err) => {
+                        return Err(Error::NotCreated {
+                            details: err.reason,
+                        })
+                    }
+                }
+
+                Ok(())
             })?;
 
             Ok(stats)

--- a/libs/mimir/src/adapters/secondary/elasticsearch/models.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/models.rs
@@ -37,12 +37,23 @@ pub struct ElasticsearchBulkResponse {
 }
 
 #[derive(Debug, Eq, PartialEq, Deserialize)]
-pub struct ElasticsearchBulkItem {
-    pub index: ElasticsearchBulkIndex,
+#[serde(rename_all = "lowercase")]
+pub enum ElasticsearchBulkItem {
+    Index(ElasticsearchBulkStatus),
+    Update(ElasticsearchBulkStatus),
+}
+
+impl ElasticsearchBulkItem {
+    pub fn inner(self) -> ElasticsearchBulkStatus {
+        match self {
+            ElasticsearchBulkItem::Index(inner) => inner,
+            ElasticsearchBulkItem::Update(inner) => inner,
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Deserialize)]
-pub struct ElasticsearchBulkIndex {
+pub struct ElasticsearchBulkStatus {
     pub status: u16,
     #[serde(flatten, deserialize_with = "deserialize_bulk_result")]
     pub result: Result<ElasticsearchBulkResult, ElasticsearchBulkError>,
@@ -118,7 +129,7 @@ mod tests {
                     }
                 },
                 {
-                    "index": {
+                    "update": {
                         "_index": "index1",
                         "_type" : "_doc",
                         "_id": "7",
@@ -146,24 +157,20 @@ mod tests {
             response,
             ElasticsearchBulkResponse {
                 items: vec![
-                    ElasticsearchBulkItem {
-                        index: ElasticsearchBulkIndex {
-                            status: 404,
-                            result: Err(ElasticsearchBulkError {
-                                err_type: "document_missing_exception".to_string(),
-                                reason: "[_doc][5]: document missing".to_string(),
-                                index: "index1".to_string().into(),
-                                index_uuid: "aAsFqTI0Tc2W0LCWgPNrOA".to_string().into(),
-                                shard: "0".to_string().into(),
-                            })
-                        }
-                    },
-                    ElasticsearchBulkItem {
-                        index: ElasticsearchBulkIndex {
-                            status: 201,
-                            result: Ok(ElasticsearchBulkResult::Created)
-                        }
-                    }
+                    ElasticsearchBulkItem::Index(ElasticsearchBulkStatus {
+                        status: 404,
+                        result: Err(ElasticsearchBulkError {
+                            err_type: "document_missing_exception".to_string(),
+                            reason: "[_doc][5]: document missing".to_string(),
+                            index: "index1".to_string().into(),
+                            index_uuid: "aAsFqTI0Tc2W0LCWgPNrOA".to_string().into(),
+                            shard: "0".to_string().into(),
+                        })
+                    }),
+                    ElasticsearchBulkItem::Update(ElasticsearchBulkStatus {
+                        status: 201,
+                        result: Ok(ElasticsearchBulkResult::Created)
+                    })
                 ]
             }
         )

--- a/libs/mimir/src/adapters/secondary/elasticsearch/models.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/models.rs
@@ -53,6 +53,7 @@ pub struct ElasticsearchBulkIndex {
 pub enum ElasticsearchBulkResult {
     Created,
     Updated,
+    Deleted,
 }
 
 #[derive(Debug, Eq, PartialEq, Deserialize)]

--- a/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/storage.rs
@@ -64,7 +64,10 @@ impl<'s> Storage<'s> for ElasticsearchStorage {
         S: Stream<Item = D> + Send + Sync + 's,
     {
         self.add_pipeline(
-            include_str!("../../../../../../config/pipeline/indexed_at.json"),
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../config/pipeline/indexed_at.json",
+            )),
             "indexed_at",
         )
         .await

--- a/libs/mimir/src/domain/model/error.rs
+++ b/libs/mimir/src/domain/model/error.rs
@@ -26,6 +26,9 @@ pub enum Error {
     #[snafu(display("Document Stream Insertion Error: {}", source))]
     DocumentStreamInsertion { source: Box<dyn std::error::Error> },
 
+    #[snafu(display("Document Stream Update Error: {}", source))]
+    DocumentStreamUpdate { source: Box<dyn std::error::Error> },
+
     #[snafu(display("Expected Index: {}", index))]
     ExpectedIndex { index: String },
 

--- a/libs/mimir/src/domain/model/mod.rs
+++ b/libs/mimir/src/domain/model/mod.rs
@@ -5,3 +5,4 @@ pub mod index;
 pub mod query;
 pub mod stats;
 pub mod status;
+pub mod update;

--- a/libs/mimir/src/domain/model/update.rs
+++ b/libs/mimir/src/domain/model/update.rs
@@ -1,0 +1,8 @@
+#[derive(Clone, Debug)]
+pub enum UpdateOperation {
+    /// Update a field `ident` with given value
+    Set {
+        ident: String,
+        value: serde_json::Value,
+    },
+}

--- a/libs/mimir/src/domain/model/update.rs
+++ b/libs/mimir/src/domain/model/update.rs
@@ -1,8 +1,5 @@
 #[derive(Clone, Debug)]
 pub enum UpdateOperation {
     /// Update a field `ident` with given value
-    Set {
-        ident: String,
-        value: serde_json::Value,
-    },
+    Set { ident: String, value: String },
 }

--- a/libs/mimir/src/domain/ports/primary/generate_index.rs
+++ b/libs/mimir/src/domain/ports/primary/generate_index.rs
@@ -1,6 +1,6 @@
-use crate::domain::model::{
-    configuration::ContainerConfig, error::Error as ModelError, index::Index,
-};
+use crate::domain::model::configuration::ContainerConfig;
+use crate::domain::model::update::UpdateOperation;
+use crate::domain::model::{error::Error as ModelError, index::Index};
 use crate::domain::ports::secondary::storage::Storage;
 use async_trait::async_trait;
 use common::document::ContainerDocument;
@@ -10,6 +10,7 @@ use tracing_futures::Instrument;
 
 #[async_trait]
 pub trait GenerateIndex<'s> {
+    /// Generate an index with provided stream of documents and publish it.
     async fn generate_index<D, S>(
         &self,
         config: &ContainerConfig,
@@ -18,6 +19,19 @@ pub trait GenerateIndex<'s> {
     where
         D: ContainerDocument + Send + Sync + 'static,
         S: Stream<Item = D> + Send + Sync + 's;
+
+    /// Same as generate_index but also applies a stream of updates to
+    /// documents before publishing.
+    async fn generate_and_update_index<D, S, U>(
+        &self,
+        config: &ContainerConfig,
+        documents: S,
+        operations: U,
+    ) -> Result<Index, ModelError>
+    where
+        D: ContainerDocument + Send + Sync + 'static,
+        S: Stream<Item = D> + Send + Sync + 's,
+        U: Stream<Item = (String, UpdateOperation)> + Send + Sync + 's;
 }
 
 #[async_trait]
@@ -25,7 +39,6 @@ impl<'s, T> GenerateIndex<'s> for T
 where
     T: Storage<'s> + Send + Sync + 'static,
 {
-    #[tracing::instrument(skip(self, config, documents))]
     async fn generate_index<D, S>(
         &self,
         config: &ContainerConfig,
@@ -35,10 +48,27 @@ where
         D: ContainerDocument + Send + Sync + 'static,
         S: Stream<Item = D> + Send + Sync + 's,
     {
+        self.generate_and_update_index(config, documents, futures::stream::empty())
+            .await
+    }
+
+    #[tracing::instrument(skip(self, config, documents, operations))]
+    async fn generate_and_update_index<D, S, U>(
+        &self,
+        config: &ContainerConfig,
+        documents: S,
+        operations: U,
+    ) -> Result<Index, ModelError>
+    where
+        D: ContainerDocument + Send + Sync + 'static,
+        S: Stream<Item = D> + Send + Sync + 's,
+        U: Stream<Item = (String, UpdateOperation)> + Send + Sync + 's,
+    {
         // 1. We create the index
         // 2. We insert the document stream in that newly created index
-        // 3. We publish the index
-        // 4. We search for the newly created index to return it.
+        // 3. We update the documents with the input stream
+        // 4. We publish the index
+        // 5. We search for the newly created index to return it.
         let index = self
             .create_container(config)
             .instrument(info_span!("Create container"))
@@ -52,6 +82,14 @@ where
             .map_err(|err| ModelError::DocumentStreamInsertion { source: err.into() })?;
 
         info!("Index generation stats: {:?}", stats);
+
+        let stats = self
+            .update_documents(index.name.clone(), operations)
+            .instrument(info_span!("Update documents"))
+            .await
+            .map_err(|err| ModelError::DocumentStreamUpdate { source: err.into() })?;
+
+        info!("Index update stats: {:?}", stats);
 
         self.publish_index(index.clone(), config.visibility)
             .instrument(info_span!("Publish index"))

--- a/libs/mimir/src/domain/ports/primary/generate_index.rs
+++ b/libs/mimir/src/domain/ports/primary/generate_index.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::domain::model::configuration::ContainerConfig;
 use crate::domain::model::update::UpdateOperation;
 use crate::domain::model::{error::Error as ModelError, index::Index};
@@ -8,67 +10,43 @@ use futures::stream::Stream;
 use tracing::{info, info_span};
 use tracing_futures::Instrument;
 
-#[async_trait]
-pub trait GenerateIndex<'s> {
+#[async_trait(?Send)]
+pub trait GenerateIndex<'s>
+where
+    Self: Storage<'s> + Send + Sync + 'static,
+{
+    /// Generate an index and provide an handle over it.
+    async fn init_container<'a, D>(
+        &'a self,
+        config: &'a ContainerConfig,
+    ) -> Result<ContainerGenerator<'a, D, Self>, ModelError>
+    where
+        D: ContainerDocument + Send + Sync + 'static;
+
     /// Generate an index with provided stream of documents and publish it.
     async fn generate_index<D, S>(
-        &self,
-        config: &ContainerConfig,
+        &'s self,
+        config: &'s ContainerConfig,
         documents: S,
     ) -> Result<Index, ModelError>
     where
         D: ContainerDocument + Send + Sync + 'static,
         S: Stream<Item = D> + Send + Sync + 's;
-
-    /// Same as generate_index but also applies a stream of updates to
-    /// documents before publishing.
-    async fn generate_and_update_index<D, S, U>(
-        &self,
-        config: &ContainerConfig,
-        documents: S,
-        operations: U,
-    ) -> Result<Index, ModelError>
-    where
-        D: ContainerDocument + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 's,
-        U: Stream<Item = (String, UpdateOperation)> + Send + Sync + 's;
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'s, T> GenerateIndex<'s> for T
 where
-    T: Storage<'s> + Send + Sync + 'static,
+    T: Storage<'s> + Send + Sync + Sized + 'static,
 {
-    async fn generate_index<D, S>(
-        &self,
-        config: &ContainerConfig,
-        documents: S,
-    ) -> Result<Index, ModelError>
+    #[tracing::instrument(skip(self, config))]
+    async fn init_container<'a, D>(
+        &'a self,
+        config: &'a ContainerConfig,
+    ) -> Result<ContainerGenerator<'a, D, Self>, ModelError>
     where
         D: ContainerDocument + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 's,
     {
-        self.generate_and_update_index(config, documents, futures::stream::empty())
-            .await
-    }
-
-    #[tracing::instrument(skip(self, config, documents, operations))]
-    async fn generate_and_update_index<D, S, U>(
-        &self,
-        config: &ContainerConfig,
-        documents: S,
-        operations: U,
-    ) -> Result<Index, ModelError>
-    where
-        D: ContainerDocument + Send + Sync + 'static,
-        S: Stream<Item = D> + Send + Sync + 's,
-        U: Stream<Item = (String, UpdateOperation)> + Send + Sync + 's,
-    {
-        // 1. We create the index
-        // 2. We insert the document stream in that newly created index
-        // 3. We update the documents with the input stream
-        // 4. We publish the index
-        // 5. We search for the newly created index to return it.
         let index = self
             .create_container(config)
             .instrument(info_span!("Create container"))
@@ -77,30 +55,97 @@ where
 
         info!("Created new index: {:?}", index);
 
+        Ok(ContainerGenerator {
+            storage: self,
+            config,
+            index,
+            _phantom: PhantomData::default(),
+        })
+    }
+
+    async fn generate_index<D, S>(
+        &'s self,
+        config: &'s ContainerConfig,
+        documents: S,
+    ) -> Result<Index, ModelError>
+    where
+        D: ContainerDocument + Send + Sync + 'static,
+        S: Stream<Item = D> + Send + Sync + 's,
+    {
+        self.init_container(config)
+            .await?
+            .insert_documents(documents)
+            .await?
+            .publish()
+            .await
+    }
+}
+
+/// Handle over an index which is beeing generated, it can be used to insert
+/// or update documents.  When all documents are ready, `.publish()` must be
+/// called to make the index available.
+#[must_use]
+pub struct ContainerGenerator<'a, D, T: ?Sized>
+where
+    D: ContainerDocument + Send + Sync + 'static,
+{
+    storage: &'a T,
+    config: &'a ContainerConfig,
+    index: Index,
+    _phantom: PhantomData<*const D>,
+}
+
+impl<'a, 's, D, T> ContainerGenerator<'a, D, T>
+where
+    D: ContainerDocument + Send + Sync + 'static,
+    T: Storage<'s> + Send + Sync,
+{
+    /// Insert new documents into the index
+    #[tracing::instrument(skip(self, documents))]
+    pub async fn insert_documents(
+        self,
+        documents: impl Stream<Item = D> + Send + Sync + 's,
+    ) -> Result<ContainerGenerator<'a, D, T>, ModelError> {
         let stats = self
-            .insert_documents(index.name.clone(), documents)
-            .instrument(info_span!("Insert documents"))
+            .storage
+            .insert_documents(self.index.name.clone(), documents)
             .await
             .map_err(|err| ModelError::DocumentStreamInsertion { source: err.into() })?;
 
-        info!("Index generation stats: {:?}", stats);
+        info!("Insertion stats: {:?}", stats);
+        Ok(self)
+    }
 
+    /// Update documents that have already been inserted
+    #[tracing::instrument(skip(self, updates))]
+    pub async fn update_documents(
+        self,
+        updates: impl Stream<Item = (String, UpdateOperation)> + Send + Sync + 's,
+    ) -> Result<ContainerGenerator<'a, D, T>, ModelError> {
         let stats = self
-            .update_documents(index.name.clone(), operations)
-            .instrument(info_span!("Update documents"))
+            .storage
+            .update_documents(self.index.name.clone(), updates)
             .await
             .map_err(|err| ModelError::DocumentStreamUpdate { source: err.into() })?;
 
-        info!("Index update stats: {:?}", stats);
+        info!("Update stats: {:?}", stats);
+        Ok(self)
+    }
 
-        self.publish_index(index.clone(), config.visibility)
-            .instrument(info_span!("Publish index"))
+    /// Publish the index, which consumes the handle
+    #[tracing::instrument(skip(self))]
+    pub async fn publish(self) -> Result<Index, ModelError> {
+        self.storage
+            .publish_index(self.index.clone(), self.config.visibility)
             .await
             .map_err(|err| ModelError::IndexPublication { source: err.into() })?;
 
-        self.find_container(index.name.clone())
+        self.storage
+            .find_container(self.index.name.clone())
             .await
             .map_err(|err| ModelError::DocumentStreamInsertion { source: err.into() })?
-            .ok_or(ModelError::ExpectedIndex { index: index.name })
+            .ok_or(ModelError::ExpectedIndex {
+                index: self.index.name,
+            })
     }
 }

--- a/libs/mimir/src/domain/ports/primary/generate_index.rs
+++ b/libs/mimir/src/domain/ports/primary/generate_index.rs
@@ -75,6 +75,8 @@ where
             .await
             .map_err(|err| ModelError::IndexCreation { source: err.into() })?;
 
+        info!("Created new index: {:?}", index);
+
         let stats = self
             .insert_documents(index.name.clone(), documents)
             .instrument(info_span!("Insert documents"))

--- a/libs/mimir/src/domain/ports/primary/generate_index.rs
+++ b/libs/mimir/src/domain/ports/primary/generate_index.rs
@@ -84,7 +84,7 @@ where
 /// Handle over an index which is beeing generated, it can be used to insert
 /// or update documents.  When all documents are ready, `.publish()` must be
 /// called to make the index available.
-#[must_use]
+#[must_use = "An index must be used after its documents are built."]
 pub struct ContainerGenerator<'a, D, T: ?Sized>
 where
     D: ContainerDocument + Send + Sync + 'static,

--- a/libs/mimir/src/lib.rs
+++ b/libs/mimir/src/lib.rs
@@ -6,3 +6,6 @@ pub mod utils;
 // context, it makes sense to re-export it here instead of publishing it as
 // its own package.
 pub use common;
+
+#[cfg(test)]
+mod tests;

--- a/libs/mimir/src/tests/generate_and_update.rs
+++ b/libs/mimir/src/tests/generate_and_update.rs
@@ -1,0 +1,109 @@
+use futures::{stream, TryStreamExt};
+use serial_test::serial;
+
+use crate::adapters::secondary::elasticsearch::{remote, ElasticsearchStorageConfig};
+use crate::domain::model::configuration::{ContainerConfig, ContainerVisibility};
+use crate::domain::model::update::UpdateOperation;
+use crate::domain::ports::primary::generate_index::GenerateIndex;
+use crate::domain::ports::primary::list_documents::ListDocuments;
+use crate::domain::ports::secondary::remote::Remote;
+use crate::utils::docker;
+use places::poi::Poi;
+
+fn sample_poi() -> Poi {
+    Poi {
+        id: "osm:poi:1".to_string(),
+        name: "eiffel tower".to_string(),
+        zip_codes: vec!["75007".to_string()],
+        ..Poi::default()
+    }
+}
+
+async fn generate_and_update_poi(id: &str, updates: Vec<UpdateOperation>) -> Vec<Poi> {
+    docker::initialize()
+        .await
+        .expect("elasticsearch docker initialization failed");
+
+    let client = remote::connection_test_pool()
+        .conn(ElasticsearchStorageConfig::default_testing())
+        .await
+        .expect("could not connect to Elasticsearch");
+
+    let container_config = ContainerConfig {
+        name: "poi".to_string(),
+        dataset: "test".to_string(),
+        visibility: ContainerVisibility::Public,
+    };
+
+    let poi_updates = updates.into_iter().map(|op| (id.to_string(), op));
+
+    client
+        .init_container(&container_config)
+        .await
+        .unwrap()
+        .insert_documents(stream::iter([sample_poi()]))
+        .await
+        .unwrap()
+        .update_documents(stream::iter(poi_updates))
+        .await
+        .unwrap()
+        .publish()
+        .await
+        .unwrap();
+
+    client
+        .list_documents()
+        .await
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+#[serial]
+async fn should_update_poi() {
+    let documents = generate_and_update_poi(
+        "osm:poi:1",
+        vec![
+            UpdateOperation::Set {
+                ident: "name".to_string(),
+                value: "tour eiffel".to_string(),
+            },
+            UpdateOperation::Set {
+                ident: "properties.image".to_string(),
+                value: "<URL>".to_string(),
+            },
+        ],
+    )
+    .await;
+
+    let result_poi = documents.into_iter().next().unwrap();
+
+    // Check that result_poi (fetched from the index) fields are updated
+    assert_eq!(result_poi.name, "tour eiffel");
+    assert_eq!(result_poi.properties["image"], "<URL>");
+
+    // This should be untouched
+    assert_eq!(result_poi.zip_codes, ["75007".to_string()]);
+}
+
+#[tokio::test]
+#[should_panic]
+#[serial]
+async fn should_fail_updating_wrong_poi() {
+    generate_and_update_poi(
+        "this_is_not_a_poi",
+        vec![
+            UpdateOperation::Set {
+                ident: "name".to_string(),
+                value: "tour eiffel".to_string(),
+            },
+            UpdateOperation::Set {
+                ident: "properties.image".to_string(),
+                value: "<URL>".to_string(),
+            },
+        ],
+    )
+    .await;
+}

--- a/libs/mimir/src/tests/mod.rs
+++ b/libs/mimir/src/tests/mod.rs
@@ -1,0 +1,1 @@
+mod generate_and_update;


### PR DESCRIPTION
The adds a more flexible API to the `generate_index` ports which allows to update documents before publishing it. This is very targeted for our use-case using mimir as a library, where we need to import data from tripadvisor which are split into different datasets: https://github.com/Qwant/fafnir/pull/71.

This new API can be called with a chain of methods, like that:

```rust
client.init_container(&container_config)
    .await?
    .insert_documents(doc_stream1)
    .await?
    .insert_documents(doc_stream2)
    .await?
    .update_documents(update_stream)
    .await?
    .publish() // there is even a warning if this last call is forgotten
    .await?;
```

The `generate_index` method is still there, I think it is still relevant as a shortcut for the new API as it will group all potential failure points in a single call.

Updates can be defined as a pair of the id of a document together with an instance of the following enum (the only available operation is to set a field, but at least we're explicit):

```rust
pub enum UpdateOperation {
    /// Update a field `ident` with given value
    Set { ident: String, value: String },
}
```

NOTE: This is base on #645 which should be reviewed & merged first (:heavy_check_mark:)