### PR TITLE
Fix empty answer autocomplete

### DIFF
--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -133,10 +133,7 @@ where
         }
     }
 
-    Err(warp::reject::custom(InternalError {
-        reason: InternalErrorReason::ObjectNotFoundError,
-        info: "Object not found".to_string(),
-    }))
+    Ok(with_status(json(&GeocodeJsonResponse::new(q, vec![])), StatusCode::OK))
 }
 
 #[instrument(skip(client, settings))]

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -133,7 +133,10 @@ where
         }
     }
 
-    Ok(with_status(json(&GeocodeJsonResponse::new(q, vec![])), StatusCode::OK))
+    Ok(with_status(
+        json(&GeocodeJsonResponse::new(q, vec![])),
+        StatusCode::OK,
+    ))
 }
 
 #[instrument(skip(client, settings))]


### PR DESCRIPTION
On autocomplete endpoint, when no answer is found, return :
```
type	"FeatureCollection"
geocoding	
version	"0.1.0"
query	""
features	[]
```
Reverse endpoint should already return this answer 