### PR TITLE
update to stable config from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,9 +536,9 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.11.0"
-source = "git+https://github.com/mehcode/config-rs.git?branch=master#6de19be2b5be7aa16b697c2587a04445c47defba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
 dependencies = [
- "async-trait",
  "lazy_static",
  "nom",
  "serde",
@@ -1911,6 +1911,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,12 +2169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,12 +2297,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.0"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
+ "lexical-core",
  "memchr",
- "minimal-lexical",
  "version_check",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ bincode = "1.3.3"
 chrono = "0.4"
 chrono-tz = "0.5"
 clap = "2.33.1"
+config = { version = "0.11", default_features = false, features = ["json", "toml"] }
 cosmogony = "0.10.3"
 csv = "1.1"
 csv-async = {version = "1.2", features = ["tokio", "with_serde"]}
@@ -71,12 +72,6 @@ warp = { version = "0.3.1" }
 common = { path = "libs/common" }
 mimir  = { path = "libs/mimir" }
 places = { path = "libs/places" }
-
-[dependencies.config]
-git = "https://github.com/mehcode/config-rs.git"
-branch = "master"
-default_features = false
-features = ["json", "toml"]
 
 [lib]
 name = "mimirsbrunn"

--- a/libs/common/Cargo.toml
+++ b/libs/common/Cargo.toml
@@ -11,11 +11,6 @@ categories = [ "application" ]
 readme = "README.md"
 
 [dependencies]
+config = { version = "0.11", default_features = false, features = ["json", "toml"] }
 serde = { version = "1.0", default_features = false }
 snafu = { version = "0.6.10", features = [ "futures" ] }
-
-[dependencies.config]
-git = "https://github.com/mehcode/config-rs.git"
-branch = "master"
-default_features = false
-features = [ "toml", "json" ]

--- a/libs/common/src/config.rs
+++ b/libs/common/src/config.rs
@@ -29,7 +29,6 @@ pub enum Error {
 pub fn config_from<
     'a,
     R: Into<Option<&'a str>> + Clone,
-    O: IntoIterator<Item = String>,
     P: Into<Option<&'a str>>,
     D: AsRef<str>,
 >(
@@ -37,7 +36,7 @@ pub fn config_from<
     sub_dirs: &[D],
     run_mode: R,
     prefix: P,
-    overrides: O,
+    overrides: Vec<String>,
 ) -> Result<Config, Error> {
     let mut config = sub_dirs
         .iter()
@@ -75,9 +74,11 @@ pub fn config_from<
     };
 
     // Add command line overrides
-    config
-        .merge(config_from_args(overrides)?)
-        .context(ConfigCompilation)?;
+    if !overrides.is_empty() {
+        config
+            .merge(config_from_args(overrides)?)
+            .context(ConfigCompilation)?;
+    }
 
     Ok(config)
 }

--- a/libs/mimir/Cargo.toml
+++ b/libs/mimir/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = "0.1.50"
 bollard = "0.11.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 common = { path = "../common" }
+config = { version = "0.11", default_features = false, features = ["json", "toml"] }
 convert_case = "0.4.0"
 cosmogony = "0.10.3"
 elasticsearch = "7.14.0-alpha.1"
@@ -47,12 +48,6 @@ tracing-subscriber = "0.2.17"
 url = { version = "2.2", features = [ "serde" ] }
 warp = "0.3.2"
 
-[dependencies.config]
-git = "https://github.com/mehcode/config-rs.git"
-branch = "master"
-default_features = false
-features = ["json"]
-
 [dev-dependencies]
 mockall = "0.9.1"
 criterion = { version = "0.3", features = [ "async_tokio" ] }
@@ -63,5 +58,3 @@ serial_test = "0.5.1"
 [lib]
 name = "mimir"
 path = "src/lib.rs"
-
-

--- a/libs/mimir/src/adapters/primary/templates.rs
+++ b/libs/mimir/src/adapters/primary/templates.rs
@@ -47,20 +47,20 @@ pub async fn import<C: Clone + ConfigureBackend>(
                 .to_string();
             let client = client.clone();
             async move {
-                let config = config::Config::builder()
+                let config = config::Config::default()
                     .set_default("elasticsearch.name", template_name)
                     .unwrap()
-                    .add_source(config::File::new(
+                    .merge(config::File::new(
                         template.to_str().unwrap(),
                         config::FileFormat::Json,
                     ))
-                    .build()
                     .context(ConfigMerge {
                         details: format!(
                             "could not read template configuration from {}",
                             template.display()
                         ),
-                    })?;
+                    })?
+                    .clone();
 
                 match template_type {
                     Template::Component => {

--- a/libs/mimir/src/adapters/secondary/elasticsearch/mod.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/mod.rs
@@ -52,7 +52,7 @@ impl Default for ElasticsearchStorageConfig {
             &["elasticsearch"],
             None,
             None,
-            None,
+            vec![],
         );
 
         config
@@ -71,7 +71,7 @@ impl ElasticsearchStorageConfig {
             &["elasticsearch"],
             "testing",
             "MIMIR_TEST",
-            None,
+            vec![],
         );
 
         config

--- a/libs/mimir/src/utils/docker.rs
+++ b/libs/mimir/src/utils/docker.rs
@@ -162,7 +162,7 @@ impl Default for DockerConfig {
             &["elasticsearch"],
             None,
             None,
-            None,
+            vec![],
         );
 
         config
@@ -186,7 +186,7 @@ impl DockerConfig {
             &["docker"],
             "testing",
             "MIMIR_TEST",
-            None,
+            vec![],
         );
 
         config

--- a/libs/places/Cargo.toml
+++ b/libs/places/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 
 [dependencies]
 chrono-tz = "0.5"
+config = { version = "0.11", default_features = false, features = ["json", "toml"] }
 common = { path = "../common" }
 cosmogony = "0.10"
 geo-types = "0.7"
@@ -22,8 +23,3 @@ serde = { version = "1", features = ["rc"]}
 tracing = "0.1.26"
 transit_model = "0.42.1"
 typed_index_collection = "2.0"
-
-[dependencies.config]
-git = "https://github.com/mehcode/config-rs.git"
-branch = "master"
-default_features = false

--- a/libs/tests/Cargo.toml
+++ b/libs/tests/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 [dependencies]
 approx = "0.5"
 async-trait = "0.1.50"
+config = { version = "0.11", default_features = false, features = ["json", "toml"] }
 common = { path = "../common" }
 cucumber = { package = "cucumber_rust", version = "0.9" }
 elasticsearch = "7.14.0-alpha.1"
@@ -29,13 +30,6 @@ snafu = { version = "0.6.10", features = [ "futures" ] }
 tokio = { version = "1.14.0", features = [ "rt-multi-thread", "macros", "process" ] }
 url = "2.2.2"
 zip = "0.5.13"
-
-[dependencies.config]
-git = "https://github.com/mehcode/config-rs.git"
-branch = "master"
-default_features = false
-features = ["json", "toml"]
-
 
 [lib]
 name = "tests"

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -113,9 +113,8 @@ impl Default for PoiConfig {
         let input_dir: PathBuf = [base_path, "config", "osm2mimir"].iter().collect();
         let input_file = input_dir.join("default.toml");
 
-        Config::builder()
-            .add_source(config::File::from(input_file))
-            .build()
+        Config::default()
+            .with_merged(config::File::from(input_file))
             .expect("cannot build the default poi configuration")
             .get("pois.config")
             .expect("poi configuration")

--- a/src/settings/cosmogony2mimir.rs
+++ b/src/settings/cosmogony2mimir.rs
@@ -1,5 +1,4 @@
 /// This module contains the definition for bano2mimir configuration and command line arguments.
-use config::Config;
 use mimir::domain::model::configuration::ContainerConfig;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
@@ -16,12 +15,8 @@ const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
 pub enum Error {
     #[snafu(display("Config Source Error: {}", source))]
     ConfigSource { source: common::config::Error },
-
-    #[snafu(display("Config Merge Error: {} [{}]", msg, source))]
-    ConfigMerge {
-        msg: String,
-        source: config::ConfigError,
-    },
+    #[snafu(display("Config Error: {}", source))]
+    ConfigBuild { source: config::ConfigError },
     #[snafu(display("Invalid Configuration: {}", msg))]
     Invalid { msg: String },
 }
@@ -84,26 +79,16 @@ pub enum Command {
 impl Settings {
     // Read the configuration from <config-dir>/cosmogony2mimir and <config-dir>/elasticsearch
     pub fn new(opts: &Opts) -> Result<Self, Error> {
-        let mut builder = Config::builder();
-
-        builder = builder.add_source(
-            common::config::config_from(
-                opts.config_dir.as_ref(),
-                &["cosmogony2mimir", "elasticsearch", "logging"],
-                opts.run_mode.as_deref(),
-                "MIMIR",
-                opts.settings.clone(),
-            )
-            .context(ConfigSource)?,
-        );
-
-        let config = builder.build().context(ConfigMerge {
-            msg: String::from("Cannot build the configuration from sources"),
-        })?;
-
-        config.try_into().context(ConfigMerge {
-            msg: String::from("Cannot convert configuration into cosmogony2mimir settings"),
-        })
+        common::config::config_from(
+            opts.config_dir.as_ref(),
+            &["cosmogony2mimir", "elasticsearch", "logging"],
+            opts.run_mode.as_deref(),
+            "MIMIR",
+            opts.settings.clone(),
+        )
+        .context(ConfigSource)?
+        .try_into()
+        .context(ConfigBuild)
     }
 }
 

--- a/src/settings/openaddresses2mimir.rs
+++ b/src/settings/openaddresses2mimir.rs
@@ -1,5 +1,4 @@
 /// This module contains the definition for bano2mimir configuration and command line arguments.
-use config::Config;
 use mimir::domain::model::configuration::ContainerConfig;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
@@ -16,11 +15,8 @@ const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
 pub enum Error {
     #[snafu(display("Config Compilation Error: {}", source))]
     ConfigCompilation { source: common::config::Error },
-    #[snafu(display("Config Merge Error: {} [{}]", msg, source))]
-    ConfigMerge {
-        msg: String,
-        source: config::ConfigError,
-    },
+    #[snafu(display("Config Error: {}", source))]
+    ConfigBuild { source: config::ConfigError },
     #[snafu(display("Invalid Configuration: {}", msg))]
     Invalid { msg: String },
 }
@@ -97,26 +93,16 @@ pub enum Command {
 impl Settings {
     // Read the configuration from <config-dir>/openaddresses2mimir and <config-dir>/elasticsearch
     pub fn new(opts: &Opts) -> Result<Self, Error> {
-        let mut builder = Config::builder();
-
-        builder = builder.add_source(
-            common::config::config_from(
-                opts.config_dir.as_ref(),
-                &["openaddresses2mimir", "elasticsearch", "logging"],
-                opts.run_mode.as_deref(),
-                "MIMIR",
-                opts.settings.clone(),
-            )
-            .context(ConfigCompilation)?,
-        );
-
-        let config = builder.build().context(ConfigMerge {
-            msg: String::from("Cannot build the configuration from sources"),
-        })?;
-
-        config.try_into().context(ConfigMerge {
-            msg: String::from("Cannot convert configuration into openaddresses2mimir settings"),
-        })
+        common::config::config_from(
+            opts.config_dir.as_ref(),
+            &["openaddresses2mimir", "elasticsearch", "logging"],
+            opts.run_mode.as_deref(),
+            "MIMIR",
+            opts.settings.clone(),
+        )
+        .context(ConfigCompilation)?
+        .try_into()
+        .context(ConfigBuild)
     }
 }
 


### PR DESCRIPTION
Config has introduced a few breaking changes on master so now it can be a bit painful if cargo decides to update it.

Instead of pinning a specific commit I think it is time to rely on the published version, which is quite recent (0.11).