### PR TITLE
Remove "boundary" field from Elasticsearch's responses to bragi

### DIFF
--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -200,6 +200,12 @@ where
         build_es_indices_to_search(&None, &params.pt_dataset, &params.poi_dataset);
     let dsl = dsl::build_features_query(&es_indices_to_search_in, &doc_id);
 
+    tracing::trace!(
+        "Searching in indexes {:?} with query {}",
+        es_indices_to_search_in,
+        serde_json::to_string_pretty(&dsl).unwrap()
+    );
+
     match client
         .get_documents_by_id(Query::QueryDSL(dsl), timeout)
         .await

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -61,7 +61,7 @@ where
     let filters = filters::Filters::from((params, geometry));
     let dsl = dsl::build_query(&q, filters.clone(), &["fr"], &settings);
 
-    debug!("{}", serde_json::to_string(&dsl).unwrap());
+    tracing::trace!("Searching in indexes {:?} with query {}", es_indices_to_search_in, serde_json::to_string_pretty(&dsl).unwrap());
 
     match client
         .search_documents(
@@ -149,6 +149,9 @@ where
         root_doctype(Street::static_doc_type()),
         root_doctype(Addr::static_doc_type()),
     ];
+
+    tracing::trace!("Searching in indexes {:?} with query {}", es_indices_to_search_in, serde_json::to_string_pretty(&dsl).unwrap());
+
 
     match client
         .search_documents(

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -61,7 +61,11 @@ where
     let filters = filters::Filters::from((params, geometry));
     let dsl = dsl::build_query(&q, filters.clone(), &["fr"], &settings);
 
-    tracing::trace!("Searching in indexes {:?} with query {}", es_indices_to_search_in, serde_json::to_string_pretty(&dsl).unwrap());
+    tracing::trace!(
+        "Searching in indexes {:?} with query {}",
+        es_indices_to_search_in,
+        serde_json::to_string_pretty(&dsl).unwrap()
+    );
 
     match client
         .search_documents(
@@ -150,8 +154,11 @@ where
         root_doctype(Addr::static_doc_type()),
     ];
 
-    tracing::trace!("Searching in indexes {:?} with query {}", es_indices_to_search_in, serde_json::to_string_pretty(&dsl).unwrap());
-
+    tracing::trace!(
+        "Searching in indexes {:?} with query {}",
+        es_indices_to_search_in,
+        serde_json::to_string_pretty(&dsl).unwrap()
+    );
 
     match client
         .search_documents(

--- a/libs/mimir/src/adapters/primary/common/dsl.rs
+++ b/libs/mimir/src/adapters/primary/common/dsl.rs
@@ -346,7 +346,7 @@ pub fn build_zone_types_filter(zone_types: Vec<String>) -> serde_json::Value {
 pub fn build_features_query(indices: &[String], doc_id: &str) -> serde_json::Value {
     let vec: Vec<serde_json::Value> = indices
         .iter()
-        .map(|index|
+        .map(|index| {
             json!({
                 "_index": index,
                 "_id" : doc_id,
@@ -354,6 +354,7 @@ pub fn build_features_query(indices: &[String], doc_id: &str) -> serde_json::Val
                     "exclude" : "boundary"
                 }
             })
-        ).collect();
+        })
+        .collect();
     json!({ "docs": vec })
 }

--- a/libs/mimir/src/adapters/primary/common/dsl.rs
+++ b/libs/mimir/src/adapters/primary/common/dsl.rs
@@ -1,6 +1,5 @@
 use geojson::Geometry;
 use serde_json::json;
-use std::collections::BTreeMap;
 
 use super::coord::Coord;
 use super::{filters, settings};
@@ -345,13 +344,16 @@ pub fn build_zone_types_filter(zone_types: Vec<String>) -> serde_json::Value {
 }
 
 pub fn build_features_query(indices: &[String], doc_id: &str) -> serde_json::Value {
-    let vec: Vec<BTreeMap<&str, &str>> = indices
+    let vec: Vec<serde_json::Value> = indices
         .iter()
-        .map(|index| {
-            vec![("_index", index.as_str()), ("_id", doc_id)]
-                .into_iter()
-                .collect()
-        })
-        .collect();
+        .map(|index|
+            json!({
+                "_index": index,
+                "_id" : doc_id,
+                "_source" : {
+                    "exclude" : "boundary"
+                }
+            })
+        ).collect();
     json!({ "docs": vec })
 }

--- a/libs/mimir/src/adapters/primary/common/dsl.rs
+++ b/libs/mimir/src/adapters/primary/common/dsl.rs
@@ -21,7 +21,10 @@ pub fn build_query(
                     "must": [ string_query ],
                     "should": boosts
                 }
-            }
+            },
+            "_source": {
+                "excludes": [ "boundary" ]
+            },
         })
     } else {
         json!({
@@ -35,7 +38,10 @@ pub fn build_query(
                         }
                     }
                 }
-            }
+            },
+            "_source": {
+                "excludes": [ "boundary" ]
+            },
         })
     }
 }
@@ -178,6 +184,9 @@ pub fn build_reverse_query(distance: &str, lat: f64, lon: f64) -> serde_json::Va
                 }
             }
         }
+    },
+    "_source": {
+        "excludes": [ "boundary" ]
     },
     "sort": [{
          "_geo_distance": {


### PR DESCRIPTION
Since the "boundary" field is quite heavy, and not used in bragi anyway, we ask Elasticsearch to *not* include it in its responses.

The  "boundary" field is still included by Elasticsearch in the queries made in *2mimir