### PR TITLE
If configured, each indexing should update all components and templates

### DIFF
--- a/config/bano2mimir/default.toml
+++ b/config/bano2mimir/default.toml
@@ -1,4 +1,5 @@
 nb_threads = 2
+update_templates = true
 
 [container]
   name = "addr"

--- a/config/cosmogony2mimir/default.toml
+++ b/config/cosmogony2mimir/default.toml
@@ -1,6 +1,7 @@
 langs = [ "fr" ]
 nb_threads = 2
 french_id_retrocompatibility = true
+update_templates = true
 
 [container]
   name = "admin"

--- a/config/ntfs2mimir/default.toml
+++ b/config/ntfs2mimir/default.toml
@@ -1,4 +1,5 @@
 nb_threads = 2
+update_templates = true
 
 [container]
   name = "stop"

--- a/config/openaddresses2mimir/default.toml
+++ b/config/openaddresses2mimir/default.toml
@@ -1,4 +1,5 @@
 nb_threads = 2
+update_templates = true
 
 [container]
   name = "addr"

--- a/config/osm2mimir/default.toml
+++ b/config/osm2mimir/default.toml
@@ -1,4 +1,5 @@
 nb_threads = 2
+update_templates = true
 
 [container-poi]
   name = "poi"

--- a/config/poi2mimir/default.toml
+++ b/config/poi2mimir/default.toml
@@ -1,4 +1,5 @@
 nb_threads = 2
