### PR TITLE
Rename binaries for migration purpose

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,6 +25,18 @@ jobs:
           apt-get update
           apt-get install -y curl wget build-essential
           apt-get install -y ${{ matrix.packages }}
+      # TODO :
+      # Remove this step after ES migration 2->7.
+      # We need it to make version 2 and 7 coexist.
+      # Be careful, binaries will not have the same name !
+      - name: Temporary rename binaries with 7
+        run: |
+          mv src/bin/bano2mimir.rs src/bin/bano2mimir7.rs
+          mv src/bin/cosmogony2mimir.rs src/bin/cosmogony2mimir7.rs
+          mv src/bin/ctlmimir.rs src/bin/ctlmimir7.rs
+          mv src/bin/openaddresses2mimir.rs src/bin/openaddresses2mimir7.rs
+          mv src/bin/osm2mimir.rs src/bin/osm2mimir7.rs
+          mv src/bin/poi2mimir.rs src/bin/poi2mimir7.rs
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
## Cluster  Migration
:warning:  Remove this step after ES migration 2->7.
We need it to make version 2 and 7 coexist.
Be careful, binaries will not have the same name !