### PR TITLE
fix non-string parameters for autocomplete-explain endpoint

### DIFF
--- a/libs/mimir/src/adapters/primary/bragi/api.rs
+++ b/libs/mimir/src/adapters/primary/bragi/api.rs
@@ -20,8 +20,68 @@ pub struct ForwardGeocoderExplainQuery {
     pub doc_id: String,
     pub doc_type: String,
 
+    // Fields from ForwardGeocoderQuery are repeated here as nesting two levels
+    // of `flatten` with serde_qs is not supported.
+    // See https://github.com/samscott89/serde_qs/issues/14
+    pub q: String,
+    pub lat: Option<f32>,
+    pub lon: Option<f32>,
+    pub shape_scope: Option<Vec<PlaceDocType>>,
+    #[serde(default, rename = "type")]
+    pub types: Option<Vec<Type>>,
+    #[serde(default, rename = "zone_type")]
+    pub zone_types: Option<Vec<ZoneType>>,
+    pub poi_types: Option<Vec<String>>,
+    #[serde(default = "default_result_limit")]
+    pub limit: i64,
+    #[serde(default = "default_lang")]
+    pub lang: String,
+    #[serde(deserialize_with = "deserialize_opt_duration", default)]
+    pub timeout: Option<Duration>,
+    pub pt_dataset: Option<Vec<String>>,
+    pub poi_dataset: Option<Vec<String>>,
+    pub request_id: Option<String>,
     #[serde(flatten)]
-    pub query: ForwardGeocoderQuery,
+    pub proximity: Option<Proximity>,
+}
+
+impl From<ForwardGeocoderExplainQuery> for ForwardGeocoderQuery {
+    fn from(val: ForwardGeocoderExplainQuery) -> Self {
+        let ForwardGeocoderExplainQuery {
+            q,
+            lat,
+            lon,
+            shape_scope,
+            types,
+            zone_types,
+            poi_types,
+            limit,
+            lang,
+            timeout,
+            pt_dataset,
+            poi_dataset,
+            request_id,
+            proximity,
+            ..
+        } = val;
+
+        ForwardGeocoderQuery {
+            q,
+            lat,
+            lon,
+            shape_scope,
+            types,
+            zone_types,
+            poi_types,
+            limit,
+            lang,
+            timeout,
+            pt_dataset,
+            poi_dataset,
+            request_id,
+            proximity,
+        }
+    }
 }
 
 /// This structure contains all the query parameters that

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -171,13 +171,16 @@ where
     S: ExplainDocument,
     S::Document: Serialize + Into<serde_json::Value>,
 {
-    let q = params.query.q.clone();
-    let lang = params.query.lang.clone();
-    let filters = filters::Filters::from((params.query, geometry));
+    let doc_id = params.doc_id.clone();
+    let doc_type = params.doc_type.clone();
+    let q = params.q.clone();
+    let lang = params.lang.clone();
+
+    let filters = filters::Filters::from((params.into(), geometry));
     let dsl = dsl::build_query(
         &q,
         filters,
-        lang.as_str(),
+        &lang,
         &settings,
         QueryType::PREFIX,
         &Option::None,
@@ -186,7 +189,7 @@ where
     debug!("{}", serde_json::to_string(&dsl).unwrap());
 
     match client
-        .explain_document(Query::QueryDSL(dsl), params.doc_id, params.doc_type)
+        .explain_document(Query::QueryDSL(dsl), doc_id, doc_type)
         .await
     {
         Ok(res) => Ok(with_status(json(&res), StatusCode::OK)),


### PR DESCRIPTION
Due to a limitation in serde_qs, you need to explicitly specify how you parse a field after a layer of #[serde(flatten)], this is what is already done for some existing fields in the autocomplete parameters.

However I don't think this workarround would work for two layers of flatten, so the simplest fix is probably to repeat the parameters definition.

Btw, the error it fixes:

```
$ curl "https://bragi.prod-maps.c4.par1.kube.qwant.ninja/api/v1/autocomplete-explain?q=bruge&lon=2.40&lat=48.90&doc_id=osm:node:1729160206&doc_type=poi"
{"short":"validation error","long":"failed with reason: invalid type: string \"48.90\", expected f32"}
```