### PR TITLE
Search in Poi OSM index by default

### DIFF
--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -379,6 +379,7 @@ pub fn build_es_indices_to_search(
             root_doctype(Addr::static_doc_type()),
             root_doctype(Street::static_doc_type()),
             root_doctype(Admin::static_doc_type()),
+            root_doctype(Poi::static_doc_type()),
         ];
         if let Some(pt_datasets) = pt_dataset {
             let doc_type_str = Stop::static_doc_type();


### PR DESCRIPTION
Autocomplete search in Poi OSM index by default (with streets, admin and addresses)