### PR TITLE
Control time spent in elasticsearch

### DIFF
--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -78,6 +78,7 @@ where
         .await
     {
         Ok(res) => {
+            tracing::trace!("Elasticsearch response {}", serde_json::to_string_pretty(&res).unwrap());
             let places: Result<Vec<Place>, serde_json::Error> = res
                 .into_iter()
                 .map(|json| serde_json::from_value::<Place>(json.into()))
@@ -102,10 +103,13 @@ where
                 })),
             }
         }
-        Err(err) => Err(warp::reject::custom(InternalError {
-            reason: InternalErrorReason::ElasticSearchError,
-            info: err.to_string(),
-        })),
+        Err(err) => {
+            tracing::trace!("Elasticsearch reponded with error {}", &err);
+            Err(warp::reject::custom(InternalError {
+                reason: InternalErrorReason::ElasticSearchError,
+                info: err.to_string(),
+            }))
+        },
     }
 }
 

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -78,7 +78,10 @@ where
         .await
     {
         Ok(res) => {
-            tracing::trace!("Elasticsearch response {}", serde_json::to_string_pretty(&res).unwrap());
+            tracing::trace!(
+                "Elasticsearch response {}",
+                serde_json::to_string_pretty(&res).unwrap()
+            );
             let places: Result<Vec<Place>, serde_json::Error> = res
                 .into_iter()
                 .map(|json| serde_json::from_value::<Place>(json.into()))
@@ -109,7 +112,7 @@ where
                 reason: InternalErrorReason::ElasticSearchError,
                 info: err.to_string(),
             }))
-        },
+        }
     }
 }
 

--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -1070,9 +1070,7 @@ impl ElasticsearchStorage {
             // search in each *shard* will end after timeout_str
             .timeout(&timeout_str)
             // global search will end after 2*timeout
-            .request_timeout(timeout.saturating_add(timeout))
-            
-            ;
+            .request_timeout(timeout.saturating_add(timeout));
 
         let response = match query {
             Query::QueryString(q) => search.q(&q).send().await.context(ElasticsearchClient {

--- a/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
+++ b/libs/mimir/src/adapters/secondary/elasticsearch/internal.rs
@@ -1054,12 +1054,13 @@ impl ElasticsearchStorage {
                 }
             }) // let's cap the timeout to self.config.timeout to prevent overloading elasticsearch with long requests
             .unwrap_or(self.config.timeout);
+        let timeout_str = format!("{}ms", timeout.as_millis());
 
         let search = self
             .client
             .search(SearchParts::Index(&indices))
-            .size(limit_result)
-            .request_timeout(timeout);
+            .terminate_after(limit_result)
+            .timeout(&timeout_str);
 
         let response = match query {
             Query::QueryString(q) => search.q(&q).send().await.context(ElasticsearchClient {


### PR DESCRIPTION
The `request_timeout()` is just setting a timeout after which, if bragi did not receive an http response from ES, an http error is returned from `.send()`.

Here I try different settings to limit the time spent in elasticsearch.

Some docs :
https://www.elastic.co/guide/en/elasticsearch/reference/7.15/search-search.html 
https://docs.rs/elasticsearch/7.14.0-alpha.1/elasticsearch/struct.Search.html#