+update_templates = true
 
 [container]
   name = "poi"

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -95,7 +95,7 @@ async fn run(
 
     tracing::info!("Connected to elasticsearch.");
 
-    // Update all the template coponents and indexes
+    // Update all the template components and indexes
     if settings.update_templates {
         update_templates(&client, opts.config_dir).await?;
     }

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -32,10 +32,10 @@ use clap::Parser;
 use futures::stream::StreamExt;
 use mimir::domain::ports::primary::generate_index::GenerateIndex;
 use mimirsbrunn::addr_reader::import_addresses_from_input_path;
+use mimirsbrunn::utils::template::update_templates;
 use snafu::{ResultExt, Snafu};
 use std::sync::Arc;
 use tracing::warn;
-use mimirsbrunn::utils::template::update_templates;
 
 use mimir::{
     adapters::secondary::elasticsearch,

--- a/src/bin/bano2mimir.rs
+++ b/src/bin/bano2mimir.rs
@@ -35,6 +35,7 @@ use mimirsbrunn::addr_reader::import_addresses_from_input_path;
 use snafu::{ResultExt, Snafu};
 use std::sync::Arc;
 use tracing::warn;
+use mimirsbrunn::utils::template::update_templates;
 
 use mimir::{
     adapters::secondary::elasticsearch,
@@ -91,6 +92,13 @@ async fn run(
         .await
         .context(ElasticsearchConnectionSnafu)
         .map_err(Box::new)?;
+
+    tracing::info!("Connected to elasticsearch.");
+
+    // Update all the template coponents and indexes
+    if settings.update_templates {
+        update_templates(&client, opts.config_dir).await?;
+    }
 
     // TODO There might be an opportunity for optimization here:
     // Lets say we're indexing a single bano department.... we don't need to retrieve

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -33,6 +33,7 @@ use snafu::{ResultExt, Snafu};
 
 use mimir::{adapters::secondary::elasticsearch, domain::ports::secondary::remote::Remote};
 use mimirsbrunn::settings::cosmogony2mimir as settings;
+use mimirsbrunn::utils::template::update_templates;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -86,6 +87,12 @@ async fn run(
         .map_err(Box::new)?;
 
     tracing::info!("Connected to elasticsearch.");
+
+    // Update all the template coponents and indexes
+    if settings.update_templates {
+        update_templates(&client, opts.config_dir).await?;
+    }
+
     tracing::info!("Indexing cosmogony from {:?}", &opts.input);
 
     mimirsbrunn::admin::index_cosmogony(

--- a/src/bin/cosmogony2mimir.rs
+++ b/src/bin/cosmogony2mimir.rs
@@ -88,7 +88,7 @@ async fn run(
 
     tracing::info!("Connected to elasticsearch.");
 
-    // Update all the template coponents and indexes
+    // Update all the template components and indexes
     if settings.update_templates {
         update_templates(&client, opts.config_dir).await?;
     }

--- a/src/bin/ctlmimir.rs
+++ b/src/bin/ctlmimir.rs
@@ -52,7 +52,7 @@ async fn run(
 
     tracing::info!("Connected to elasticsearch.");
 
-    // Update all the template coponents and indexes
+    // Update all the template components and indexes
     update_templates(&client, opts.config_dir).await?;
 
     Ok(())

--- a/src/bin/ctlmimir.rs
+++ b/src/bin/ctlmimir.rs
@@ -5,7 +5,6 @@ use mimirsbrunn::settings::ctlmimir as settings;
 use mimirsbrunn::utils::template::update_templates;
 use snafu::{ResultExt, Snafu};
 
-
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Settings (Configuration or CLI) Error: {}", source))]

--- a/src/bin/ctlmimir.rs
+++ b/src/bin/ctlmimir.rs
@@ -1,11 +1,10 @@
 use clap::Parser;
-use mimir::{
-    adapters::{primary::templates, secondary::elasticsearch},
-    domain::ports::secondary::remote::Remote,
-};
+use mimir::adapters::secondary::elasticsearch;
+use mimir::domain::ports::secondary::remote::Remote;
 use mimirsbrunn::settings::ctlmimir as settings;
+use mimirsbrunn::utils::template::update_templates;
 use snafu::{ResultExt, Snafu};
-use std::path::PathBuf;
+
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -54,27 +53,8 @@ async fn run(
 
     tracing::info!("Connected to elasticsearch.");
 
-    let path: PathBuf = opts
-        .config_dir
-        .join("elasticsearch")
-        .join("templates")
-        .join("components");
-
-    tracing::info!("Beginning components imports from {:?}", &path);
-    templates::import(client.clone(), path, templates::Template::Component)
-        .await
-        .map_err(Box::new)?;
-
-    let path: PathBuf = opts
-        .config_dir
-        .join("elasticsearch")
-        .join("templates")
-        .join("indices");
-
-    tracing::info!("Beginning indices imports from {:?}", &path);
-    templates::import(client, path, templates::Template::Index)
-        .await
-        .map_err(Box::new)?;
+    // Update all the template coponents and indexes
+    update_templates(&client, opts.config_dir).await?;
 
     Ok(())
 }

--- a/src/bin/ntfs2mimir.rs
+++ b/src/bin/ntfs2mimir.rs
@@ -88,7 +88,7 @@ async fn run(
 
     tracing::info!("Connected to elasticsearch.");
 
-    // Update all the template coponents and indexes
+    // Update all the template components and indexes
     if settings.update_templates {
         update_templates(&client, opts.config_dir).await?;
     }

--- a/src/bin/ntfs2mimir.rs
+++ b/src/bin/ntfs2mimir.rs
@@ -33,6 +33,7 @@ use snafu::{ResultExt, Snafu};
 
 use mimir::{adapters::secondary::elasticsearch, domain::ports::secondary::remote::Remote};
 use mimirsbrunn::settings::ntfs2mimir as settings;
+use mimirsbrunn::utils::template::update_templates;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -86,6 +87,11 @@ async fn run(
         .map_err(Box::new)?;
 
     tracing::info!("Connected to elasticsearch.");
+
+    // Update all the template coponents and indexes
+    if settings.update_templates {
+        update_templates(&client, opts.config_dir).await?;
+    }
 
     mimirsbrunn::stops::index_ntfs(
         opts.input,

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -98,7 +98,7 @@ async fn run(
 
     tracing::info!("Connected to elasticsearch.");
 
-    // Update all the template coponents and indexes
+    // Update all the template components and indexes
     if settings.update_templates {
         update_templates(&client, opts.config_dir).await?;
     }

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -42,6 +42,7 @@ use mimirsbrunn::{
     addr_reader::import_addresses_from_input_path, openaddresses::OpenAddress,
     settings::openaddresses2mimir as settings,
 };
+use mimirsbrunn::utils::template::update_templates;
 use places::admin::Admin;
 
 #[derive(Debug, Snafu)]
@@ -94,6 +95,13 @@ async fn run(
         .await
         .context(ElasticsearchConnectionSnafu)
         .map_err(Box::new)?;
+
+    tracing::info!("Connected to elasticsearch.");
+
+    // Update all the template coponents and indexes
+    if settings.update_templates {
+        update_templates(&client, opts.config_dir).await?;
+    }
 
     // Fetch and index admins for `into_addr`
     let into_addr = {

--- a/src/bin/openaddresses2mimir.rs
+++ b/src/bin/openaddresses2mimir.rs
@@ -38,11 +38,11 @@ use mimir::{
     adapters::secondary::elasticsearch,
     domain::ports::{primary::list_documents::ListDocuments, secondary::remote::Remote},
 };
+use mimirsbrunn::utils::template::update_templates;
 use mimirsbrunn::{
     addr_reader::import_addresses_from_input_path, openaddresses::OpenAddress,
     settings::openaddresses2mimir as settings,
 };
-use mimirsbrunn::utils::template::update_templates;
 use places::admin::Admin;
 
 #[derive(Debug, Snafu)]

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -14,6 +14,7 @@ use mimir::{
 use mimirsbrunn::{
     admin_geofinder::AdminGeoFinder, osm_reader::street::streets, settings::osm2mimir as settings,
 };
+use mimirsbrunn::utils::template::update_templates;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -85,6 +86,11 @@ async fn run(
         .conn(settings.elasticsearch.clone())
         .await
         .context(ElasticsearchConnectionSnafu)?;
+
+    // Update all the template coponents and indexes
+    if settings.update_templates {
+        update_templates(&client, opts.config_dir).await?;
+    }
 
     let admins_geofinder: AdminGeoFinder = match client.list_documents().await {
         Ok(stream) => {

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -87,7 +87,7 @@ async fn run(
         .await
         .context(ElasticsearchConnectionSnafu)?;
 
-    // Update all the template coponents and indexes
+    // Update all the template components and indexes
     if settings.update_templates {
         update_templates(&client, opts.config_dir).await?;
     }

--- a/src/bin/osm2mimir.rs
+++ b/src/bin/osm2mimir.rs
@@ -11,10 +11,10 @@ use mimir::{
         secondary::remote::Remote,
     },
 };
+use mimirsbrunn::utils::template::update_templates;
 use mimirsbrunn::{
     admin_geofinder::AdminGeoFinder, osm_reader::street::streets, settings::osm2mimir as settings,
 };
-use mimirsbrunn::utils::template::update_templates;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/src/bin/poi2mimir.rs
+++ b/src/bin/poi2mimir.rs
@@ -48,7 +48,7 @@ async fn run(
         .await
         .context(ElasticsearchConnectionSnafu)?;
 
-    // Update all the template coponents and indexes
+    // Update all the template components and indexes
     if settings.update_templates {
         update_templates(&client, opts.config_dir).await?;
     }

--- a/src/bin/poi2mimir.rs
+++ b/src/bin/poi2mimir.rs
@@ -3,6 +3,7 @@ use snafu::{ResultExt, Snafu};
 
 use mimir::{adapters::secondary::elasticsearch, domain::ports::secondary::remote::Remote};
 use mimirsbrunn::settings::poi2mimir as settings;
+use mimirsbrunn::utils::template::update_templates;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -46,6 +47,11 @@ async fn run(
         .conn(settings.elasticsearch.clone())
         .await
         .context(ElasticsearchConnectionSnafu)?;
+
+    // Update all the template coponents and indexes
+    if settings.update_templates {
+        update_templates(&client, opts.config_dir).await?;
+    }
 
     mimirsbrunn::pois::index_pois(opts.input, &client, settings.container).await?;
 

--- a/src/settings/bano2mimir.rs
+++ b/src/settings/bano2mimir.rs
@@ -34,6 +34,8 @@ pub struct Settings {
     #[cfg(feature = "db-storage")]
     pub database: Option<Database>,
     pub nb_threads: Option<usize>,
+    #[serde(default)]
+    pub update_templates: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/cosmogony2mimir.rs
+++ b/src/settings/cosmogony2mimir.rs
@@ -27,6 +27,8 @@ pub struct Settings {
     pub container: ContainerConfig,
     pub nb_threads: Option<usize>,
     pub french_id_retrocompatibility: bool,
+    #[serde(default)]
+    pub update_templates: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/ntfs2mimir.rs
+++ b/src/settings/ntfs2mimir.rs
@@ -26,6 +26,8 @@ pub struct Settings {
     pub container: ContainerConfig,
     pub nb_threads: Option<usize>,
     pub physical_mode_weight: Option<Vec<PhysicalModeWeight>>,
+    #[serde(default)]
+    pub update_templates: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/openaddresses2mimir.rs
+++ b/src/settings/openaddresses2mimir.rs
@@ -40,6 +40,8 @@ pub struct Settings {
     #[cfg(feature = "db-storage")]
     pub database: Option<Database>,
     pub nb_threads: Option<usize>,
+    #[serde(default)]
+    pub update_templates: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/osm2mimir.rs
+++ b/src/settings/osm2mimir.rs
@@ -50,6 +50,8 @@ pub struct Settings {
     #[cfg(feature = "db-storage")]
     pub database: Option<Database>,
     pub nb_threads: Option<usize>,
+    #[serde(default)]
+    pub update_templates: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/settings/poi2mimir.rs
+++ b/src/settings/poi2mimir.rs
@@ -32,6 +32,8 @@ pub struct Settings {
     pub elasticsearch: ElasticsearchStorageConfig,
     pub container: ContainerConfig,
     pub nb_threads: Option<usize>,
+    #[serde(default)]
+    pub update_templates: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod fs;
 pub mod launch;
 pub mod logger;
+pub mod template;

--- a/src/utils/template.rs
+++ b/src/utils/template.rs
@@ -1,0 +1,31 @@
+use mimir::{
+    adapters::{primary::templates, secondary::elasticsearch::ElasticsearchStorage}
+};
+use std::path::PathBuf;
+
+
+pub async fn update_templates(
+    client: &ElasticsearchStorage,
+    db_file: PathBuf
+) -> Result<(), Box<dyn std::error::Error>> {
+    let path: PathBuf = db_file
+        .join("elasticsearch")
+        .join("templates")
+        .join("components");
+
+    tracing::info!("Beginning components imports from {:?}", &path);
+    templates::import(client.clone(), path, templates::Template::Component)
+        .await
+        .map_err(Box::new)?;
+
+    let path: PathBuf = db_file
+        .join("elasticsearch")
+        .join("templates")
+        .join("indices");
+
+    tracing::info!("Beginning indices imports from {:?}", &path);
+    templates::import(client.clone(), path, templates::Template::Index)
+        .await
+        .map_err(Box::new)?;
+    Ok(())
+}

--- a/src/utils/template.rs
+++ b/src/utils/template.rs
@@ -1,12 +1,9 @@
-use mimir::{
-    adapters::{primary::templates, secondary::elasticsearch::ElasticsearchStorage}
-};
+use mimir::adapters::{primary::templates, secondary::elasticsearch::ElasticsearchStorage};
 use std::path::PathBuf;
-
 
 pub async fn update_templates(
     client: &ElasticsearchStorage,
-    db_file: PathBuf
+    db_file: PathBuf,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let path: PathBuf = db_file
         .join("elasticsearch")


### PR DESCRIPTION
In ES7, the function to update components and templates for each type of data (poi, ntfs, bano...) is separated and is ctlmimir.
Instead of executing ctlmimir each time to update components and templates if there is any modifications, this function is also called if configured while indexing any type of data.

To activate update of components and templates, add 'update_templates = true' in /config/xx2mimir/default.toml

Without any modification of configuration, it should work as before.
