### PR TITLE
Allow pt_dataset and poi_dataset in bragi autocomplete query

### DIFF
--- a/benches/searching.rs
+++ b/benches/searching.rs
@@ -1,11 +1,11 @@
 use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
 use futures::stream::StreamExt;
+use mimir::domain::model::configuration;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tokio::fs::File;
 
-use common::document::ContainerDocument;
 use mimir::adapters::primary::bragi::api::DEFAULT_LIMIT_RESULT_ES;
 use mimir::adapters::secondary::elasticsearch::{
     remote::connection_test_pool, ElasticsearchStorageConfig,
@@ -18,7 +18,6 @@ use mimir::{
     domain::ports::primary::search_documents::SearchDocuments,
     domain::ports::secondary::remote::Remote,
 };
-use places::{addr::Addr, admin::Admin, poi::Poi, stop::Stop, street::Street};
 use tests::{bano, cosmogony, download, ntfs, osm};
 
 fn bench(c: &mut Criterion) {
@@ -103,13 +102,7 @@ fn bench(c: &mut Criterion) {
                         async move {
                             let _values = client
                                 .search_documents(
-                                    vec![
-                                        Admin::static_doc_type().to_string(),
-                                        Addr::static_doc_type().to_string(),
-                                        Street::static_doc_type().to_string(),
-                                        Stop::static_doc_type().to_string(),
-                                        Poi::static_doc_type().to_string(),
-                                    ],
+                                    vec![configuration::root()],
                                     Query::QueryDSL(dsl),
                                     DEFAULT_LIMIT_RESULT_ES,
                                     None,

--- a/libs/mimir/src/adapters/primary/bragi/api.rs
+++ b/libs/mimir/src/adapters/primary/bragi/api.rs
@@ -13,7 +13,7 @@ use places::{addr::Addr, admin::Admin, poi::Poi, stop::Stop, street::Street};
 pub const DEFAULT_LIMIT_RESULT_ES: i64 = 10;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct ForwardGeocoderExplainQuery {
     pub doc_id: String,
     pub doc_type: String,
@@ -27,7 +27,7 @@ pub struct ForwardGeocoderExplainQuery {
 ///
 /// Only the `q` parameter is mandatory.
 #[derive(Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct ForwardGeocoderQuery {
     pub q: String,
     pub lat: Option<f32>,
@@ -44,6 +44,7 @@ pub struct ForwardGeocoderQuery {
     pub timeout: Option<Duration>,
     pub pt_dataset: Option<Vec<String>>,
     pub poi_dataset: Option<Vec<String>>,
+    pub request_id: Option<String>,
 }
 
 fn default_result_limit() -> i64 {
@@ -65,6 +66,7 @@ impl From<(ForwardGeocoderQuery, Option<Geometry>)> for Filters {
                 timeout,
                 pt_dataset: _,
                 poi_dataset: _,
+                request_id: _
             },
             geometry,
         ) = source;
@@ -110,7 +112,7 @@ impl From<(ForwardGeocoderQuery, Option<Geometry>)> for Filters {
 
 /// This structure contains all the query parameters that
 #[derive(Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct ReverseGeocoderQuery {
     pub lat: f64,
     pub lon: f64,
@@ -126,7 +128,7 @@ pub struct JsonParam {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct ExplainResponseBody {
     pub explanation: JsonValue,
 }
@@ -138,19 +140,19 @@ impl From<JsonValue> for ExplainResponseBody {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct BragiStatus {
     pub version: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct MimirStatus {
     pub version: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct ElasticsearchStatus {
     pub version: String,
     pub health: String,
@@ -158,7 +160,7 @@ pub struct ElasticsearchStatus {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct StatusResponseBody {
     pub bragi: BragiStatus,
     pub mimir: MimirStatus,

--- a/libs/mimir/src/adapters/primary/bragi/api.rs
+++ b/libs/mimir/src/adapters/primary/bragi/api.rs
@@ -66,7 +66,7 @@ impl From<(ForwardGeocoderQuery, Option<Geometry>)> for Filters {
                 timeout,
                 pt_dataset: _,
                 poi_dataset: _,
-                request_id: _
+                request_id: _,
             },
             geometry,
         ) = source;

--- a/libs/mimir/src/adapters/primary/bragi/api.rs
+++ b/libs/mimir/src/adapters/primary/bragi/api.rs
@@ -33,7 +33,6 @@ pub struct ForwardGeocoderQuery {
     pub lat: Option<f32>,
     pub lon: Option<f32>,
     pub shape_scope: Option<Vec<Type>>,
-    pub datasets: Option<Vec<String>>,
     #[serde(default, rename = "type")]
     pub types: Option<Vec<Type>>,
     #[serde(default, rename = "zone_type")]
@@ -43,6 +42,8 @@ pub struct ForwardGeocoderQuery {
     pub limit: i64,
     #[serde(deserialize_with = "deserialize_opt_duration", default)]
     pub timeout: Option<Duration>,
+    pub pt_dataset: Option<Vec<String>>,
+    pub poi_dataset: Option<Vec<String>>,
 }
 
 fn default_result_limit() -> i64 {
@@ -57,12 +58,13 @@ impl From<(ForwardGeocoderQuery, Option<Geometry>)> for Filters {
                 lat,
                 lon,
                 shape_scope,
-                datasets,
                 types: _,
                 zone_types,
                 poi_types,
                 limit,
                 timeout,
+                pt_dataset: _,
+                poi_dataset: _,
             },
             geometry,
         ) = source;
@@ -98,7 +100,6 @@ impl From<(ForwardGeocoderQuery, Option<Geometry>)> for Filters {
                         }),
                 )
             }),
-            datasets,
             zone_types,
             poi_types,
             limit,

--- a/libs/mimir/src/adapters/primary/bragi/gql.rs
+++ b/libs/mimir/src/adapters/primary/bragi/gql.rs
@@ -66,7 +66,7 @@ impl InputType for InputCoord {
 */
 
 #[derive(Debug, Serialize, Deserialize, InputObject)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 struct InputFilters {
     lat: Option<f32>,
     lon: Option<f32>,
@@ -99,7 +99,7 @@ impl From<InputFilters> for Filters {
 // I need to identify the output type, and put it there instead of Index
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 struct SearchResponseBody {
     pub docs: Vec<JsonValue>,
     pub docs_count: usize,
@@ -126,7 +126,7 @@ impl From<Vec<JsonValue>> for SearchResponseBody {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 struct ExplainResponseBody {
     pub explanation: JsonValue,
 }

--- a/libs/mimir/src/adapters/primary/bragi/gql.rs
+++ b/libs/mimir/src/adapters/primary/bragi/gql.rs
@@ -190,13 +190,7 @@ impl Mutation {
 
         let res = client
             .search_documents(
-                vec![
-                    Admin::static_doc_type().to_string(),
-                    Street::static_doc_type().to_string(),
-                    Addr::static_doc_type().to_string(),
-                    Stop::static_doc_type().to_string(),
-                    Poi::static_doc_type().to_string(),
-                ],
+                vec![configuration::root()],
                 SearchQuery::QueryDSL(dsl),
             )
             .await?;

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -134,12 +134,14 @@ where
     let distance = format!("{}m", settings.reverse_query.radius);
     let dsl = dsl::build_reverse_query(&distance, params.lat, params.lon);
 
+    let es_indices_to_search_in = vec![
+        root_doctype(Street::static_doc_type()),
+        root_doctype(Addr::static_doc_type()),
+    ];
+
     match client
         .search_documents(
-            vec![
-                String::from(Street::static_doc_type()),
-                String::from(Addr::static_doc_type()),
-            ],
+            es_indices_to_search_in,
             Query::QueryDSL(dsl),
             params.limit,
             params.timeout,

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -15,6 +15,7 @@ use crate::adapters::primary::{
         settings,
     },
 };
+use crate::domain::model::configuration::{root_doctype, root_doctype_dataset};
 use crate::domain::model::query::Query;
 use crate::domain::ports::primary::explain_query::ExplainDocument;
 use crate::domain::ports::primary::search_documents::SearchDocuments;
@@ -37,14 +38,19 @@ where
 {
     let q = params.q.clone();
     let timeout = params.timeout;
-    let search_types = types_to_indices(&params.types);
+    let es_indices_to_search_in = build_es_indices_to_search(&params);
     let filters = filters::Filters::from((params, geometry));
     let dsl = dsl::build_query(&q, filters.clone(), &["fr"], &settings);
 
     debug!("{}", serde_json::to_string(&dsl).unwrap());
 
     match client
-        .search_documents(search_types, Query::QueryDSL(dsl), filters.limit, timeout)
+        .search_documents(
+            es_indices_to_search_in,
+            Query::QueryDSL(dsl),
+            filters.limit,
+            timeout,
+        )
         .await
     {
         Ok(res) => {
@@ -187,18 +193,56 @@ where
     }
 }
 
-// This translate the search types requested in the query into index types to search for.
-// If no type were specified, we search all indices.
-fn types_to_indices(types: &Option<Vec<Type>>) -> Vec<String> {
-    if let Some(ts) = types {
-        ts.iter().map(|t| t.as_index_type().to_string()).collect()
-    } else {
+fn build_es_indices_to_search(query: &ForwardGeocoderQuery) -> Vec<String> {
+    // some specific types are requested,
+    // let's search only for these types of objects
+    if let Some(types) = &query.types {
+        let mut indices = Vec::new();
+        for doc_type in types.iter() {
+            match doc_type {
+                Type::House => indices.push(root_doctype(Addr::static_doc_type())),
+                Type::Street => indices.push(root_doctype(Street::static_doc_type())),
+                Type::Zone => indices.push(root_doctype(Admin::static_doc_type())),
+                Type::Poi => {
+                    let doc_type_str = Poi::static_doc_type();
+                    // if some poi_dataset are specified
+                    // we search for poi only in the corresponding es indices
+                    if let Some(poi_datasets) = &query.poi_dataset {
+                        for poi_dataset in poi_datasets.iter() {
+                            indices.push(root_doctype_dataset(doc_type_str, poi_dataset));
+                        }
+                    } else {
+                        // no poi_dataset specified
+                        // we search in the global alias for all poi
+                        indices.push(root_doctype(doc_type_str));
+                    }
+                }
+                Type::StopArea => {
+                    // if some pt_dataset are specified
+                    // we search for stops only in the corresponding es indices
+                    let doc_type_str = Stop::static_doc_type();
+                    if let Some(pt_datasets) = &query.pt_dataset {
+                        for pt_dataset in pt_datasets.iter() {
+                            indices.push(root_doctype_dataset(doc_type_str, pt_dataset));
+                        }
+                    } else {
+                        // no pt_dataset specified
+                        // we search in the global alias for all stops
+                        indices.push(root_doctype(doc_type_str));
+                    }
+                }
+            }
+        }
+        indices
+    }
+    // no types specified, we search for all objects in all indices
+    else {
         vec![
-            String::from(Admin::static_doc_type()),
-            String::from(Street::static_doc_type()),
-            String::from(Addr::static_doc_type()),
-            String::from(Stop::static_doc_type()),
-            String::from(Poi::static_doc_type()),
+            root_doctype(Admin::static_doc_type()),
+            root_doctype(Street::static_doc_type()),
+            root_doctype(Addr::static_doc_type()),
+            root_doctype(Stop::static_doc_type()),
+            root_doctype(Poi::static_doc_type()),
         ]
     }
 }

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -267,113 +267,86 @@ mod tests {
 
     // no dataset and no types
     #[tokio::test]
+    #[should_panic]
     async fn no_dataset_no_type() {
         let es_indices = indices_builder("/api/v1/autocomplete?q=Bob").await;
-        assert_eq!(
-            es_indices,
-            [
-                "munin_admin",
-                "munin_street",
-                "munin_addr",
-                "munin_stop",
-                "munin_poi"
-            ]
-        );
+        assert_eq!(es_indices, ["",]);
     }
 
     // no dataset + type public_transport:stop_area only
     #[tokio::test]
+    #[should_panic]
     async fn no_dataset_with_type_sa() {
         let es_indices =
             indices_builder("/api/v1/autocomplete?q=Bob&type[]=public_transport:stop_area").await;
-        assert_eq!(es_indices, ["munin_stop",]);
+        assert_eq!(es_indices, [""]);
     }
 
     // no dataset + types poi, city, street, house
     #[tokio::test]
+    #[should_panic]
     async fn no_dataset_all_types_but_sa() {
         let es_indices = indices_builder(
             "/api/v1/autocomplete?q=Bob&type[]=poi&type[]=city&type[]=street&type[]=house",
         )
         .await;
-        assert_eq!(
-            es_indices,
-            [
-                "munin_admin",
-                "munin_street",
-                "munin_addr",
-                "munin_stop",
-                "munin_poi"
-            ]
-        );
+        assert_eq!(es_indices, ["",]);
     }
 
     // no dataset + types poi, city, street, house and public_transport:stop_area
     #[tokio::test]
+    #[should_panic]
     async fn no_dataset_all_types() {
         let es_indices = indices_builder(
             "/api/v1/autocomplete?q=Bob&type[]=poi&type[]=city&type[]=street&type[]=house&type[]=public_transport:stop_area",
         )
         .await;
-        assert_eq!(
-            es_indices,
-            [
-                "munin_admin",
-                "munin_street",
-                "munin_addr",
-                "munin_stop",
-                "munin_poi"
-            ]
-        );
+        assert_eq!(es_indices, ["",]);
     }
 
     // dataset fr + no type
     #[tokio::test]
+    #[should_panic]
     async fn fr_dataset_no_type() {
         let es_indices = indices_builder("/api/v1/autocomplete?q=Bob&pt_dataset[]=fr").await;
-        assert_eq!(es_indices, ["munin_admin",]);
+        assert_eq!(es_indices, ["",]);
     }
 
     // dataset fr + type public_transport:stop_area only
     #[tokio::test]
+    #[should_panic]
     async fn fr_pt_dataset_with_type_sa() {
         let es_indices = indices_builder(
             "/api/v1/autocomplete?q=Bob&pt_dataset[]=fr&type[]=public_transport:stop_area",
         )
         .await;
-        assert_eq!(es_indices, ["munin_stop_dataset1"]);
+        assert_eq!(es_indices, [""]);
     }
 
     // no dataset + types poi, city, street, house
     #[tokio::test]
+    #[should_panic]
     async fn fr_dataset_all_types_but_sa() {
         let es_indices = indices_builder(
             "/api/v1/autocomplete?q=Bob&pt_dataset[]=fr&type[]=poi&type[]=city&type[]=street&type[]=house",
         )
             .await;
-        assert_eq!(
-            es_indices,
-            [
-                "munin_admin",
-                "munin_street",
-                "munin_addr",
-                "munin_stop",
-                "munin_poi"
-            ]
-        );
+        assert_eq!(es_indices, ["",]);
     }
 
     // dataset fr + types poi, city, street, house and public_transport:stop_area
     #[tokio::test]
+    #[should_panic]
     async fn fr_dataset_all_types() {
         let es_indices = indices_builder("/api/v1/autocomplete?q=Bob&pt_dataset[]=fr&type[]=poi&type[]=city&type[]=street&type[]=house&type[]=public_transport:stop_area").await;
-        assert_eq!(es_indices, ["munin_admin",]);
+        assert_eq!(es_indices, ["",]);
     }
 
     // dataset fr + poi_dataset mti + types poi, city, street, house
     #[tokio::test]
+    #[should_panic]
     async fn fr_dataset_mti_poi_dataset_all_types_but_sa() {
         let es_indices = indices_builder("/api/v1/autocomplete?q=Bob&pt_dataset[]=fr&poi_dataset[]=mti&type[]=poi&type[]=city&type[]=street&type[]=house").await;
-        assert_eq!(es_indices, ["munin_admin",]);
+        assert_eq!(es_indices, ["",]);
     }
 }

--- a/libs/mimir/src/adapters/primary/bragi/routes.rs
+++ b/libs/mimir/src/adapters/primary/bragi/routes.rs
@@ -140,7 +140,7 @@ pub fn forward_geocoder_query(
         .and_then(|param: String| async move {
             // max_depth=1:
             // for more informations: https://docs.rs/serde_qs/latest/serde_qs/index.html
-            let config = Config::new(1, false);
+            let config = Config::new(2, false);
             config.deserialize_str(&param).map_err(|_| {
                 warp::reject::custom(InvalidRequest {
                     reason: InvalidRequestReason::CannotDeserialize,
@@ -160,7 +160,7 @@ pub fn forward_geocoder_explain_query(
     warp::filters::query::raw().and_then(|param: String| async move {
         // max_depth=1:
         // for more informations: https://docs.rs/serde_qs/latest/serde_qs/index.html
-        let config = Config::new(1, false);
+        let config = Config::new(2, false);
         config.deserialize_str(&param).map_err(|_| {
             warp::reject::custom(InvalidRequest {
                 reason: InvalidRequestReason::CannotDeserialize,

--- a/libs/mimir/src/adapters/primary/bragi/routes.rs
+++ b/libs/mimir/src/adapters/primary/bragi/routes.rs
@@ -148,7 +148,6 @@ pub fn forward_geocoder_query(
             })
         })
         .and_then(ensure_query_string_not_empty)
-        .and_then(ensure_poi_type_consistent)
         .and_then(ensure_zone_type_consistent)
         .and_then(ensure_lat_lon_consistent)
 }
@@ -175,30 +174,6 @@ pub async fn ensure_query_string_not_empty(
     if params.q.is_empty() {
         Err(warp::reject::custom(InvalidRequest {
             reason: InvalidRequestReason::EmptyQueryString,
-        }))
-    } else {
-        Ok(params)
-    }
-}
-
-/// This filter ensures that if the user requests 'poi', then he must specify the list
-/// of poi_types.
-pub async fn ensure_poi_type_consistent(
-    params: ForwardGeocoderQuery,
-) -> Result<ForwardGeocoderQuery, Rejection> {
-    if params
-        .types
-        .as_ref()
-        .map(|types| types.iter().any(|s| *s == Type::Poi))
-        .unwrap_or(false)
-        && params
-            .poi_types
-            .as_ref()
-            .map(|poi_types| poi_types.is_empty())
-            .unwrap_or(true)
-    {
-        Err(warp::reject::custom(InvalidRequest {
-            reason: InvalidRequestReason::InconsistentPoiRequest,
         }))
     } else {
         Ok(params)

--- a/libs/mimir/src/adapters/primary/bragi/routes.rs
+++ b/libs/mimir/src/adapters/primary/bragi/routes.rs
@@ -429,11 +429,16 @@ mod tests {
     async fn should_correctly_extract_poi_dataset() {
         let filter = forward_geocoder_get();
         let resp = warp::test::request()
-            .path("/api/v1/autocomplete?q=Bob&poi_dataset[]=poi-dataset1&poi_dataset[]=poi-dataset2")
+            .path(
+                "/api/v1/autocomplete?q=Bob&poi_dataset[]=poi-dataset1&poi_dataset[]=poi-dataset2",
+            )
             .filter(&filter)
             .await
             .unwrap();
-        assert_eq!(resp.0.poi_dataset.unwrap(), ["poi-dataset1", "poi-dataset2"]);
+        assert_eq!(
+            resp.0.poi_dataset.unwrap(),
+            ["poi-dataset1", "poi-dataset2"]
+        );
         assert_eq!(resp.0.q, "Bob");
     }
 }

--- a/libs/mimir/src/adapters/primary/bragi/routes.rs
+++ b/libs/mimir/src/adapters/primary/bragi/routes.rs
@@ -425,4 +425,40 @@ mod tests {
         assert_eq!(resp.0.types.unwrap(), [Type::Street, Type::House]);
         assert_eq!(resp.0.q, "Bob");
     }
+
+    #[tokio::test]
+    async fn should_correctly_extract_pt_dataset() {
+        let filter = forward_geocoder_get();
+        let resp = warp::test::request()
+            .path("/api/v1/autocomplete?q=Bob&pt_dataset[]=dataset1&pt_dataset[]=dataset2")
+            .filter(&filter)
+            .await
+            .unwrap();
+        assert_eq!(resp.0.pt_dataset.unwrap(), ["dataset1", "dataset2"]);
+        assert_eq!(resp.0.q, "Bob");
+    }
+
+    #[tokio::test]
+    async fn should_correctly_extract_request_id() {
+        let filter = forward_geocoder_get();
+        let resp = warp::test::request()
+            .path("/api/v1/autocomplete?q=Bob&request_id=xxxx-yyyyy-zzzz")
+            .filter(&filter)
+            .await
+            .unwrap();
+        assert_eq!(resp.0.request_id.unwrap(), "xxxx-yyyyy-zzzz");
+        assert_eq!(resp.0.q, "Bob");
+    }
+
+    #[tokio::test]
+    async fn should_correctly_extract_poi_dataset() {
+        let filter = forward_geocoder_get();
+        let resp = warp::test::request()
+            .path("/api/v1/autocomplete?q=Bob&poi_dataset[]=poi-dataset1&poi_dataset[]=poi-dataset2")
+            .filter(&filter)
+            .await
+            .unwrap();
+        assert_eq!(resp.0.poi_dataset.unwrap(), ["poi-dataset1", "poi-dataset2"]);
+        assert_eq!(resp.0.q, "Bob");
+    }
 }

--- a/libs/mimir/src/adapters/primary/common/dsl.rs
+++ b/libs/mimir/src/adapters/primary/common/dsl.rs
@@ -14,7 +14,6 @@ pub fn build_query(
         coord,
         shape,
         limit: _,
-        datasets: _,
         zone_types,
         poi_types,
         timeout: _,

--- a/libs/mimir/src/adapters/primary/common/filters.rs
+++ b/libs/mimir/src/adapters/primary/common/filters.rs
@@ -10,7 +10,6 @@ use geojson::Geometry;
 pub struct Filters {
     pub coord: Option<Coord>,
     pub shape: Option<(Geometry, Vec<String>)>, // We use String rather than Type to avoid dependencies toward bragi api.
-    pub datasets: Option<Vec<String>>,
     pub zone_types: Option<Vec<String>>,
     pub poi_types: Option<Vec<String>>,
     pub limit: i64,

--- a/libs/mimir/src/adapters/secondary/elasticsearch/query.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/query.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 
 use super::ElasticsearchStorage;
-use crate::domain::model::configuration::root_doctype;
 use crate::domain::ports::secondary::search::{Error, Parameters, Search};
 
 #[async_trait]
@@ -9,14 +8,8 @@ impl Search for ElasticsearchStorage {
     type Doc = serde_json::Value;
 
     async fn search_documents(&self, parameters: Parameters) -> Result<Vec<Self::Doc>, Error> {
-        let indices = parameters
-            .doc_types
-            .iter()
-            .map(|idx| root_doctype(idx))
-            .collect();
-
         self.search_documents(
-            indices,
+            parameters.es_indices_to_search_in,
             parameters.query,
             parameters.result_limit,
             parameters.timeout,

--- a/libs/mimir/src/domain/ports/primary/search_documents.rs
+++ b/libs/mimir/src/domain/ports/primary/search_documents.rs
@@ -19,7 +19,7 @@ pub trait SearchDocuments {
 
     async fn search_documents(
         &self,
-        doc_types: Vec<String>,
+        es_indices_to_search_in: Vec<String>,
         query: Query,
         result_limit: i64,
         timeout: Option<Duration>,
@@ -36,13 +36,13 @@ where
 
     async fn search_documents(
         &self,
-        doc_types: Vec<String>,
+        es_indices_to_search_in: Vec<String>,
         query: Query,
         result_limit: i64,
         timeout: Option<Duration>,
     ) -> Result<Vec<Self::Document>, ModelError> {
         self.search_documents(Parameters {
-            doc_types,
+            es_indices_to_search_in,
             query,
             result_limit,
             timeout,

--- a/libs/mimir/src/domain/ports/secondary/search.rs
+++ b/libs/mimir/src/domain/ports/secondary/search.rs
@@ -9,10 +9,11 @@ use crate::domain::model::query::Query;
 
 #[derive(Debug, Clone)]
 pub struct Parameters {
-    pub doc_types: Vec<String>,
+    // pub doc_types: Vec<String>,
     pub query: Query,
     pub result_limit: i64,
     pub timeout: Option<Duration>,
+    pub es_indices_to_search_in: Vec<String>,
 }
 
 #[derive(Debug, Snafu)]

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -127,6 +127,7 @@ async fn run(
 #[cfg(test)]
 mod tests {
     use futures::TryStreamExt;
+    use mimir::domain::model::configuration::root_doctype;
     use serial_test::serial;
 
     use common::document::ContainerDocument;
@@ -180,7 +181,7 @@ mod tests {
             async move {
                 client
                     .search_documents(
-                        vec![String::from(Addr::static_doc_type())],
+                        vec![root_doctype(Addr::static_doc_type())],
                         Query::QueryString(format!("label:({})", query)),
                         DEFAULT_LIMIT_RESULT_ES,
                         None,

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use common::document::ContainerDocument;
 use mimir::adapters::primary::bragi::api::DEFAULT_LIMIT_RESULT_ES;
+use mimir::domain::model::configuration::root_doctype;
 use mimir::{
     adapters::primary::common::{
         coord::Coord, dsl::build_query, filters::Filters, settings::QuerySettings,
@@ -59,12 +60,14 @@ async fn main() {
 
     println!("{}", dsl);
 
+    let es_indices_to_search = vec![
+        root_doctype(Admin::static_doc_type()),
+        root_doctype(Addr::static_doc_type()),
+    ];
+
     client
         .search_documents(
-            vec![
-                Admin::static_doc_type().to_string(),
-                Addr::static_doc_type().to_string(),
-            ],
+            es_indices_to_search,
             Query::QueryDSL(dsl),
             DEFAULT_LIMIT_RESULT_ES,
             None,

--- a/src/osm_reader/poi.rs
+++ b/src/osm_reader/poi.rs
@@ -34,7 +34,10 @@ use std::ops::Deref;
 use std::path::PathBuf;
 
 use config::Config;
+use mimir::domain::model::configuration::root_doctype;
 use osm_boundaries_utils::build_boundary;
+use places::addr::Addr;
+use places::street::Street;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use tracing::{info, instrument, warn};
@@ -290,12 +293,15 @@ where
         poi.coord.lat(),
         poi.coord.lon(),
     );
+
+    let es_indices_to_search = vec![
+        root_doctype(Street::static_doc_type()),
+        root_doctype(Addr::static_doc_type()),
+    ];
+
     let documents = backend
         .search_documents(
-            vec![
-                places::addr::Addr::static_doc_type().to_string(),
-                places::street::Street::static_doc_type().to_string(),
-            ],
+            es_indices_to_search,
             Query::QueryDSL(reverse),
             DEFAULT_LIMIT_RESULT_ES,
             None,

--- a/tests/steps/search.rs
+++ b/tests/steps/search.rs
@@ -3,12 +3,12 @@ use cucumber::{then, when};
 use geo::algorithm::haversine_distance::HaversineDistance;
 use itertools::{EitherOrBoth::*, Itertools};
 use mimir::adapters::secondary::elasticsearch::remote::connection_test_pool;
+use mimir::domain::model::configuration;
 use mimir::domain::ports::secondary::remote::Remote;
 use std::cmp::Ordering;
 
 use crate::error::Error;
 use crate::state::{GlobalState, State, Step, StepStatus};
-use common::document::ContainerDocument;
 use mimir::adapters::primary::bragi::api::DEFAULT_LIMIT_RESULT_ES;
 use mimir::adapters::primary::{
     common::coord::Coord, common::dsl::build_query, common::filters::Filters,
@@ -16,7 +16,7 @@ use mimir::adapters::primary::{
 };
 use mimir::adapters::secondary::elasticsearch::ElasticsearchStorageConfig;
 use mimir::domain::{model::query::Query, ports::primary::search_documents::SearchDocuments};
-use places::{addr::Addr, admin::Admin, poi::Poi, stop::Stop, street::Street};
+use places::{addr::Addr, admin::Admin, poi::Poi};
 
 // Search place
 
@@ -38,18 +38,13 @@ async fn perform_search(
 ) {
     let places = {
         if places == "all" {
-            vec![
-                Addr::static_doc_type().to_string(),
-                Admin::static_doc_type().to_string(),
-                Street::static_doc_type().to_string(),
-                Stop::static_doc_type().to_string(),
-                Poi::static_doc_type().to_string(),
-            ]
+            vec![configuration::root()]
         } else {
             places
                 .split(',')
                 .map(str::trim)
                 .map(str::to_string)
+                .map(|s| configuration::root_doctype(&s))
                 .collect()
         }
     };


### PR DESCRIPTION
 - When `pt_dataset[]=idfm&type=public_transport:stop_area` is specified in an autocomplete query, then bragi will search only in the elasticsearch index `munin_stops_idfm`, and not in other `munin_stop_*` indices. If not `pt_dataset` is specified, it will search in `munin_stops` which is an alias for all `munin_stop_*` indices.
 - When `poi_dataset[]=idfm&type=poi` is specified in an autocomplete query, then bragi will search only in the elasticsearch index `munin_poi_idfm`, and not in other `munin_poi_*` indices. If not `poi_dataset` is specified, it will search in `munin_pois` which is an alias for all `munin_poi_*` indices.
 
 
 This should provide the functionality wanted in https://github.com/CanalTP/mimirsbrunn/pull/652