### PR TITLE
Remove `search_as_you_type` field to use previous mapping

### DIFF
--- a/config/elasticsearch/templates/components/mimir-base.json
+++ b/config/elasticsearch/templates/components/mimir-base.json
@@ -8,22 +8,46 @@
         "analysis": {
           "analyzer": {
             "word": {
+              "type": "custom",
               "tokenizer": "standard",
-              "filter": [
-                "lowercase",
-                "asciifolding"
-              ],
-              "char_filter": []
+              "filter": [ "lowercase", "asciifolding" ],
+              "char_filter" : [ ]
             },
-            "label_analyzer": {
+            "word_elision": {
+              "type": "custom",
               "tokenizer": "standard",
-              "filter": [
-                "lowercase",
-                "asciifolding",
-                "synonym",
-                "elision"
-              ],
-              "char_filter": []
+              "filter": [ "lowercase", "elision_filter", "asciifolding" ],
+              "char_filter" : [ ]
+            },
+            "prefix": {
+              "type": "custom",
+              "tokenizer": "standard",
+              "filter": [ "lowercase", "asciifolding", "synonym_filter", "prefix_filter" ],
+              "char_filter" : [ ]
+            },
+            "prefix_elision": {
+              "type": "custom",
+              "tokenizer": "standard",
+              "filter": [ "lowercase", "elision_filter", "asciifolding", "synonym_filter", "prefix_filter" ],
+              "char_filter" : [ ]
+            },
+            "ngram_with_synonyms": {
+              "type": "custom",
+              "tokenizer": "standard",
+              "filter": [ "lowercase", "asciifolding", "synonym_filter", "ngram_filter" ],
+              "char_filter" : [ ]
+            },
+            "ngram": {
+              "tokenizer": "my_ngram_tokenizer",
+              "filter": [ "lowercase", "asciifolding" ]
+            }
+          },
+          "tokenizer": {
+            "my_ngram_tokenizer": {
+              "type": "nGram",
+              "min_gram": "3",
+              "max_gram": "3",
+              "token_chars": [ "letter", "digit" ]
             }
           },
           "filter": {
@@ -55,6 +79,16 @@
                 "l",
                 "d"
               ]
+            },
+            "ngram": {
+              "type": "nGram",
+              "min_gram": "3",
+              "max_gram": "3"
+            },
+            "prefix": {
+              "type": "edge_ngram",
+              "min_gram": 1,
+              "max_gram": 20
             }
           }
         }
@@ -84,12 +118,73 @@
             "enabled": false
           },
           "label": {
-            "type": "search_as_you_type",
-            "analyzer": "label_analyzer"
+            "type": "text",
+            "analyzer": "label_analyzer",
+            "copy_to": "full_label",
+            "fields": {
+              "prefix": {
+                "type": "text",
+                "index_options": "docs",
+                "analyzer": "prefix",
+                "search_analyzer": "word",
+                "norms": {
+                  "enabled": false
+                }
+              },
+              "ngram": {
+                "type": "text",
+                "index_options": "docs",
+                "analyzer": "ngram_with_synonyms",
+                "search_analyzer": "ngram",
+                "norms": {
+                  "enabled": false
+                }
+              }
+            },
+            "norms": {
+              "enabled": false
+            }
+          },
+          "full_label": {
+            "type": "text",
+            "index_options": "docs",
+            "analyzer": "word",
+            "fields": {
+              "prefix": {
+                "type": "text",
+                "index_options": "docs",
+                "analyzer": "prefix_elision",
+                "search_analyzer": "word_elision",
+                "norms": {
+                  "enabled": false
+                }
+              },
+              "ngram": {
+                "type": "text",
+                "index_options": "docs",
+                "analyzer": "ngram_with_synonyms",
+                "search_analyzer": "ngram",
+                "norms": {
+                  "enabled": false
+                }
+              }
+            },
+            "norms": {
+              "enabled": false
+            }
           },
           "name": {
             "type": "text",
-            "analyzer": "word"
+            "index_options": "docs",
+            "analyzer": "word",
+            "fields": {
+              "prefix": {
+                "type": "string",
+                "index_options": "docs",
+                "analyzer": "prefix",
+                "search_analyzer": "word"
+              }
+            }
           },
           "weight": {
             "type": "float"
@@ -97,7 +192,16 @@
           "zip_codes": {
             "type": "text",
             "index_options": "docs",
-            "analyzer": "word"
+            "analyzer": "word",
+            "copy_to": "full_label",
+            "fields": {
+              "prefix": {
+                "type": "string",
+                "index_options": "docs",
+                "analyzer": "prefix",
+                "search_analyzer": "word"
+              }
+            }
           }
         }
       }

