### PR TITLE
Change Var Env separator

### DIFF
--- a/config/bano2mimir/default.toml
+++ b/config/bano2mimir/default.toml
@@ -1,4 +1,4 @@
-nbthreads = 2
+nb_threads = 2
 
 [container]
   name = "addr"

--- a/config/bragi/default.toml
+++ b/config/bragi/default.toml
@@ -1,5 +1,5 @@
 mode = "default"
-nbthreads = 2
+nb_threads = 2
 
 [service]
 host = "0.0.0.0"

--- a/config/cosmogony2mimir/default.toml
+++ b/config/cosmogony2mimir/default.toml
@@ -1,5 +1,5 @@
 langs = [ "fr" ]
-nbthreads = 2
+nb_threads = 2
 
 [container]
   name = "admin"

--- a/config/ntfs2mimir/default.toml
+++ b/config/ntfs2mimir/default.toml
@@ -1,4 +1,4 @@
-nbthreads = 2
+nb_threads = 2
 
 [container]
   name = "stop"

--- a/config/openaddresses2mimir/default.toml
+++ b/config/openaddresses2mimir/default.toml
@@ -1,4 +1,4 @@
-nbthreads = 2
+nb_threads = 2
 
 [container]
   name = "addr"

--- a/config/osm2mimir/default.toml
+++ b/config/osm2mimir/default.toml
@@ -1,4 +1,4 @@
-nbthreads = 2
+nb_threads = 2
 
 [container-poi]
   name = "poi"

--- a/config/poi2mimir/default.toml
+++ b/config/poi2mimir/default.toml
@@ -1,4 +1,4 @@
-nbthreads = 2
+nb_threads = 2
 
 [container]
   name = "poi"

--- a/libs/common/src/config.rs
+++ b/libs/common/src/config.rs
@@ -69,7 +69,7 @@ pub fn config_from<
     // Add in settings from the environment
     // Eg.. `<prefix>_DEBUG=1 ./target/app` would set the `debug` key
     if let Some(prefix) = prefix.into() {
-        let prefix = Environment::with_prefix(prefix).separator("-");
+        let prefix = Environment::with_prefix(prefix).separator("__");
         config.merge(prefix).context(ConfigCompilation)?;
     };
 

