### PR TITLE
Fix nb_threads xxx2mimir

### DIFF
--- a/libs/tests/src/osm.rs
+++ b/libs/tests/src/osm.rs
@@ -11,8 +11,6 @@ use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 use places::poi::Poi;
 use places::street::Street;
 
-const POI_REVERSE_GEOCODING_CONCURRENCY: usize = 8;
-
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(crate)")]
 pub enum Error {
@@ -119,8 +117,7 @@ pub async fn index_pois(
 
     let pois: Vec<Poi> = futures::stream::iter(pois)
         .map(mimirsbrunn::osm_reader::poi::compute_weight)
-        .map(|poi| mimirsbrunn::osm_reader::poi::add_address(client, poi))
-        .buffer_unordered(POI_REVERSE_GEOCODING_CONCURRENCY)
+        .then(|poi| mimirsbrunn::osm_reader::poi::add_address(client, poi))
         .collect()
         .await;
     let _ = client

--- a/src/addr_reader.rs
+++ b/src/addr_reader.rs
@@ -56,9 +56,8 @@ where
         .chunks(1000)
         .map(move |addresses| {
             let into_addr = into_addr.clone();
-
             async move {
-                tokio::task::spawn_blocking(move || {
+                tokio::spawn(async move {
                     let addresses = addresses
                         .into_iter()
                         .filter_map(|rec| {
@@ -83,9 +82,12 @@ where
                     futures::stream::iter(addresses)
                 })
                 .await
-                .expect("tokio thread panicked")
+                .expect("tokio task panicked")
             }
         })
+        // This line will spawn at most num_cpus::get() tasks (running asynchronously)
+        // and give them to tokio runtime,
+        // so the real number of running threads is up to tokio runtime
         .buffered(num_cpus::get())
         .flatten();
 

--- a/src/pois.rs
+++ b/src/pois.rs
@@ -133,12 +133,11 @@ pub async fn index_pois(
     let poi_types = Arc::new(poi_types);
 
     let pois: Vec<_> = futures::stream::iter(pois.into_iter())
-        .map(|(_id, poi)| {
+        .then(|(_id, poi)| {
             let poi_types = poi_types.clone();
             let admins_geofinder = admins_geofinder.clone();
             into_poi(poi, poi_types, client, admins_geofinder)
         })
-        .buffer_unordered(8)
         .filter_map(|poi_res| futures::future::ready(poi_res.ok()))
         .collect()
         .await;


### PR DESCRIPTION
We just removed all confusing 'buffered' & 'buffer_unordered' functions because tasks were not running asynchronously !!! 
To run async tasks with  'buffered' & 'buffer_unordered' functions  please use tokio::spawn. 
The number of function running in // is up to tokio runtime (cf config nb_threads)
