### PR TITLE
Reproduce bragi prefix autocomplete search

### DIFF
--- a/benches/searching.rs
+++ b/benches/searching.rs
@@ -97,7 +97,7 @@ fn bench(c: &mut Criterion) {
                         let rec = rec.unwrap();
                         let client = client.clone();
                         let filters = filters.clone();
-                        let dsl = build_query(&rec.query, filters, "fr".to_string(), &settings);
+                        let dsl = build_query(&rec.query, filters, "fr", &settings);
 
                         async move {
                             let _values = client

--- a/benches/searching.rs
+++ b/benches/searching.rs
@@ -97,7 +97,7 @@ fn bench(c: &mut Criterion) {
                         let rec = rec.unwrap();
                         let client = client.clone();
                         let filters = filters.clone();
-                        let dsl = build_query(&rec.query, filters, &["fr"], &settings);
+                        let dsl = build_query(&rec.query, filters, "fr".to_string(), &settings);
 
                         async move {
                             let _values = client

--- a/libs/mimir/src/adapters/primary/bragi/api.rs
+++ b/libs/mimir/src/adapters/primary/bragi/api.rs
@@ -41,6 +41,7 @@ pub struct ForwardGeocoderQuery {
     pub poi_types: Option<Vec<String>>,
     #[serde(default = "default_result_limit")]
     pub limit: i64,
+    pub lang: Option<String>,
     #[serde(deserialize_with = "deserialize_opt_duration", default)]
     pub timeout: Option<Duration>,
     pub pt_dataset: Option<Vec<String>>,

--- a/libs/mimir/src/adapters/primary/bragi/api.rs
+++ b/libs/mimir/src/adapters/primary/bragi/api.rs
@@ -12,6 +12,7 @@ use places::{addr::Addr, admin::Admin, poi::Poi, stop::Stop, street::Street, Pla
 
 pub const DEFAULT_LIMIT_RESULT_ES: i64 = 10;
 pub const DEFAULT_LIMIT_RESULT_REVERSE_API: i64 = 1;
+pub const DEFAULT_LANG: &str = "fr";
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -41,7 +42,8 @@ pub struct ForwardGeocoderQuery {
     pub poi_types: Option<Vec<String>>,
     #[serde(default = "default_result_limit")]
     pub limit: i64,
-    pub lang: Option<String>,
+    #[serde(default = "default_lang")]
+    pub lang: String,
     #[serde(deserialize_with = "deserialize_opt_duration", default)]
     pub timeout: Option<Duration>,
     pub pt_dataset: Option<Vec<String>>,
@@ -58,6 +60,11 @@ fn default_result_limit() -> i64 {
 fn default_result_limit_reverse() -> i64 {
     DEFAULT_LIMIT_RESULT_REVERSE_API
 }
+
+fn default_lang() -> String {
+    DEFAULT_LANG.to_string()
+}
+
 impl From<(ForwardGeocoderQuery, Option<Geometry>)> for Filters {
     fn from(source: (ForwardGeocoderQuery, Option<Geometry>)) -> Self {
         let (query, geometry) = source;

--- a/libs/mimir/src/adapters/primary/bragi/autocomplete.rs
+++ b/libs/mimir/src/adapters/primary/bragi/autocomplete.rs
@@ -39,7 +39,7 @@ pub fn build_query(
     })
 }
 
-fn build_string_query(q: &str, settings: &StringQuery) -> serde_json::Value {
+fn build_autocomplete_should_query(q: &str, _lang: &str, settings: &StringQuery) -> serde_json::Value {
     json!({
         "bool": {
             "boost": settings.global,
@@ -47,23 +47,39 @@ fn build_string_query(q: &str, settings: &StringQuery) -> serde_json::Value {
                 {
                     "multi_match": {
                         "query": q,
-                        "fields": ["name"],
+                        "fields": ["name", format!("names.{}", lang)],
                         "boost": settings.boosts.name
                     }
                 },
                 {
                     "multi_match": {
                         "query": q,
-                        "fields": ["label"],
+                        "fields": ["label", format!("label.{}", lang)],
                         "boost": settings.boosts.label
                     }
                 },
                 {
                     "multi_match": {
                         "query": q,
-                        "fields": ["label.prefix"],
+                        "fields": ["label.prefix", format!("label.prefix.{}", lang)],
                         "boost": settings.boosts.label_prefix
                     }
+                },
+                {
+                    "match": {
+                        "zip_codes": {
+                        "query": q,
+                    }
+                    }
+                    "boost": settings.boosts.zip_codes
+                },
+                {
+                    "match": {
+                        "house_number": {,
+                         "query": q,
+                    }
+                    }
+                   "boost": settings.boosts.house_number
                 }
             ]
         }

--- a/libs/mimir/src/adapters/primary/bragi/autocomplete.rs
+++ b/libs/mimir/src/adapters/primary/bragi/autocomplete.rs
@@ -25,8 +25,6 @@ pub struct Filters {
 
 pub fn build_query(
     q: &str,
-    _filters: Filters,
-    _langs: &[&str],
     settings: &QuerySettings,
 ) -> serde_json::Value {
     json!({
@@ -39,7 +37,7 @@ pub fn build_query(
     })
 }
 
-fn build_autocomplete_should_query(q: &str, _lang: &str, settings: &StringQuery) -> serde_json::Value {
+fn build_autocomplete_should_query(q: &str, lang: &str, settings: &StringQuery) -> serde_json::Value {
     json!({
         "bool": {
             "boost": settings.global,

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -58,8 +58,9 @@ where
     let timeout = params.timeout;
     let es_indices_to_search_in =
         build_es_indices_to_search(&params.types, &params.pt_dataset, &params.poi_dataset);
+    let lang = params.lang.clone().unwrap_or_else(|| "fr".to_string());
     let filters = filters::Filters::from((params, geometry));
-    let dsl = dsl::build_query(&q, filters.clone(), &["fr"], &settings);
+    let dsl = dsl::build_query(&q, filters.clone(), lang, &settings);
 
     debug!("{}", serde_json::to_string(&dsl).unwrap());
 
@@ -116,8 +117,13 @@ where
     S::Document: Serialize + Into<serde_json::Value>,
 {
     let q = params.query.q.clone();
+    let lang = params
+        .query
+        .lang
+        .clone()
+        .unwrap_or_else(|| "fr".to_string());
     let filters = filters::Filters::from((params.query, geometry));
-    let dsl = dsl::build_query(&q, filters, &["fr"], &settings);
+    let dsl = dsl::build_query(&q, filters, lang, &settings);
 
     debug!("{}", serde_json::to_string(&dsl).unwrap());
 

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -58,7 +58,7 @@ where
     let timeout = params.timeout;
     let es_indices_to_search_in =
         build_es_indices_to_search(&params.types, &params.pt_dataset, &params.poi_dataset);
-    let lang = params.lang.clone().unwrap_or_else(|| "fr".to_string());
+    let lang = params.lang.clone();
     let filters = filters::Filters::from((params, geometry));
     let dsl = dsl::build_query(&q, filters.clone(), lang, &settings);
 
@@ -117,11 +117,7 @@ where
     S::Document: Serialize + Into<serde_json::Value>,
 {
     let q = params.query.q.clone();
-    let lang = params
-        .query
-        .lang
-        .clone()
-        .unwrap_or_else(|| "fr".to_string());
+    let lang = params.query.lang.clone();
     let filters = filters::Filters::from((params.query, geometry));
     let dsl = dsl::build_query(&q, filters, lang, &settings);
 

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -60,7 +60,7 @@ where
         build_es_indices_to_search(&params.types, &params.pt_dataset, &params.poi_dataset);
     let lang = params.lang.clone();
     let filters = filters::Filters::from((params, geometry));
-    let dsl = dsl::build_query(&q, filters.clone(), lang, &settings);
+    let dsl = dsl::build_query(&q, filters.clone(), lang.as_str(), &settings);
 
     debug!("{}", serde_json::to_string(&dsl).unwrap());
 
@@ -119,7 +119,7 @@ where
     let q = params.query.q.clone();
     let lang = params.query.lang.clone();
     let filters = filters::Filters::from((params.query, geometry));
-    let dsl = dsl::build_query(&q, filters, lang, &settings);
+    let dsl = dsl::build_query(&q, filters, lang.as_str(), &settings);
 
     debug!("{}", serde_json::to_string(&dsl).unwrap());
 

--- a/libs/mimir/src/adapters/primary/common/dsl.rs
+++ b/libs/mimir/src/adapters/primary/common/dsl.rs
@@ -9,11 +9,11 @@ use super::{filters, settings};
 pub fn build_query(
     q: &str,
     filters: filters::Filters,
-    _lang: String,
+    lang: String,
     settings: &settings::QuerySettings,
 ) -> serde_json::Value {
     let type_query = build_place_type_boost(&settings.type_query.boosts);
-    let string_query = build_string_query(q, _lang.as_str(), &settings.string_query);
+    let string_query = build_string_query(q, lang.as_str(), &settings.string_query);
     let boosts = build_boosts(q, settings, &filters);
     let mut filters_poi = build_filters(filters.shape, filters.poi_types, filters.zone_types);
     let filters = vec![build_house_number_condition(q), build_matching_condition(q)]
@@ -33,7 +33,7 @@ pub fn build_query(
     })
 }
 
-fn build_string_query(q: &str, _lang: &str, settings: &StringQuery) -> serde_json::Value {
+fn build_string_query(q: &str, lang: &str, settings: &StringQuery) -> serde_json::Value {
     json!({
         "bool": {
             "boost": settings.global,
@@ -41,21 +41,21 @@ fn build_string_query(q: &str, _lang: &str, settings: &StringQuery) -> serde_jso
                 {
                     "multi_match": {
                         "query": q,
-                        "fields": ["name", format!("names.{}", _lang)],
+                        "fields": ["name", format!("names.{}", lang)],
                         "boost": settings.boosts.name
                     }
                 },
                 {
                     "multi_match": {
                         "query": q,
-                        "fields": ["label", format!("label.{}", _lang)],
+                        "fields": ["label", format!("label.{}", lang)],
                         "boost": settings.boosts.label
                     }
                 },
                 {
                     "multi_match": {
                         "query": q,
-                        "fields": ["label.prefix", format!("label.prefix.{}", _lang)],
+                        "fields": ["label.prefix", format!("label.prefix.{}", lang)],
                         "boost": settings.boosts.label_prefix
                     }
                 },

--- a/libs/mimir/src/adapters/primary/common/dsl.rs
+++ b/libs/mimir/src/adapters/primary/common/dsl.rs
@@ -1,6 +1,7 @@
 use crate::adapters::primary::common::settings::{BuildWeight, ImportanceQueryBoosts, StringQuery};
 use geojson::Geometry;
 use serde_json::json;
+use std::collections::BTreeMap;
 
 use super::coord::Coord;
 use super::{filters, settings};

--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -1119,11 +1119,11 @@ impl ElasticsearchStorage {
         let response = match query {
             Query::QueryString(_) => {
                 return Err(Error::Internal {
-                    reason: format!("QueryString not handled for get document by id"),
+                    reason: "QueryString not handled for get document by id".to_string(),
                 })
             }
             Query::QueryDSL(json) => get.body(json).send().await.context(ElasticsearchClient {
-                details: format!("could not get document by id"),
+                details: "could not get document by id".to_string(),
             })?,
         };
 

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -56,7 +56,7 @@ async fn main() {
 
     let settings = QuerySettings::default();
 
-    let dsl = build_query(&opt.q, filters, "fr".to_string(), &settings);
+    let dsl = build_query(&opt.q, filters, "fr", &settings);
 
     println!("{}", dsl);
 

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -56,7 +56,7 @@ async fn main() {
 
     let settings = QuerySettings::default();
 
-    let dsl = build_query(&opt.q, filters, &["fr"], &settings);
+    let dsl = build_query(&opt.q, filters, "fr".to_string(), &settings);
 
     println!("{}", dsl);
 

--- a/src/bragi/server.rs
+++ b/src/bragi/server.rs
@@ -119,7 +119,7 @@ pub async fn run_server(settings: Settings) -> Result<(), Error> {
             routes::cache_filter(filter, settings.http_cache_duration)
         }))
         .with(warp::trace::request())
-        .with(warp::log::custom(move |log| update_metrics(log)));
+        .with(warp::log::custom(update_metrics));
 
     info!("api ready");
 

--- a/tests/steps/search.rs
+++ b/tests/steps/search.rs
@@ -105,7 +105,7 @@ impl Step for Search {
         let dsl = build_query(
             &self.query,
             self.filters.clone(),
-            "fr".to_string(),
+            "fr",
             &QuerySettings::default(),
         );
 

--- a/tests/steps/search.rs
+++ b/tests/steps/search.rs
@@ -60,15 +60,12 @@ async fn perform_search(
         }
     };
 
-    let zone_types = match zone_types {
-        Some(f) => Some(
-            f.split(',')
-                .map(str::trim)
-                .map(str::to_string)
-                .collect::<Vec<String>>(),
-        ),
-        _ => None,
-    };
+    let zone_types = zone_types.map(|f| {
+        f.split(',')
+            .map(str::trim)
+            .map(str::to_string)
+            .collect::<Vec<String>>()
+    });
 
     let filters = Filters {
         coord,
@@ -108,7 +105,7 @@ impl Step for Search {
         let dsl = build_query(
             &self.query,
             self.filters.clone(),
-            &["fr"],
+            "fr".to_string(),
             &QuerySettings::default(),
         );
 


### PR DESCRIPTION
Reproduce in ElasticSearch7 what Bragi, with ES2, was doing for the `prefix` autocomplete part.
