### PR TITLE
Docker remove bunyan

### DIFF
--- a/docker/bragi/Dockerfile
+++ b/docker/bragi/Dockerfile
@@ -79,6 +79,5 @@ EXPOSE 4000
 
 ENV CONFIG_DIR  /etc/bragi
 ENV RUST_LOG    info,hyper=info
-ENV BUNYAN      0
 
 ENTRYPOINT [ "./run_with_default_config.sh", "bragi" ]

--- a/docker/mimirsbrunn/Dockerfile
+++ b/docker/mimirsbrunn/Dockerfile
@@ -64,19 +64,17 @@ ARG DEBIAN_VERSION
 
 RUN if [ "${DEBIAN_VERSION}" = "buster" ]; then \
   apt-get update \
-    && apt-get install -y libcurl4 sqlite3 npm \
+    && apt-get install -y libcurl4 sqlite3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
 elif [ "${DEBIAN_VERSION}" = "stretch" ]; then \
   apt-get update \
-    && apt-get install -y libcurl3 sqlite3 npm \
+    && apt-get install -y libcurl3 sqlite3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
 else \
   echo "Unsupported debian version '$DEBIAN_VERSION'"; \
 fi
-
-RUN npm install -g bunyan
 
 COPY config /etc/mimirsbrunn
 COPY docker/run_with_default_config.sh .

--- a/docker/run_with_default_config.sh
+++ b/docker/run_with_default_config.sh
@@ -13,17 +13,7 @@ CMD=$1
 shift
 ARG=$@
 
-BUNYAN=${BUNYAN:-"1"}
 RUN_MODE=${RUN_MODE:-"docker"}
 CONFIG_DIR=${CONFIG_DIR:-"/etc/mimirsbrunn"}
 
-# By default, a pipeline's exit code is the exit code of the last command. This
-# will make this script exit with code 1 if $CMD fails, even if bunyan exits
-# with code 0.
-set -o pipefail
-
-if [ $BUNYAN -eq "1" ] ; then
-    $CMD --config-dir $CONFIG_DIR --run-mode $RUN_MODE $ARG | bunyan
-else
-    $CMD --config-dir $CONFIG_DIR --run-mode $RUN_MODE $ARG
-fi
+$CMD --config-dir $CONFIG_DIR --run-mode $RUN_MODE $ARG


### PR DESCRIPTION
As it is not used anymore, we don't need to bloat docker images with node/npm/bunyan :slightly_smiling_face: 