--- a/config/elasticsearch/templates/components/mimir-base.json
+++ b/config/elasticsearch/templates/components/mimir-base.json
@@ -10,36 +10,62 @@
             "word": {
               "type": "custom",
               "tokenizer": "standard",
-              "filter": [ "lowercase", "asciifolding" ],
-              "char_filter" : [ ]
+              "filter": [
+                "lowercase",
+                "asciifolding"
+              ],
+              "char_filter": []
             },
             "word_elision": {
               "type": "custom",
               "tokenizer": "standard",
-              "filter": [ "lowercase", "elision_filter", "asciifolding" ],
-              "char_filter" : [ ]
+              "filter": [
+                "lowercase",
+                "elision",
+                "asciifolding"
+              ],
+              "char_filter": []
             },
             "prefix": {
               "type": "custom",
               "tokenizer": "standard",
-              "filter": [ "lowercase", "asciifolding", "synonym_filter", "prefix_filter" ],
-              "char_filter" : [ ]
+              "filter": [
+                "lowercase",
+                "asciifolding",
+                "synonym",
+                "prefix"
+              ],
+              "char_filter": []
             },
             "prefix_elision": {
               "type": "custom",
               "tokenizer": "standard",
-              "filter": [ "lowercase", "elision_filter", "asciifolding", "synonym_filter", "prefix_filter" ],
-              "char_filter" : [ ]
+              "filter": [
+                "lowercase",
+                "elision",
+                "asciifolding",
+                "synonym",
+                "prefix"
+              ],
+              "char_filter": []
             },
             "ngram_with_synonyms": {
               "type": "custom",
               "tokenizer": "standard",
-              "filter": [ "lowercase", "asciifolding", "synonym_filter", "ngram_filter" ],
-              "char_filter" : [ ]
+              "filter": [
+                "lowercase",
+                "asciifolding",
+                "synonym",
+                "ngram"
+              ],
+              "char_filter": []
             },
             "ngram": {
               "tokenizer": "my_ngram_tokenizer",
-              "filter": [ "lowercase", "asciifolding" ]
+              "filter": [
+                "lowercase",
+                "asciifolding"
+              ]
             }
           },
           "tokenizer": {
@@ -47,7 +73,10 @@
               "type": "nGram",
               "min_gram": "3",
               "max_gram": "3",
-              "token_chars": [ "letter", "digit" ]
+              "token_chars": [
+                "letter",
+                "digit"
+              ]
             }
           },
           "filter": {
@@ -119,7 +148,8 @@
           },
           "label": {
             "type": "text",
-            "analyzer": "label_analyzer",
+            "index_options": "docs",
+            "analyzer": "word",
             "copy_to": "full_label",
             "fields": {
               "prefix": {
@@ -127,23 +157,17 @@
                 "index_options": "docs",
                 "analyzer": "prefix",
                 "search_analyzer": "word",
-                "norms": {
-                  "enabled": false
-                }
+                "norms": false
               },
               "ngram": {
                 "type": "text",
                 "index_options": "docs",
                 "analyzer": "ngram_with_synonyms",
                 "search_analyzer": "ngram",
-                "norms": {
-                  "enabled": false
-                }
+                "norms": false
               }
             },
-            "norms": {
-              "enabled": false
-            }
+            "norms": false
           },
           "full_label": {
             "type": "text",
@@ -155,23 +179,17 @@
                 "index_options": "docs",
                 "analyzer": "prefix_elision",
                 "search_analyzer": "word_elision",
-                "norms": {
-                  "enabled": false
-                }
+                "norms": false
               },
               "ngram": {
                 "type": "text",
                 "index_options": "docs",
                 "analyzer": "ngram_with_synonyms",
                 "search_analyzer": "ngram",
-                "norms": {
-                  "enabled": false
-                }
+                "norms": false
               }
             },
