### PR TITLE
Docker images stabilization

### DIFF
--- a/docker/bragi/Dockerfile
+++ b/docker/bragi/Dockerfile
@@ -74,12 +74,9 @@ fi
 COPY --from=builder /home/mimirsbrunn/bin/bragi /usr/bin/bragi
 COPY --from=builder /home/mimirsbrunn/config /etc/bragi
 
-EXPOSE 4000
+EXPOSE 5000
 
-ENV RUST_LOG                    info,hyper=info
-ENV BUNYAN                      0
-ENV BRAGI_ELASTICSEARCH_URL     http://localhost:9200/munin
-ENV BRAGI_SERVICE_HOST          0.0.0.0
-ENV BRAGI_SERVICE_PORT          4000
+ENV RUST_LOG    info,hyper=info
+ENV BUNYAN      0
 
 ENTRYPOINT [ "./run_with_default_config.sh", "bragi" ]

--- a/docker/bragi/Dockerfile
+++ b/docker/bragi/Dockerfile
@@ -71,8 +71,9 @@ else \
   echo "Unsupported debian version '$DEBIAN_VERSION'"; \
 fi
 
+COPY config /etc/bragi
+COPY docker/run_with_default_config.sh .
 COPY --from=builder /home/mimirsbrunn/bin/bragi /usr/bin/bragi
-COPY --from=builder /home/mimirsbrunn/config /etc/bragi
 
 EXPOSE 5000
 

--- a/docker/bragi/Dockerfile
+++ b/docker/bragi/Dockerfile
@@ -77,6 +77,7 @@ COPY --from=builder /home/mimirsbrunn/bin/bragi /usr/bin/bragi
 
 EXPOSE 5000
 
+ENV CONFIG_DIR  /etc/bragi
 ENV RUST_LOG    info,hyper=info
 ENV BUNYAN      0
 

--- a/docker/bragi/Dockerfile
+++ b/docker/bragi/Dockerfile
@@ -77,8 +77,9 @@ COPY --from=builder /home/mimirsbrunn/config /etc/bragi
 EXPOSE 4000
 
 ENV RUST_LOG                    info,hyper=info
+ENV BUNYAN                      0
 ENV BRAGI_ELASTICSEARCH_URL     http://localhost:9200/munin
 ENV BRAGI_SERVICE_HOST          0.0.0.0
 ENV BRAGI_SERVICE_PORT          4000
 
-ENTRYPOINT ["/usr/bin/bragi", "--config-dir", "/etc/bragi", "run"]
+ENTRYPOINT [ "./run_with_default_config.sh", "bragi" ]

--- a/docker/run_with_default_config.sh
+++ b/docker/run_with_default_config.sh
@@ -22,7 +22,7 @@ CONFIG_DIR=${CONFIG_DIR:-"/etc/mimirsbrunn"}
 # with code 0.
 set -o pipefail
 
-if [ $BUNYAN ] ; then
+if [ $BUNYAN -eq "1" ] ; then
     $CMD --config-dir $CONFIG_DIR --run-mode $RUN_MODE $ARG | bunyan
 else
     $CMD --config-dir $CONFIG_DIR --run-mode $RUN_MODE $ARG

--- a/docker/run_with_default_config.sh
+++ b/docker/run_with_default_config.sh
@@ -13,6 +13,7 @@ CMD=$1
 shift
 ARG=$@
 
+BUNYAN=${BUNYAN:-"1"}
 RUN_MODE=${RUN_MODE:-"docker"}
 CONFIG_DIR=${CONFIG_DIR:-"/etc/mimirsbrunn"}
 
@@ -21,4 +22,8 @@ CONFIG_DIR=${CONFIG_DIR:-"/etc/mimirsbrunn"}
 # with code 0.
 set -o pipefail
 
-$CMD --config-dir $CONFIG_DIR --run-mode $RUN_MODE $ARG | bunyan
+if [ $BUNYAN ] ; then
+    $CMD --config-dir $CONFIG_DIR --run-mode $RUN_MODE $ARG | bunyan
+else
+    $CMD --config-dir $CONFIG_DIR --run-mode $RUN_MODE $ARG
+fi

--- a/docker/run_with_default_config.sh
+++ b/docker/run_with_default_config.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-# Call the given command with an extra default `--config-dir` parameter value.
+# Call the given command with extra defaults `--run-mode` `--config-dir`
+# parameter values.
+#
+# You can still override those default parameters if you need with through
+# variables $RUN_MODE and $CONFIG_DIR.
 #
 # This is useful in the context of the docker images where the config directory
 # is embeded at a fixed path.
@@ -9,10 +13,12 @@ CMD=$1
 shift
 ARG=$@
 
+RUN_MODE=${RUN_MODE:-"docker"}
+CONFIG_DIR=${CONFIG_DIR:-"/etc/mimirsbrunn"}
+
 # By default, a pipeline's exit code is the exit code of the last command. This
 # will make this script exit with code 1 if $CMD fails, even if bunyan exits
 # with code 0.
 set -o pipefail
 
-echo "$CMD --run-mode docker --config-dir /etc/mimirsbrunn $ARG | bunyan"
-$CMD --config-dir=/etc/mimirsbrunn --run-mode=docker $ARG | bunyan
+$CMD --config-dir $CONFIG_DIR --run-mode $RUN_MODE $ARG | bunyan

--- a/src/settings/ctlmimir.rs
+++ b/src/settings/ctlmimir.rs
@@ -92,7 +92,7 @@ impl Settings {
                     opts.config_dir.as_ref(),
                     &["elasticsearch", "logging"],
                     opts.run_mode.as_deref(),
-                    "CTLMIMIR",
+                    "MIMIR",
                     opts.settings.clone(),
                 )
                 .context(ConfigCompilation)?,


### PR DESCRIPTION
This makes a few changes to the ergonomic of docker images:

 - make `--config-dir` and `--run-mode` overridable through env
 - make it possible to disable bunyan formatting through env
 - use `run_with_default_config` for Bragi to interact with it the same way as other mimirsbrunn utils
 - remove env overrides in Bragi image, which was redundant with default config files
 - changed environment prefix from `CTLMIMIR_` to `MIMIR_` for ctlmimir, this is consistent with importers, only still has a different prefix (is that fine? there may  have been a motivation?)