### PR TITLE
CI: Update Jenkins credential with Github App

### DIFF
--- a/.jenkins/release
+++ b/.jenkins/release
@@ -35,10 +35,10 @@ pipeline {
         }
         stage('Create and push new version') {
             steps {
-                withCredentials([string(credentialsId: 'jenkins-core-github-access-token', variable: 'GITHUB_TOKEN')]) {
+                withCredentials([usernamePassword(credentialsId: 'jenkins-app-core', usernameVariable: 'GITHUB_APP', passwordVariable: 'GITHUB_TOKEN')]) {
                     sh '''
                         githubflow_release --release-type $release_type --base-branch master --github-repo CanalTP/mimirsbrunn  --remote-name origin
-                        git push https://jenkins-kisio-core:$GITHUB_TOKEN@github.com/CanalTP/mimirsbrunn.git master release --tags
+                        git push https://${GITHUB_APP}:${GITHUB_TOKEN}@github.com/CanalTP/mimirsbrunn.git master release --tags
                     '''
                 }
             }


### PR DESCRIPTION
Following the https://github.com/CanalTP/mimirsbrunn/pull/656 job, the migration with _Github App_ is needed to respect the security policy.