-            "norms": {
-              "enabled": false
-            }
+            "norms": false
           },
           "name": {
             "type": "text",
@@ -179,7 +197,7 @@
             "analyzer": "word",
             "fields": {
               "prefix": {
-                "type": "string",
+                "type": "text",
                 "index_options": "docs",
                 "analyzer": "prefix",
                 "search_analyzer": "word"
@@ -196,7 +214,7 @@
             "copy_to": "full_label",
             "fields": {
               "prefix": {
-                "type": "string",
+                "type": "text",
                 "index_options": "docs",
                 "analyzer": "prefix",
                 "search_analyzer": "word"

--- a/config/elasticsearch/templates/components/mimir-dynamic-mappings.json
+++ b/config/elasticsearch/templates/components/mimir-dynamic-mappings.json
@@ -13,7 +13,7 @@
                 "analyzer": "word",
                 "fields": {
                   "prefix": {
-                    "type": "string",
+                    "type": "text",
                     "index_options": "docs",
                     "analyzer": "prefix",
                     "search_analyzer": "word"
@@ -37,23 +37,17 @@
                     "index_options": "docs",
                     "analyzer": "prefix",
                     "search_analyzer": "word",
-                    "norms": {
-                      "enabled": false
-                    }
+                    "norms": false
                   },
                   "ngram": {
                     "type": "text",
                     "index_options": "docs",
                     "analyzer": "ngram_with_synonyms",
                     "search_analyzer": "ngram",
-                    "norms": {
-                      "enabled": false
-                    }
+                    "norms": false
                   }
                 },
-                "norms": {
-                  "enabled": false
-                }
+                "norms": false
               }
             }
           },

--- a/config/elasticsearch/templates/components/mimir-dynamic-mappings.json
+++ b/config/elasticsearch/templates/components/mimir-dynamic-mappings.json
@@ -8,7 +8,17 @@
               "match_pattern": "regex",
               "path_match": "^name($|s\\.\\w+)",
               "mapping": {
-                "type": "search_as_you_type"
+                "type": "text",
+                "index_options": "docs",
+                "analyzer": "word",
+                "fields": {
+                  "prefix": {
+                    "type": "string",
+                    "index_options": "docs",
+                    "analyzer": "prefix",
+                    "search_analyzer": "word"
+                  }
+                }
               }
             }
           },
@@ -17,7 +27,33 @@
               "match_pattern": "regex",
               "path_match": "^label($|s\\.\\w+)",
               "mapping": {
-                "type": "search_as_you_type"
+                "type": "text",
+                "index_options": "docs",
+                "analyzer": "word",
+                "copy_to": "full_label",
+                "fields": {
+                  "prefix": {
+                    "type": "text",
+                    "index_options": "docs",
+                    "analyzer": "prefix",
+                    "search_analyzer": "word",
+                    "norms": {
+                      "enabled": false
+                    }
+                  },
+                  "ngram": {
+                    "type": "text",
+                    "index_options": "docs",
+                    "analyzer": "ngram_with_synonyms",
+                    "search_analyzer": "ngram",
+                    "norms": {
+                      "enabled": false
+                    }
+                  }
+                },
+                "norms": {
+                  "enabled": false
+                }
               }
             }
           },


### PR DESCRIPTION
`Search_as_you_type` type is not using character tokenizer for his `_2gram` and, `_3gram` subfield.
The goal of this PR is to use the previous mapping used in ES2.