### PR TITLE
Parse timeout in autocomplete query

### DIFF
--- a/benches/searching.rs
+++ b/benches/searching.rs
@@ -112,6 +112,7 @@ fn bench(c: &mut Criterion) {
                                     ],
                                     Query::QueryDSL(dsl),
                                     DEFAULT_LIMIT_RESULT_ES,
+                                    None,
                                 )
                                 .await
                                 .unwrap();

--- a/libs/mimir/src/adapters/primary/bragi/api.rs
+++ b/libs/mimir/src/adapters/primary/bragi/api.rs
@@ -1,9 +1,9 @@
-use std::time::Duration;
 use crate::utils::deserialize::deserialize_opt_duration;
 use cosmogony::ZoneType;
 use geojson::{GeoJson, Geometry};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use std::time::Duration;
 
 use crate::adapters::primary::common::coord::Coord;
 use crate::adapters::primary::common::filters::Filters;

--- a/libs/mimir/src/adapters/primary/bragi/api.rs
+++ b/libs/mimir/src/adapters/primary/bragi/api.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+use crate::utils::deserialize::deserialize_opt_duration;
 use cosmogony::ZoneType;
 use geojson::{GeoJson, Geometry};
 use serde::{Deserialize, Serialize};
@@ -39,6 +41,8 @@ pub struct ForwardGeocoderQuery {
     pub poi_types: Option<Vec<String>>,
     #[serde(default = "default_result_limit")]
     pub limit: i64,
+    #[serde(deserialize_with = "deserialize_opt_duration")]
+    pub timeout: Option<Duration>,
 }
 
 fn default_result_limit() -> i64 {
@@ -58,6 +62,7 @@ impl From<(ForwardGeocoderQuery, Option<Geometry>)> for Filters {
                 zone_types,
                 poi_types,
                 limit,
+                timeout,
             },
             geometry,
         ) = source;
@@ -97,6 +102,7 @@ impl From<(ForwardGeocoderQuery, Option<Geometry>)> for Filters {
             zone_types,
             poi_types,
             limit,
+            timeout,
         }
     }
 }