--- a/libs/common/src/config.rs
+++ b/libs/common/src/config.rs
@@ -69,7 +69,7 @@ pub fn config_from<
     // Add in settings from the environment
     // Eg.. `<prefix>_DEBUG=1 ./target/app` would set the `debug` key
     if let Some(prefix) = prefix.into() {
-        let prefix = Environment::with_prefix(prefix).separator("_");
+        let prefix = Environment::with_prefix(prefix).separator("-");
         config.merge(prefix).context(ConfigCompilation)?;
     };
 

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), Error> {
     match opts.cmd {
         settings::Command::Run => mimirsbrunn::utils::launch::launch_with_runtime(
             &settings.logging.path.clone(),
-            settings.nbthreads,
+            settings.nb_threads,
             run(opts, settings),
         )
         .context(Execution),

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), Error> {
     match opts.cmd {
         settings::Command::Run => mimirsbrunn::utils::launch::launch_with_runtime(
             &settings.logging.path.clone(),
-            settings.nbthreads,
+            settings.nb_threads,
             run(opts, settings),
         )
         .context(Execution),

--- a/src/bin/ctlmimir.rs
+++ b/src/bin/ctlmimir.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Error> {
     match opts.cmd {
         settings::Command::Run => mimirsbrunn::utils::launch::launch_with_runtime(
             &settings.logging.path.clone(),
-            settings.nbthreads,
+            settings.nb_threads,
             run(opts, settings),
         )
         .context(Execution),

--- a/src/bin/ntfs2mimir.rs
+++ b/src/bin/ntfs2mimir.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), Error> {
     match opts.cmd {
         settings::Command::Run => mimirsbrunn::utils::launch::launch_with_runtime(
             &settings.logging.path.clone(),
-            settings.nbthreads,
+            settings.nb_threads,
             run(opts, settings),
         )
         .context(Execution),

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -71,7 +71,7 @@ fn main() -> Result<(), Error> {
     match opts.cmd {
         settings::Command::Run => mimirsbrunn::utils::launch::launch_with_runtime(
             &settings.logging.path.clone(),
-            settings.nbthreads,
+            settings.nb_threads,
             run(opts, settings),
         )
         .context(Execution),

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Error> {
     match opts.cmd {
         settings::Command::Run => mimirsbrunn::utils::launch::launch_with_runtime(
             &settings.logging.path.clone(),
-            settings.nbthreads,
+            settings.nb_threads,
             run(opts, settings),
         )
         .context(Execution),

--- a/src/bin/poi2mimir.rs
+++ b/src/bin/poi2mimir.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Error> {
     match opts.cmd {
         settings::Command::Run => mimirsbrunn::utils::launch::launch_with_runtime(
             &settings.logging.path.clone(),
-            settings.nbthreads,
+            settings.nb_threads,
             run(opts, settings),
         )
         .context(Execution),

--- a/src/bragi/server.rs
+++ b/src/bragi/server.rs
@@ -78,7 +78,7 @@ pub fn run(opts: &Opts) -> Result<(), Error> {
     tracing::subscriber::set_global_default(subscriber).expect("tracing subscriber global default");
 
     let runtime = runtime::Builder::new_multi_thread()
-        .worker_threads(settings.nbthreads.unwrap_or_else(num_cpus::get))
+        .worker_threads(settings.nb_threads.unwrap_or_else(num_cpus::get))
         .enable_all()
         .build()
         .expect("Failed to build tokio runtime.");

--- a/src/bragi/settings.rs
+++ b/src/bragi/settings.rs
@@ -60,7 +60,7 @@ pub struct Settings {
     pub elasticsearch: ElasticsearchStorageConfig,
     pub query: QuerySettings,
     pub service: Service,
-    pub nbthreads: Option<usize>,
+    pub nb_threads: Option<usize>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/bragi/settings.rs
+++ b/src/bragi/settings.rs
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_port_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("BRAGI_ELASTICSEARCH_URL", "http://localhost:9999");
+        std::env::set_var("BRAGI_ELASTICSEARCH-URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: Some(String::from("testing")),

--- a/src/bragi/settings.rs
+++ b/src/bragi/settings.rs
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_port_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("BRAGI_ELASTICSEARCH-URL", "http://localhost:9999");
+        std::env::set_var("BRAGI_ELASTICSEARCH__URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: Some(String::from("testing")),

--- a/src/settings/bano2mimir.rs
+++ b/src/settings/bano2mimir.rs
@@ -40,7 +40,7 @@ pub struct Settings {
     pub container: ContainerConfig,
     #[cfg(feature = "db-storage")]
     pub database: Option<Database>,
-    pub nbthreads: Option<usize>,
+    pub nb_threads: Option<usize>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/bano2mimir.rs
+++ b/src/settings/bano2mimir.rs
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_url_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH__URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/bano2mimir.rs
+++ b/src/settings/bano2mimir.rs
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_url_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH_URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/cosmogony2mimir.rs
+++ b/src/settings/cosmogony2mimir.rs
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_url_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH__URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/cosmogony2mimir.rs
+++ b/src/settings/cosmogony2mimir.rs
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_url_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH_URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/cosmogony2mimir.rs
+++ b/src/settings/cosmogony2mimir.rs
@@ -32,7 +32,7 @@ pub struct Settings {
     pub langs: Vec<String>,
     pub elasticsearch: ElasticsearchStorageConfig,
     pub container: ContainerConfig,
-    pub nbthreads: Option<usize>,
+    pub nb_threads: Option<usize>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/ctlmimir.rs
+++ b/src/settings/ctlmimir.rs
@@ -33,7 +33,7 @@ pub struct Settings {
     pub mode: Option<String>,
     pub logging: Logging,
     pub elasticsearch: ElasticsearchStorageConfig,
-    pub nbthreads: Option<usize>,
+    pub nb_threads: Option<usize>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/ntfs2mimir.rs
+++ b/src/settings/ntfs2mimir.rs
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_url_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH_URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/ntfs2mimir.rs
+++ b/src/settings/ntfs2mimir.rs
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_url_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH__URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/ntfs2mimir.rs
+++ b/src/settings/ntfs2mimir.rs
@@ -31,7 +31,7 @@ pub struct Settings {
     pub logging: Logging,
     pub elasticsearch: ElasticsearchStorageConfig,
     pub container: ContainerConfig,
-    pub nbthreads: Option<usize>,
+    pub nb_threads: Option<usize>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/openaddresses2mimir.rs
+++ b/src/settings/openaddresses2mimir.rs
@@ -159,7 +159,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_url_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH_URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/openaddresses2mimir.rs
+++ b/src/settings/openaddresses2mimir.rs
@@ -159,7 +159,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_url_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH__URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/openaddresses2mimir.rs
+++ b/src/settings/openaddresses2mimir.rs
@@ -46,7 +46,7 @@ pub struct Settings {
     pub coordinates: Coordinates,
     #[cfg(feature = "db-storage")]
     pub database: Option<Database>,
-    pub nbthreads: Option<usize>,
+    pub nb_threads: Option<usize>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/osm2mimir.rs
+++ b/src/settings/osm2mimir.rs
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_port_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH_URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/osm2mimir.rs
+++ b/src/settings/osm2mimir.rs
@@ -56,7 +56,7 @@ pub struct Settings {
     pub container_street: ContainerConfig,
     #[cfg(feature = "db-storage")]
     pub database: Option<Database>,
-    pub nbthreads: Option<usize>,
+    pub nb_threads: Option<usize>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/osm2mimir.rs
+++ b/src/settings/osm2mimir.rs
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_port_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH__URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/poi2mimir.rs
+++ b/src/settings/poi2mimir.rs
@@ -36,7 +36,7 @@ pub struct Settings {
     pub logging: Logging,
     pub elasticsearch: ElasticsearchStorageConfig,
     pub container: ContainerConfig,
-    pub nbthreads: Option<usize>,
+    pub nb_threads: Option<usize>,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/poi2mimir.rs
+++ b/src/settings/poi2mimir.rs
@@ -149,7 +149,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_port_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH_URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,

--- a/src/settings/poi2mimir.rs
+++ b/src/settings/poi2mimir.rs
@@ -149,7 +149,7 @@ mod tests {
     #[test]
     fn should_override_elasticsearch_port_environment_variable() {
         let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config");
-        std::env::set_var("MIMIR_ELASTICSEARCH-URL", "http://localhost:9999");
+        std::env::set_var("MIMIR_ELASTICSEARCH__URL", "http://localhost:9999");
         let opts = Opts {
             config_dir,
             run_mode: None,


### PR DESCRIPTION
This PR allow variable like "nb_thread" to be set by an env var with underscore character ->  BRAGI_NB_THREADS. 
So now to set for example ES URL we have to use the following env var : 
BRAGI_ELASTICSEARCH__URL instead of BRAGI_ELASTICSEARCH_URL previously 