### PR TITLE
re-implement metric `bragi_elasticsearch_request_duration_seconds`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 BRAGI_VERSION = $(shell cat Cargo.toml | grep '^version' | cut -d '=' -f 2 | tr -d '[[:space:]]'\")
 
 SHELL=/bin/bash
+
 # Configuration
 .PHONY: check help
 .DEFAULT_GOAL := help
+
+CLIPPY_PACKAGES := -p mimir -p common -p places
+CLIPPY_EXTRA := --warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings
 
 check: pre-build ## Runs several tests (alias for pre-build)
 pre-build: fmt lint test
@@ -14,9 +18,9 @@ format: ## Check formatting of the code
 
 clippy: lint ## Check quality of the code (alias for 'lint')
 lint: ## Check quality of the code
-	CLIPPY_EXTRA="--warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings"
-	cargo clippy --all-targets -- $$CLIPPY_EXTRA
-	cargo clippy --bins --all-features -- $$CLIPPY_EXTRA
+	cargo clippy $(CLIPPY_PACKAGES) --all-targets -- $(CLIPPY_EXTRA)
+	cargo clippy $(CLIPPY_PACKAGES) --bins --all-features -- $(CLIPPY_EXTRA)
+	cargo clippy $(CLIPPY_PACKAGES) --all-targets --no-default-features -- $(CLIPPY_EXTRA)
 
 test: ## Launch all tests
 	cargo test --lib

--- a/benches/searching.rs
+++ b/benches/searching.rs
@@ -104,11 +104,11 @@ fn bench(c: &mut Criterion) {
                         let filters = filters.clone();
                         let dsl = build_query(
                             &rec.query,
-                            filters,
+                            &filters,
                             "fr",
                             &settings,
                             QueryType::PREFIX,
-                            &None,
+                            None,
                         );
 
                         async move {

--- a/libs/mimir/src/adapters/primary/bragi/handlers.rs
+++ b/libs/mimir/src/adapters/primary/bragi/handlers.rs
@@ -37,12 +37,12 @@ use crate::{
 use common::document::ContainerDocument;
 use places::{addr::Addr, admin::Admin, poi::Poi, stop::Stop, street::Street, Place};
 
-#[cfg(metrics)]
+#[cfg(features = "metrics")]
 use prometheus::{exponential_buckets, register_histogram_vec, HistogramVec};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[cfg(metrics)]
+#[cfg(features = "metrics")]
 lazy_static::lazy_static! {
     static ref ES_REQ_HISTOGRAM: HistogramVec = register_histogram_vec!(
         "bragi_elasticsearch_request_duration_seconds",
@@ -125,7 +125,7 @@ where
             "Query ES",
         );
 
-        #[cfg(metrics)]
+        #[cfg(features = "metrics")]
         let timer = ES_REQ_HISTOGRAM
             .get_metric_with_label_values(&[query_type.as_str()])
             .map(|h| h.start_timer())
@@ -146,7 +146,7 @@ where
             )
             .await;
 
-        #[cfg(metrics)]
+        #[cfg(features = "metrics")]
         if let Some(timer) = timer {
             timer.observe_duration();
         }

--- a/libs/mimir/src/adapters/primary/bragi/prometheus_handler.rs
+++ b/libs/mimir/src/adapters/primary/bragi/prometheus_handler.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "metrics")]
 use prometheus::{Encoder, TextEncoder};
-use tracing::trace;
 
 #[cfg(feature = "metrics")]
 lazy_static::lazy_static! {
@@ -61,7 +60,7 @@ lazy_static::lazy_static! {
 
 #[cfg(feature = "metrics")]
 pub fn update_metrics(info: warp::log::Info) {
-    trace!(
+    tracing::trace!(
         "Metric Status: {} - Method: {} - Path: {} - Time: {:?}",
         &info.status().as_u16().to_string(),
         &info.method(),

--- a/libs/mimir/src/adapters/primary/common/dsl.rs
+++ b/libs/mimir/src/adapters/primary/common/dsl.rs
@@ -17,20 +17,24 @@ pub enum QueryType {
 
 pub fn build_query(
     q: &str,
-    filters: filters::Filters,
+    filters: &filters::Filters,
     lang: &str,
     settings: &settings::QuerySettings,
     query_type: QueryType,
-    excludes: &Option<Vec<String>>,
+    excludes: Option<&[String]>,
 ) -> serde_json::Value {
     let type_query = build_place_type_boost(&settings.type_query);
-    let boosts = build_boosts(settings, &filters, query_type);
+    let boosts = build_boosts(settings, filters, query_type);
 
     let string_query =
         build_string_query(q, lang, &settings.string_query, query_type, &filters.coord);
 
     let filters = [
-        build_filters(filters.shape, filters.poi_types, filters.zone_types),
+        build_filters(
+            filters.shape.as_ref(),
+            filters.poi_types.as_deref(),
+            filters.zone_types.as_deref(),
+        ),
         vec![
             build_matching_condition(q, query_type),
             build_house_number_condition(q),
@@ -143,9 +147,9 @@ fn build_boosts(
 }
 
 fn build_filters(
-    shape: Option<(Geometry, Vec<String>)>,
-    poi_types: Option<Vec<String>>,
-    zone_types: Option<Vec<String>>,
+    shape: Option<&(Geometry, Vec<String>)>,
+    poi_types: Option<&[String]>,
+    zone_types: Option<&[String]>,
 ) -> Vec<serde_json::Value> {
     [
         shape.map(|(geometry, scope)| build_shape_query(geometry, scope)),
@@ -398,7 +402,7 @@ should [
   }
 ]
 */
-pub fn build_shape_query(shape: Geometry, scope: Vec<String>) -> serde_json::Value {
+pub fn build_shape_query(shape: &Geometry, scope: &[String]) -> serde_json::Value {
     json!({
         "bool": {
             "should": [
@@ -446,7 +450,7 @@ should [
      type: poi
   }
 ]*/
-pub fn build_poi_types_filter(poi_types: Vec<String>) -> serde_json::Value {
+pub fn build_poi_types_filter(poi_types: &[String]) -> serde_json::Value {
     json!({
         "bool": {
             "should": [
@@ -494,7 +498,7 @@ should [
   }
 ]
 */
-pub fn build_zone_types_filter(zone_types: Vec<String>) -> serde_json::Value {
+pub fn build_zone_types_filter(zone_types: &[String]) -> serde_json::Value {
     json!({
         "bool": {
             "should": [

--- a/libs/mimir/src/adapters/primary/common/dsl.rs
+++ b/libs/mimir/src/adapters/primary/common/dsl.rs
@@ -15,6 +15,15 @@ pub enum QueryType {
     FUZZY,
 }
 
+impl QueryType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            QueryType::PREFIX => "prefix",
+            QueryType::FUZZY => "fuzzy",
+        }
+    }
+}
+
 pub fn build_query(
     q: &str,
     filters: &filters::Filters,

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -64,11 +64,11 @@ async fn main() {
 
     let dsl = build_query(
         &opt.q,
-        filters,
+        &filters,
         "fr",
         &settings,
         QueryType::PREFIX,
-        &Option::None,
+        Option::None,
     );
 
     println!("{}", dsl);

--- a/tests/steps/search.rs
+++ b/tests/steps/search.rs
@@ -115,11 +115,11 @@ impl Step for Search {
         // Build ES query
         let dsl = build_query(
             &self.query,
-            self.filters.clone(),
+            &self.filters,
             "fr",
             &QuerySettings::default(),
             QueryType::PREFIX,
-            &Option::None,
+            None,
         );
 
         // Fetch documents


### PR DESCRIPTION
This was a metric that was computed for the ES2 branch and will be useful to debug were the time is spent during computation.