@@ -109,6 +115,8 @@ pub struct ReverseGeocoderQuery {
     pub lon: f64,
     #[serde(default = "default_result_limit")]
     pub limit: i64,
+    #[serde(deserialize_with = "deserialize_opt_duration")]
+    pub timeout: Option<Duration>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/libs/mimir/src/adapters/primary/bragi/api.rs
+++ b/libs/mimir/src/adapters/primary/bragi/api.rs
@@ -41,7 +41,7 @@ pub struct ForwardGeocoderQuery {
     pub poi_types: Option<Vec<String>>,
     #[serde(default = "default_result_limit")]
     pub limit: i64,
-    #[serde(deserialize_with = "deserialize_opt_duration")]
+    #[serde(deserialize_with = "deserialize_opt_duration", default)]
     pub timeout: Option<Duration>,
 }
 

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -36,14 +36,16 @@ where
     S::Document: Serialize + Into<serde_json::Value>,
 {
     let q = params.q.clone();
+    let timeout = params.timeout.clone();
     let search_types = types_to_indices(&params.types);
     let filters = filters::Filters::from((params, geometry));
     let dsl = dsl::build_query(&q, filters.clone(), &["fr"], &settings);
 
     debug!("{}", serde_json::to_string(&dsl).unwrap());
 
+
     match client
-        .search_documents(search_types, Query::QueryDSL(dsl), filters.limit)
+        .search_documents(search_types, Query::QueryDSL(dsl), filters.limit, timeout)
         .await
     {
         Ok(res) => {
@@ -135,6 +137,7 @@ where
             ],
             Query::QueryDSL(dsl),
             params.limit,
+            params.timeout,
         )
         .await
     {

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -43,7 +43,6 @@ where
 
     debug!("{}", serde_json::to_string(&dsl).unwrap());
 
-
     match client
         .search_documents(search_types, Query::QueryDSL(dsl), filters.limit, timeout)
         .await

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -36,7 +36,7 @@ where
     S::Document: Serialize + Into<serde_json::Value>,
 {
     let q = params.q.clone();
-    let timeout = params.timeout.clone();
+    let timeout = params.timeout;
     let search_types = types_to_indices(&params.types);
     let filters = filters::Filters::from((params, geometry));
     let dsl = dsl::build_query(&q, filters.clone(), &["fr"], &settings);

--- a/libs/mimir/src/adapters/primary/common/dsl.rs
+++ b/libs/mimir/src/adapters/primary/common/dsl.rs
@@ -17,6 +17,7 @@ pub fn build_query(
         datasets: _,
         zone_types,
         poi_types,
+        timeout: _,
     } = filters;
 
     let string_query = build_string_query(q, &settings.string_query);

--- a/libs/mimir/src/adapters/primary/common/filters.rs
+++ b/libs/mimir/src/adapters/primary/common/filters.rs
@@ -14,5 +14,5 @@ pub struct Filters {
     pub zone_types: Option<Vec<String>>,
     pub poi_types: Option<Vec<String>>,
     pub limit: i64,
-    pub timeout : Option<Duration>,
+    pub timeout: Option<Duration>,
 }

--- a/libs/mimir/src/adapters/primary/common/filters.rs
+++ b/libs/mimir/src/adapters/primary/common/filters.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use super::coord::Coord;
 use geojson::Geometry;
 
@@ -12,4 +14,5 @@ pub struct Filters {
     pub zone_types: Option<Vec<String>>,
     pub poi_types: Option<Vec<String>>,
     pub limit: i64,
+    pub timeout : Option<Duration>,
 }

--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -1029,7 +1029,7 @@ impl ElasticsearchStorage {
         D: DeserializeOwned + Send + Sync + 'static,
     {
         let indices = indices.iter().map(String::as_str).collect::<Vec<_>>();
-        let timeout = timeout.unwrap_or_else(|| self.config.timeout);
+        let timeout = timeout.unwrap_or(self.config.timeout);
         let search = self
             .client
             .search(SearchParts::Index(&indices))

--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -1023,7 +1023,7 @@ impl ElasticsearchStorage {
         indices: Vec<String>,
         query: Query,
         limit_result: i64,
-        timeout : Option<Duration>, //in milliseconds
+        timeout: Option<Duration>, //in milliseconds
     ) -> Result<Vec<D>, Error>
     where
         D: DeserializeOwned + Send + Sync + 'static,

--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -1030,7 +1030,17 @@ impl ElasticsearchStorage {
     {
         let indices = indices.iter().map(String::as_str).collect::<Vec<_>>();
         let timeout = timeout
-            .map(|t| std::cmp::min(t, self.config.timeout)) // let's cap the timeout to self.config.timeout to prevent overloading elasticsearch with long requests
+            .map(|t| {
+                if t > self.config.timeout {
+                    info!(
+                        "Requested timeout {:?} is too big. I'll use {:?} instead.",
+                        t, self.config.timeout
+                    );
+                    self.config.timeout
+                } else {
+                    t
+                }
+            }) // let's cap the timeout to self.config.timeout to prevent overloading elasticsearch with long requests
             .unwrap_or(self.config.timeout);
 
         let search = self

--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -17,6 +17,7 @@ use snafu::{ResultExt, Snafu};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::pin::Pin;
+use std::time::Duration;
 use tracing::info;
 
 use super::configuration::{
@@ -1022,16 +1023,18 @@ impl ElasticsearchStorage {
         indices: Vec<String>,
         query: Query,
         limit_result: i64,
+        timeout : Option<Duration>, //in milliseconds
     ) -> Result<Vec<D>, Error>
     where
         D: DeserializeOwned + Send + Sync + 'static,
     {
         let indices = indices.iter().map(String::as_str).collect::<Vec<_>>();
+        let timeout = timeout.unwrap_or_else(|| self.config.timeout);
         let search = self
             .client
             .search(SearchParts::Index(&indices))
             .size(limit_result)
-            .request_timeout(self.config.timeout);
+            .request_timeout(timeout);
 
         let response = match query {
             Query::QueryString(q) => search.q(&q).send().await.context(ElasticsearchClient {

--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -1023,7 +1023,7 @@ impl ElasticsearchStorage {
         indices: Vec<String>,
         query: Query,
         limit_result: i64,
-        timeout: Option<Duration>, 
+        timeout: Option<Duration>,
     ) -> Result<Vec<D>, Error>
     where
         D: DeserializeOwned + Send + Sync + 'static,

--- a/libs/mimir/src/adapters/secondary/elasticsearch/query.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/query.rs
@@ -15,8 +15,13 @@ impl Search for ElasticsearchStorage {
             .map(|idx| root_doctype(idx))
             .collect();
 
-        self.search_documents(indices, parameters.query, parameters.result_limit, parameters.timeout)
-            .await
-            .map_err(|err| Error::DocumentRetrievalError { source: err.into() })
+        self.search_documents(
+            indices,
+            parameters.query,
+            parameters.result_limit,
+            parameters.timeout,
+        )
+        .await
+        .map_err(|err| Error::DocumentRetrievalError { source: err.into() })
     }
 }

--- a/libs/mimir/src/adapters/secondary/elasticsearch/query.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/query.rs
@@ -15,7 +15,7 @@ impl Search for ElasticsearchStorage {
             .map(|idx| root_doctype(idx))
             .collect();
 
-        self.search_documents(indices, parameters.query, parameters.result_limit)
+        self.search_documents(indices, parameters.query, parameters.result_limit, parameters.timeout)
             .await
             .map_err(|err| Error::DocumentRetrievalError { source: err.into() })
     }

--- a/libs/mimir/src/domain/ports/primary/search_documents.rs
+++ b/libs/mimir/src/domain/ports/primary/search_documents.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 
@@ -20,6 +22,7 @@ pub trait SearchDocuments {
         doc_types: Vec<String>,
         query: Query,
         result_limit: i64,
+        timeout: Option<Duration>,
     ) -> Result<Vec<Self::Document>, ModelError>;
 }
 
@@ -36,11 +39,13 @@ where
         doc_types: Vec<String>,
         query: Query,
         result_limit: i64,
+        timeout: Option<Duration>,
     ) -> Result<Vec<Self::Document>, ModelError> {
         self.search_documents(Parameters {
             doc_types,
             query,
             result_limit,
+            timeout,
         })
         .await
         .map_err(|err| ModelError::DocumentRetrievalError { source: err.into() })

--- a/libs/mimir/src/domain/ports/secondary/search.rs
+++ b/libs/mimir/src/domain/ports/secondary/search.rs
@@ -12,7 +12,7 @@ pub struct Parameters {
     pub doc_types: Vec<String>,
     pub query: Query,
     pub result_limit: i64,
-    pub timeout : Option<Duration>,
+    pub timeout: Option<Duration>,
 }
 
 #[derive(Debug, Snafu)]

--- a/libs/mimir/src/domain/ports/secondary/search.rs
+++ b/libs/mimir/src/domain/ports/secondary/search.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 
 use serde::de::DeserializeOwned;
@@ -10,6 +12,7 @@ pub struct Parameters {
     pub doc_types: Vec<String>,
     pub query: Query,
     pub result_limit: i64,
+    pub timeout : Option<Duration>,
 }
 
 #[derive(Debug, Snafu)]

--- a/libs/mimir/src/utils/deserialize.rs
+++ b/libs/mimir/src/utils/deserialize.rs
@@ -9,3 +9,11 @@ where
     let ms: u64 = Deserialize::deserialize(deserializer)?;
     Ok(Duration::from_millis(ms))
 }
+
+pub fn deserialize_opt_duration<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let ms: u64 = Deserialize::deserialize(deserializer)?;
+    Ok(Some(Duration::from_millis(ms)))
+}

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -183,6 +183,7 @@ mod tests {
                         vec![String::from(Addr::static_doc_type())],
                         Query::QueryString(format!("label:({})", query)),
                         DEFAULT_LIMIT_RESULT_ES,
+                        None,
                     )
                     .await
                     .unwrap()

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -67,6 +67,7 @@ async fn main() {
             ],
             Query::QueryDSL(dsl),
             DEFAULT_LIMIT_RESULT_ES,
+            None,
         )
         .await
         .unwrap()

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -298,6 +298,7 @@ where
             ],
             Query::QueryDSL(reverse),
             DEFAULT_LIMIT_RESULT_ES,
+            None,
         )
         .await
         .map(|results| {

--- a/src/pois.rs
+++ b/src/pois.rs
@@ -198,6 +198,7 @@ async fn into_poi(
             ],
             Query::QueryDSL(dsl),
             1,
+            None,
         )
         .await
         .context(ReverseAddressSearch)

--- a/tests/steps/search.rs
+++ b/tests/steps/search.rs
@@ -102,6 +102,7 @@ impl Step for Search {
                     self.places.clone(),
                     Query::QueryDSL(dsl),
                     DEFAULT_LIMIT_RESULT_ES,
+                    None,
                 )
                 .await
                 .unwrap()


### PR DESCRIPTION
If a "timeout=2000" is present in the query made to bragi, use this timeout value for querying elasticsearch (instead of the default one in the config)